### PR TITLE
Fonts file should use SASS

### DIFF
--- a/app/assets/stylesheets/fonts.scss
+++ b/app/assets/stylesheets/fonts.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: 'nta';
-  src: url("<%= asset_data_uri 'nta_light-webfont-ps.woff' %>") format('woff');
+  src: asset_data_url('nta_light-webfont-ps.woff') format('woff');
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
Rather than use the `asset_data_uri` helper provided by Sprockets, get rid of the ERB template and just use the equivalent helper within the sass-rails gem.
