### PR TITLE
Give sitemap an absolute URL in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,5 +8,5 @@ Allow: /licence-finder
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
-Sitemap: /sitemap.xml
+Sitemap: https://www.gov.uk/sitemap.xml
 Crawl-delay: 0.5


### PR DESCRIPTION
Google Webmaster Tools is complaining about a relative URL for the
sitemap, and a few sources[1](http://www.sitemaps.org/protocol.html#submit_robots) suggest robots.txt needs an absolute
URL for the sitemap.
