### PR TITLE
Track printing

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -29,7 +29,7 @@
 
 <script type="text/javascript">
   (function() {
-    var utm = "https://ssl.google-analytics.com/__utm.gif";
+    var utm = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/__utm.gif';
 
     // Construct the gif hit url.
     utm += "?utmwv=" + "5.3.9";


### PR DESCRIPTION
This JS constructs a __utm.gif URL and adds it to a CSS print media query which is inserted into the `<head>` of each page. When the print stylesheets are loaded (on printing a page) the gif URL is hit causing GA to record a visit.

We need to check that the visits are being recorded. 
- Are these the only required arguments for GA?
- Are the values in the arguments enough for GA to record the metrics correctly?
