### PR TITLE
Straightforward grammar fix

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -63,7 +63,7 @@
     <!--end header-->
 
     <div id="global-cookie-message">
-      <p>GOV.UK uses cookies to make the site simpler. <a href="/help/cookies">Find out more about cookies</a></p>
+      <p>GOV.UK uses cookies to make this site more simple to use. <a href="/help/cookies">Find out more about cookies</a></p>
     </div>
 
     <%= banner_notification %>


### PR DESCRIPTION
I fixed the grammar on the global cookie message.  It said "GOV.UK uses cookies to make the site simpler." and now says "GOV.UK uses cookies to make this site more simple to use."
