### PR TITLE
Remove comma from footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -90,7 +90,7 @@
             <h2>Explore GOV.UK</h2>
 
             <ul>
-              <li><a href="/browse/driving">Driving, transport, and travel</a></li>
+              <li><a href="/browse/driving">Driving, transport and travel</a></li>
               <li><a href="/browse/benefits">Benefits</a></li>
               <li><a href="/browse/business">Businesses and self-employed</a></li>
               <li><a href="/browse/employing-people">Employing people</a></li>


### PR DESCRIPTION
Driving, transport, and travel should read Driving, transport and travel
https://govuk.zendesk.com/agent/#/tickets/20387
