### PR TITLE
robots.txt for GOV.UK

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,3 +8,4 @@ Allow: /licence-finder
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
+Sitemap: /sitemap.xml


### PR DESCRIPTION
First pass at this but probably sufficient to launch with.

I had put it in frontend, but it probably belongs in static. Helpfully that's where the site is already configured to look for it.

**Do not merge yet** we need to verify that /*/print is valid syntax as far as modern day web crawlers (or at least google) are concerned.
