### PR TITLE
Remove unneeded styles for related box

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -172,12 +172,6 @@ h4 {
   right: 0;
   width: 15em;
 
-  @include ie-lte(8) {
-    display: inline;
-    height: 1%;
-    zoom: 1;
-  }
-
   @include media(tablet) {
     position: static;
     right: auto;


### PR DESCRIPTION
The height: 1% was making the sticky code judge its height incorrectly. It's only IE6 that treats height as a minimum value so this will set it as that in the other IE versions the conditional targets. 

In addition testing has proved the other fixes in the conditional are not necessary.
