### PR TITLE
Preventing multiple 'report a problem' submissions

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -43,6 +43,8 @@ function recordOutboundLink(e) {
 
 function submitAProblemReport() {
   $('.report-a-problem-container .error-notification').remove();
+  var submitButton = $(this).find('.button');
+  submitButton.attr("disabled", true);
   $.ajax({
     type: "POST",
     url: "/feedback",
@@ -53,6 +55,7 @@ function submitAProblemReport() {
       },
     error: function(req,data) {
         if (req.status == 422) {
+          submitButton.attr("disabled", false);
           $('<p class="error-notification">Please enter details of what you were doing.</p>').insertAfter('.report-a-problem-container p:first-child');
         } else if (data.message !== '') {
           $('.report-a-problem-container').html(data.message);

--- a/spec/javascripts/ReportingAProblemSpec.js
+++ b/spec/javascripts/ReportingAProblemSpec.js
@@ -1,0 +1,60 @@
+FORM_TEXT = '<div class="report-a-problem-container"><form><button class="button" name="button" type="submit">Send</button></form></div>';
+
+describe("form submission for reporting a problem", function () {
+    var form;
+
+    beforeEach(function() {
+        setFixtures(FORM_TEXT);
+        form = $('form');
+        form.submit(submitAProblemReport);
+    });
+
+    describe("while the request is being handled", function() {
+        it("should disable the submit button to prevent multiple problem reports", function () {
+            spyOn($, "ajax").andCallFake(function(options) {});
+
+            form.triggerHandler('submit');
+
+            expect($('.button')).toBeDisabled();
+        });
+    });
+
+    describe("if the request succeeds", function() {
+        it("should replace the form with the response from the AJAX call", function() {
+            spyOn($, "ajax").andCallFake(function(options) {
+                options.success({message: 'great success!'});
+            });
+
+            form.triggerHandler('submit');
+
+            expect(form).toBeHidden();
+            expect($('.report-a-problem-container').html()).toEqual('great success!');
+        });
+    });
+
+    describe("if the request is invalid", function() {
+        it("should re-enable the submit button, in order to allow the user to resubmit", function () {
+            spyOn($, "ajax").andCallFake(function(options) {
+                options.error({status: 422});
+            });
+
+            form.triggerHandler('submit');
+
+            expect(form).toBeVisible();
+            expect($('.button')).not.toBeDisabled();
+        });
+    });
+
+    describe("if the request has failed for some other reason", function() {
+        it("should replace the form with the error message from the AJAX call", function() {
+            spyOn($, "ajax").andCallFake(function(options) {
+                options.error({status: 500}, {message: "big failure"});
+            });
+
+            form.triggerHandler('submit');
+
+            expect(form).not.toBeVisible();
+            expect($('.report-a-problem-container').html()).toEqual('big failure');
+        });
+    });
+});


### PR DESCRIPTION
Without this change, users with JS enabled are able to submit
the same 'report a problem' request multiple times,
resulting in duplicate Zendesk tickets.

This PR also retrofits some Jasmine specs for the 'report a problem' form.
