### PR TITLE
Fix safari print bug

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -145,7 +145,7 @@ $(document).ready(function() {
 
   // fix for printing bug in Windows Safari
   (function () {
-    var windows_safari = (window.navigator.userAgent.match(/(\(Windows[\s\w\.;]+\))[\/\(\s\w\.\,\)]+(Version\/[\d\.]+)\s(Safari\/[\d\.]+)/) !== null),
+    var windows_safari = (window.navigator.userAgent.match(/(\(Windows[\s\w\.]+\))[\/\(\s\w\.\,\)]+(Version\/[\d\.]+)\s(Safari\/[\d\.]+)/) !== null),
         $new_styles;
 
     if (windows_safari) {


### PR DESCRIPTION
Fix for Safari on Windows producing bad encoding in its print view.

Represented in some of the incidents associated with this problem: https://govuk.zendesk.com/tickets/40736

Fixes this ticket: 43918187
