### PR TITLE
Switch to using shared fixed scrolling JavaScript

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,4 +22,4 @@ end
 gem 'plek', '~> 0'
 gem 'jasmine'
 
-gem 'govuk_frontend_toolkit', '0.3.1'
+gem 'govuk_frontend_toolkit', '0.4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,8 +46,9 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    govuk_frontend_toolkit (0.3.1)
+    govuk_frontend_toolkit (0.4.0)
       rails (>= 3.1.0)
+      sass (>= 3.2.0)
     hike (1.2.1)
     i18n (0.6.1)
     jasmine (1.2.1)
@@ -150,7 +151,7 @@ PLATFORMS
 DEPENDENCIES
   aws-ses
   exception_notification
-  govuk_frontend_toolkit (= 0.3.1)
+  govuk_frontend_toolkit (= 0.4.0)
   jasmine
   lograge
   plek (~> 0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,6 +1,7 @@
 //= require libs/jquery/jquery-ui-1.8.16.custom.min
 //= require libs/jquery/plugins/jquery.base64
 //= require libs/jquery/plugins/jquery.mustache.js
+//= require govuk_toolkit
 //= require core
 //= require devolution
 //= require popup

--- a/app/assets/javascripts/stop-related-scrolling.js
+++ b/app/assets/javascripts/stop-related-scrolling.js
@@ -1,87 +1,22 @@
-(function () {
-  "use strict"
-  var root = this,
-      $ = root.jQuery;
-
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
-
-  var stopRelatedScrolling = {
-    _hasScrolled: false,
-    _scrollTimeout: false,
-
-    init: function(){
-      stopRelatedScrolling.$related = $('.related-positioning');
-      stopRelatedScrolling.footerTop = $('#footer').offset().top - 10;
-
-      if (!stopRelatedScrolling.$related.length) { return; }
-      
-      var relatedOffset = stopRelatedScrolling.$related.css('top');
-      relatedOffset = parseInt(relatedOffset.substr(0, relatedOffset.length-2));
-      stopRelatedScrolling.relatedOffset = relatedOffset;
-      stopRelatedScrolling.relatedHeight = relatedOffset + $('#related').height();
-
-      stopRelatedScrolling.state = 'fixed';
-
-      if(stopRelatedScrolling._scrollTimeout === false) {
-        $(window).scroll(stopRelatedScrolling.onScroll);
-        stopRelatedScrolling._scrollTimeout = window.setInterval(stopRelatedScrolling.checkScroll, 25);
-      }
-      $(window).resize(stopRelatedScrolling.onResize);
-      stopRelatedScrolling.checkScroll();
-    },
-    onScroll: function(){
-      stopRelatedScrolling._hasScrolled = true;
-    },
-    checkScroll: function(){
-      if(stopRelatedScrolling._hasScrolled === true){
-        stopRelatedScrolling._hasScrolled = false;
-
-        var bottomOfRelated = $(window).scrollTop() + stopRelatedScrolling.relatedHeight;
-
-        if (bottomOfRelated > stopRelatedScrolling.footerTop){
-          stopRelatedScrolling.stick();
-        } else {
-          stopRelatedScrolling.unstick();
-        }
-      }
-    },
-    stick: function(){
-      if(stopRelatedScrolling.state === 'fixed'){
-        stopRelatedScrolling.$related.css({ 'position': 'absolute', 'top': stopRelatedScrolling.footerTop + stopRelatedScrolling.relatedOffset - stopRelatedScrolling.relatedHeight });
-        stopRelatedScrolling.state = 'absolute';
-      }
-    },
-    unstick: function(){
-      if(stopRelatedScrolling.state === 'absolute'){
-        stopRelatedScrolling.$related.css({ 'position': '', 'top': '' });
-        stopRelatedScrolling.state = 'fixed';
-      }
-    },
-    checkOverflow: function(){
-      if($(window).width() >= "768"){
-        if($(".related-positioning").length !== 0){
+$(function(){
+  function checkOverflow(){
+    if($(window).width() >= "768"){
+      if($(".related-positioning").length !== 0){
+        var viewPort = $(window).height();
+        var relatedBox = $(".related").height();
+        var boxOffset = $(".related-positioning").position().top;
+        if(relatedBox > (viewPort - boxOffset)){
           $(".related-positioning").css("position", "absolute");
-          var viewPort = $(window).height();
-          var relatedBox = $(".related").height();
-          var boxOffset = $(".related-positioning").position();
-          var topBoxOffset = boxOffset.top;
-          if(relatedBox > (viewPort - topBoxOffset)){
-            $(".related-positioning").css("position", "absolute");
-            return true;
-          }
-          else{
-            $(".related-positioning").css("position", "fixed");
-            return false;
-          }
+          return true;
+        } else {
+          $(".related-positioning").css("position", "fixed");
+          return false;
         }
       }
     }
+    return false;
   }
-  root.GOVUK.stopRelatedScrolling = stopRelatedScrolling;
-}).call(this);
-
-$(function(){
-  if(!window.GOVUK.stopRelatedScrolling.checkOverflow()){
-    window.GOVUK.stopRelatedScrolling.init();
+  if(!checkOverflow()){
+    window.GOVUK.stopScrollingAtFooter.addEl($('.related-positioning'), $('#related').height());
   }
-})
+});


### PR DESCRIPTION
This pulls out the JavaScript which stops the related sidebar from
covering the footer. It is now more generic and hosted in the
govuk_frontend_toolkit.

It also fixes the bug that caused the box to jump in IE7.
