### PR TITLE
Stop heading section breaking for tablets

### DIFF
--- a/app/assets/stylesheets/static-pages/campaigns.scss
+++ b/app/assets/stylesheets/static-pages/campaigns.scss
@@ -50,8 +50,13 @@ section.campaign {
       margin-left: -3px;
       max-width: 700px;
 
+      @include media ($max-width: 900px) {
+        width: 70%;
+      }
+
       @include media (mobile) {
         padding: 0.5em 2rem;
+        width: auto;
       }
 
       @include ie(6) {
@@ -136,6 +141,11 @@ section.campaign {
     float: left;
     margin: 0em 0 1em 1em;
     padding: 0;
+  }
+
+  @include media (tablet) {
+    padding-top: 7px;
+    padding-top: 0.7rem;
   }
 
   a.organisation-logo {


### PR DESCRIPTION
Keep both the page heading and the department on the same line and align their spacing.
