### PR TITLE
Update DECC colour variable name and bump toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ end
 gem 'plek', '~> 0'
 gem 'jasmine', '1.1.2'
 
-gem 'govuk_frontend_toolkit', '0.9.0'
+gem 'govuk_frontend_toolkit', '0.10.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    govuk_frontend_toolkit (0.9.0)
+    govuk_frontend_toolkit (0.10.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.1)
@@ -167,7 +167,7 @@ DEPENDENCIES
   aws-ses
   capybara (= 1.1.0)
   exception_notification
-  govuk_frontend_toolkit (= 0.9.0)
+  govuk_frontend_toolkit (= 0.10.1)
   jasmine (= 1.1.2)
   lograge (~> 0.1.0)
   mocha (= 0.10.0)

--- a/app/assets/stylesheets/organisations.scss
+++ b/app/assets/stylesheets/organisations.scss
@@ -82,7 +82,7 @@
 }
 
 .department-for-energy-and-climate-change {
-  @include organisation-logo-border($department-for-energy-and-climate-change)
+  @include organisation-logo-border($department-of-energy-climate-change)
 }
 
 .department-for-environment-food-and-rural-affairs {


### PR DESCRIPTION
The latest version of the toolkit has a new name for the DECC variable.
This is to match the slug that they have on gov.uk.

This bumps the toolkit to the newest version and updates that variable
name.
