### PR TITLE
Make breadcrumbs globally usable

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -190,3 +190,52 @@ body.government #global-header .header-context {
     }
   }
 }
+
+#global-breadcrumb {
+  background-color: #fff;
+  padding: 0.25em 0;
+  z-index: 50;
+
+  &.content-fixed {
+    border-bottom: solid 3px #F2F2F2;
+  }
+
+  nav {
+    width: 960px;
+    margin: 0 auto;
+
+    ol {
+      margin: 0;
+      padding: 0;
+
+      li {
+        background-image: image-url("separator.png");
+        background-position: 100% 50%;
+        background-repeat: no-repeat;
+        float: left;
+        font-size: 1.1875em;
+        line-height: 1.7;
+        list-style: none;
+        margin-left: 0.5em;
+        padding-right: 1em;
+
+        &:first-child {
+          margin-left: 0;
+        }
+
+        strong {
+          font-weight: normal;
+        }
+
+        a {
+          white-space: nowrap;
+        }
+
+        &:last-child {
+          margin-right: 0
+        }
+
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -3,55 +3,6 @@
 @import "styleguide/_font-stacks.scss";
 @import "styleguide/_typography.scss";
 
-body.mainstream .header-context {
-  background-color: #fff;
-  padding: 0.25em 0;
-  z-index: 50;
-
-  &.content-fixed {
-    border-bottom: solid 3px #F2F2F2;
-  }
-
-  nav {
-    width: 960px;
-    margin: 0 auto;
-
-    ol {
-      margin: 0;
-      padding: 0;
-
-      li {
-        background-image: image-url("separator.png");
-        background-position: 100% 50%;
-        background-repeat: no-repeat;
-        float: left;
-        font-size: 1.1875em;
-        line-height: 1.7;
-        list-style: none;
-        margin-left: 0.5em;
-        padding-right: 1em;
-
-        &:first-child {
-          margin-left: 0;
-        }
-
-        strong {
-          font-weight: normal;
-        }
-
-        a {
-          white-space: nowrap;
-        }
-
-        &:last-child {
-          margin-right: 0
-        }
-
-      }
-    }
-  }
-}
-
 /*
  * Core global styles
  */

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -73,7 +73,7 @@
     <% end %>
 
     <% unless local_assigns[:hide_nav] %>
-      <div class="header-context js-stick-at-top-when-scrolling">
+      <div id="global-breadcrumb" class="header-context js-stick-at-top-when-scrolling">
         <nav role="navigation">
           <ol class="group">
             <li><a href="/">Home</a></li>


### PR DESCRIPTION
This makes breadcrumbs more easily addressable and removes the dependency on the `mainstream` HTML classname.

Additionally it's now moved into the header/footer styles for future proofing.
