### PR TITLE
Add pixel density ratio tracking in Google Analytics 

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -9,6 +9,10 @@
     _gaq.push(['_setDomainName', document.domain]);
   }
   _gaq.push(['_setAllowLinker', true]);
+    // track pixel density ratio
+  if (window.devicePixelRatio) {
+    _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
+  }
 </script>
 <%# This is here rather than in application to guarantee that GOVUK and _gaq exist %>
 <%= javascript_include_tag 'analytics' %>


### PR DESCRIPTION
I've added this to the _google_analytics partial that gets included in the main template because I couldn't find a relevant place to add it in the analytics javascript files, as they are tracking event success.

I did try adding this to core.js but that would have required another page tracking call to GA which I was worried may have impacted our analytics. Custom Variables must be set before any tracking calls, and as this is where the main tracking call is made, it made sense to me to add it here.

If this is incorrect or there is a better home for this please let me know.
