### PR TITLE
Edd stop sidebar

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -77,24 +77,6 @@ $(document).ready(function() {
     }
   }
 
-
-   // related box fixer
-  if($(window).width() >= "768"){
-    if($(".related-positioning").length !== 0){
-      $(".related-positioning").css("position", "absolute");
-      var viewPort = $(window).height();
-      var relatedBox = $(".related").height();
-      var boxOffset = $(".related-positioning").position();
-      var topBoxOffset = boxOffset.top;
-      if(relatedBox > (viewPort - topBoxOffset)){
-        $(".related-positioning").css("position", "absolute");
-      }
-      else{
-        $(".related-positioning").css("position", "fixed");
-      }
-    }
-  }
-
   // toggle for reporting a problem (on all content pages)
   $('.report-a-problem-toggle a').on('click', function() {
     $('.report-a-problem-container').toggle();

--- a/app/assets/javascripts/stop-related-scrolling.js
+++ b/app/assets/javascripts/stop-related-scrolling.js
@@ -54,13 +54,32 @@
         stopRelatedScrolling.$related.css({ 'position': '', 'top': '' });
         stopRelatedScrolling.state = 'fixed';
       }
+    },
+    checkOverflow: function(){
+      if($(window).width() >= "768"){
+        if($(".related-positioning").length !== 0){
+          $(".related-positioning").css("position", "absolute");
+          var viewPort = $(window).height();
+          var relatedBox = $(".related").height();
+          var boxOffset = $(".related-positioning").position();
+          var topBoxOffset = boxOffset.top;
+          if(relatedBox > (viewPort - topBoxOffset)){
+            $(".related-positioning").css("position", "absolute");
+            return true;
+          }
+          else{
+            $(".related-positioning").css("position", "fixed");
+            return false;
+          }
+        }
+      }
     }
   }
   root.GOVUK.stopRelatedScrolling = stopRelatedScrolling;
 }).call(this);
 
 $(function(){
-  if($(".related-positioning").css("position") != "absolute"){
+  if(!window.GOVUK.stopRelatedScrolling.checkOverflow()){
     window.GOVUK.stopRelatedScrolling.init();
   }
 })


### PR DESCRIPTION
This is just a script from @edds that stops the related box from crashing into and sitting over the footer. It also combines the little script that was in core.js and wasn't put back correctly in an earlier commit.  

The script itself needs some prettying, but keen to get this out with next deploy in the meantime so the layout is not broken.
