### PR TITLE
Add child selector to .steps CSS, so the styles don't apply to nested li's

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -489,7 +489,7 @@ article ol.steps {
   padding-left: 0;
   margin-left: 0;
 
-  li {
+  > li {
     background-position: 0 0.87em;
     background-repeat: no-repeat;
     list-style-type: none;


### PR DESCRIPTION
This should fix a bug where if you try to use a list inside a list with the .steps class applied it inherits the big numbered bullets.

PS - my first proper pull request so apologies if I'm DOING IT ALL WRONG.
