### PR TITLE
Delete a duplicate and incorrect width

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -20,9 +20,6 @@ section#content {
   margin: 0 auto;
   max-width: 1020px;
   position: relative;
-  @include ie-lte(7) {
-    width: 1020px;
-  }
 
   @include ie-lte(7) {
     width: 960px;


### PR DESCRIPTION
Looks like I let an automatic merge rewrite some code :( Now fixed.

Incorrect width set for IE. Luckily overridden by a duplicate statement below.
