### PR TITLE
Bump frontend toolkit version to 0.7.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ end
 gem 'plek', '~> 0'
 gem 'jasmine', '1.1.2'
 
-gem 'govuk_frontend_toolkit', '0.6.2'
+gem 'govuk_frontend_toolkit', '0.7.0'


### PR DESCRIPTION
This fixes a syntax issue with the css3 box-sizing mixin which was affecting the search button on mobile views
