### PR TITLE
Update tookit & fix SCSS variable reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ end
 gem 'plek', '~> 0'
 gem 'jasmine', '1.1.2'
 
-gem 'govuk_frontend_toolkit', '0.8.2'
+gem 'govuk_frontend_toolkit', '0.9.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    govuk_frontend_toolkit (0.8.2)
+    govuk_frontend_toolkit (0.9.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.1)
@@ -166,7 +166,7 @@ DEPENDENCIES
   aws-ses
   capybara (= 1.1.0)
   exception_notification
-  govuk_frontend_toolkit (= 0.8.2)
+  govuk_frontend_toolkit (= 0.9.0)
   jasmine (= 1.1.2)
   lograge
   mocha (= 0.10.0)

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -249,7 +249,7 @@ input[type="search"]::-webkit-search-results-decoration {
       li {
         @include core-16;
         width: auto;
-        color: $grey-63;
+        color: $secondary-text-colour;
 
         a, 
         a:focus,


### PR DESCRIPTION
Update brings in alphagov/govuk_frontend_toolkit@e53b16bd2992c76f189277c5329e1efe90e96790 which changes
the SCSS variables for grey colours.

This commit includes a fix for a variable no longer supported.
