### PR TITLE
Anonymise IP tracking in Google Analytics

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -18,6 +18,7 @@
 <%= javascript_include_tag 'analytics' %>
 
 <script type="text/javascript">
+  _gaq.push(['_gat._anonymizeIp']);
   _gaq.push(['_trackPageview']);
   (function() {
     var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;


### PR DESCRIPTION
Give further privacy to our users.

By calling this function, Google anonymise the IP (by removing the last octet)
before they write anything to disk.

http://support.google.com/analytics/bin/answer.py?hl=en&answer=2763052

I "tested" the change by looking for the parameter that the Google support page says should  be added to the request for `_utm.gif`.
