### PR TITLE
Match highlight to webkit default

### DIFF
--- a/app/assets/stylesheets/accessibility.scss
+++ b/app/assets/stylesheets/accessibility.scss
@@ -45,7 +45,7 @@
 
 /* Give a strong clear visual idea as to what is currently in focus */
 a {
-  -webkit-tap-highlight-color: rgba(255, 191, 71, 1);
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0.3);
 }
 
 a:focus {


### PR DESCRIPTION
The existing highlight colour was obscuring the text of links & introduces a new visual for no reason. Links do need a highlight assigned to enable contextual menus on HTC devices so setting to the IOS default colour.
