### PR TITLE
Remove inline-block from external links

### DIFF
--- a/app/assets/stylesheets/core.css.erb
+++ b/app/assets/stylesheets/core.css.erb
@@ -100,10 +100,6 @@ a:active {
   color: #c11;
 }
 
-a[rel="external"] {
-  display: inline-block;
-}
-
 a[rel="external"]:after,
 .external-link:after {
   content: url(<%= asset_path "external-link.png" %>);


### PR DESCRIPTION
Having inline-block pushes the display of the block down a line. In the case of bullet-points which go across two lines, it means that the bullet will be placed on the second line.

Removing inline-block fixes this case.
