### PR TITLE
we have rate limiting enabled so we should tell bots that care about it

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,3 +9,4 @@ Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
 Sitemap: /sitemap.xml
+Crawl-delay: 0.5


### PR DESCRIPTION
For Google this is done in the webmaster tools, but for other bots that play nice we should tell them about our rate limiting. Obviously this happens lower down the stack than Akamai at present.
