### PR TITLE
Remove cause from guide success tracking

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -14,10 +14,10 @@
     {
         var success = { "success": false };
         setTimeout(function() {
-            onSuccess("Duration", success, needID);
+            onSuccess(success, needID);
         }, 7000);
         $("#content a").click(function() {
-            onSuccess("Interaction", success, needID);
+            onSuccess(success, needID);
             try {
                 setTimeout('document.location = "' + $(this).attr("href") + '"', 50)
             }catch(err){}
@@ -25,12 +25,11 @@
         });
     }
 
-    function onSuccess(string, dict, needID) {
+    function onSuccess(dict, needID) {
         if (dict.success) {
             return;
         }
         dict.success = true;
-        _gaq.push(['_trackEvent', 'MS_guide', needID, 'Success-' + string]);
         _gaq.push(['_trackEvent', 'MS_guide', needID, 'Success']);
     }
 


### PR DESCRIPTION
We no longer need to track whether a success was caused by the user
spending more than 7 seconds on the page or clicking to another section
of the guide.
