### PR TITLE
HTC longpress bug

### DIFF
--- a/app/assets/stylesheets/accessibility.scss
+++ b/app/assets/stylesheets/accessibility.scss
@@ -45,7 +45,7 @@
 
 /* Give a strong clear visual idea as to what is currently in focus */
 a {
-  -webkit-tap-highlight-color: rgba(255, 191, 71, 1); /* 3 */
+  -webkit-tap-highlight-color: rgba(255, 191, 71, 1);
 }
 
 a:focus {


### PR DESCRIPTION
Hyperlinks across all of gov.uk do not bring up the contextual menu when 'longpressed' on HTC handsets, as explained in this ticket:

https://govuk.zendesk.com/tickets/1390

This is an after-effect of our setting the `-webkit-tap-highlight-color` property to transparent (to solve this bug: www.yuiblog.com/blog/2010/10/01/quick-tip-customizing-the-mobile-safari-tap-highlight-color/). This makes the HTC default browser treat hyperlinks as normal text (which have a different longpress menu).

The colour applied to hyperlinks is the same as the focus colour we use anyway.
