### PR TITLE
Minor typo fix. <meta> viewport tag should use a comma.

### DIFF
--- a/app/views/root/_wrapper.html.erb
+++ b/app/views/root/_wrapper.html.erb
@@ -4,7 +4,7 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <meta name="viewport" content="width=device-width; initial-scale=1.0">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>GOV.UK - This is a trial ‘beta’ version of the UK government's official website</title>
   <%= stylesheet_link_tag "application" %>


### PR DESCRIPTION
Closes #6. For reference, see:
- https://developer.mozilla.org/en/Mobile/Viewport_meta_tag
- [https://developer.apple.com/library/safari...UsingtheViewport.html](https://developer.apple.com/library/safari/#documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html)
