### PR TITLE
Truncate long breadcrumbs so they fit on one line

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,3 +11,4 @@
 //= require jquery.history
 //= require jquery.tabs
 //= require js-stick-at-top-when-scrolling
+//= require js-breadcrumb-truncate

--- a/app/assets/javascripts/js-breadcrumb-truncate.js
+++ b/app/assets/javascripts/js-breadcrumb-truncate.js
@@ -1,0 +1,62 @@
+(function () {
+  "use strict"
+  var root = this,
+      $ = root.jQuery;
+  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+
+  var breadcrumbTruncate = {
+    init: function(){
+      var $els = $('.js-breadcrumb-truncate');
+
+      if($els.length > 0){
+        breadcrumbTruncate.$els = $els;
+        breadcrumbTruncate.hideExtra();
+      }
+
+    },
+    hideExtra: function(){
+      breadcrumbTruncate.$els.each(function(i, el){
+        var $el = $(el),
+            children = $el.children().toArray(),
+            $child;
+
+        // shift off the home element before we enter the loop
+        children.shift();
+
+        while(breadcrumbTruncate.isMoreThanOneRow($el)){
+          $child = $(children.shift());
+
+          $child.html('<a href="#" class="hellip" title="Expand breadcrumb">&hellip;</a><span class="shrunk">'+ $child.html() +'</span>');
+
+          $child.find('.hellip').click(function(e){
+            e.preventDefault();
+
+            var $el = $(e.target).parent();
+
+            $el.find('.hellip').remove();
+            $el.find('.shrunk').removeClass('shrunk').focus();
+          });
+        }
+      });
+    },
+    isMoreThanOneRow: function($el){
+      var offsetTop = $el.offset().top,
+          $children = $el.children(),
+          moreThanOneRow = false;
+
+      $children.each(function(i, el){
+        if($(el).offset().top - offsetTop > 0){
+          moreThanOneRow = true;
+        }
+      });
+
+      return moreThanOneRow;
+    }
+  };
+
+  root.GOVUK.breadcrumbTruncate = breadcrumbTruncate;
+}).call(this);
+
+$(function() {
+  GOVUK.breadcrumbTruncate.init();
+})

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -231,6 +231,10 @@ body.government #global-header .header-context {
           white-space: nowrap;
         }
 
+        .shrunk {
+          display: none;
+        }
+
         &:last-child {
           margin-right: 0
         }

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -72,7 +72,7 @@
     <% unless local_assigns[:hide_nav] %>
       <div id="global-breadcrumb" class="header-context">
         <nav role="navigation">
-          <ol class="group">
+          <ol class="group js-breadcrumb-truncate">
             <li><a href="/">Home</a></li>
           </ol>
         </nav>


### PR DESCRIPTION
On some detailed guidance documents the breadcrumb gets so long it wraps
onto two lines. This enables truncating of early breadcrumb entries when
you are in that deep. It should have no effect if there is only one line
of breadcrumbs.
