### PR TITLE
Disallow crawling of search results w/o casualties

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Disallow: /*/print
-Disallow: /search
+# Don't allow indexing of search results
+Disallow: /search?
 # We only allow indexing of the licence-finder landing page
 Disallow: /licence-finder/
 Allow: /licence-finder


### PR DESCRIPTION
Previously we disallowed e.g. /search-for-patent.
Tested using https://github.com/knu/webrobots.
