### PR TITLE
Fix table caption padding in IE7

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -181,7 +181,7 @@ article table {
   caption {
     @include core-19;
     text-align: left;
-    margin-bottom: 0.5em;
+    padding-bottom: 0.5em;
     padding-left: 1em;
   }
 


### PR DESCRIPTION
IE7 (and probably 6) ignore margins on table captions.
