### PR TITLE
Change footer metadata to single line

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -187,18 +187,14 @@
       @include core-16;
       display: inline-block;
       list-style: none;
-      margin: 0 3.1% 30px 0;
-      margin: 0 3.1% 3rem 0;
       padding: 0;
-
-      width: 31%;
 
       @include ie-lte(7) {
         display: inline;
         float: left;
       }
 
-       li {
+      li {
         display: inline-block;
         margin: 0 1.5rem 0 0;
 
@@ -211,22 +207,6 @@
 
       @include media(mobile) {
         width: auto;
-        margin: 0 0 1.5em 0;
-      }
-    }
-
-    .colophon {
-      @include core-16;
-      display: inline-block;
-      margin: 0 0 3rem 0;
-
-      @include ie-lte(7) {
-        display: inline;
-        float: left;
-        margin-bottom: 30px;
-      }
-
-      @include media(mobile) {
         margin: 0 0 1.5em 0;
       }
     }

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -118,9 +118,9 @@
             <li><a href="/support/cookies">Cookies</a></li>
             <li><a href="/feedback">Feedback</a></li>
             <li><a href="/cymraeg">Cymraeg</a></li>
+            <li>Built by the <a href="http://digital.cabinetoffice.gov.uk/">Government Digital Service</a></li>
           </ul>
 
-          <div class="colophon">Built by the <a href="http://digital.cabinetoffice.gov.uk/">Government Digital Service</a></div>
           <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/">Open Government Licence</a>, except where otherwise stated</p>
 
         </div>


### PR DESCRIPTION
Addition of Welsh link and change of Help to Support had knocked the links to two lines. As the content has no relation to the links above it makes sense to run it all as a single line.
