### PR TITLE
Remove set width on address containers

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -456,10 +456,6 @@ article .address {
   margin: 0.75em 0;
   padding: 2em 16% 2em 15%;
   min-width: 35%;
-
-  @include ie-lte(8) {
-    width: 35%;
-  }
 }
 
 article ol.places {


### PR DESCRIPTION
Assumption is the width was set to deal with IE versions not supporting min-width.

Page widths are locked on IE<8 so the container's parent will not resize
anyway and IE8 recognises min-width so doesn't need conditional styles.

This is a fix for https://govuk.zendesk.com/tickets/3869
