### PR TITLE
Make cookie class handle beta banner

### DIFF
--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -29,12 +29,28 @@ function getCookie(name){
 $(function() {
   var addStyle,
       $message = $('#global-cookie-message'),
-      $relatedColumn = $('#wrapper .related-positioning');
+      $relatedColumn = $('#wrapper .related-positioning'),
+      hasCookieMessage = ($message.length && getCookie('seen_cookie_message') === null),
+      release = ($('.beta-notice').length) ? 'beta' : 'live';
+      addRelatedClass;
 
-  if ($message.length && getCookie('seen_cookie_message') === null) {
-    if ($relatedColumn.length) {
+  function addRelatedClass() {
+    var relatedClass = 'related-' + release;
+
+    if (hasCookieMessage) {
       // correct the related module top position to consider the cookie bar
-      $relatedColumn.addClass('related-with-cookie');
+      relatedClass = relatedClass + '-with-cookie';
+    } else if (release === 'live') {
+      return;
+    }
+
+    if ($relatedColumn.length) {
+      $relatedColumn.addClass(relatedClass);
+    }
+  };
+
+  if (hasCookieMessage) {
+    if ($relatedColumn.length) {
       // related content box needs to know the top position of the footer
       // this changes when content is split into tabs
       if (typeof GOVUK.stopScrollingAtFooter !== 'undefined') {
@@ -44,4 +60,6 @@ $(function() {
     $message.show();
     setCookie('seen_cookie_message', 'yes', 28);
   }
+
+  addRelatedClass();
 });

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -101,7 +101,11 @@ h4 {
   }
 }
 
-.related-with-cookie {
+.related-beta-with-cookie {
+  top: 12em;
+}
+.related-live-with-cookie,
+.related-beta {
   top: 9.5em;
 }
 


### PR DESCRIPTION
The cookie class that makes the top position relative to the cookie
banner should also take the beta banner into consideration.

This introduces classes to deal with the different variations of banners that may appear.

There is also a pull request on govuk_tookit that deals with errors having these banners cause: https://github.com/alphagov/govuk_frontend_toolkit/pull/31
