### PR TITLE
Make related classes work without JS

### DIFF
--- a/app/assets/javascripts/welcome.js
+++ b/app/assets/javascripts/welcome.js
@@ -31,20 +31,18 @@ $(function() {
       $message = $('#global-cookie-message'),
       $relatedColumn = $('#wrapper .related-positioning'),
       hasCookieMessage = ($message.length && getCookie('seen_cookie_message') === null),
-      release = ($('.beta-notice').length) ? 'beta' : 'live';
+      release = ($('.beta-notice').length) ? 'beta' : null;
       addRelatedClass;
 
   function addRelatedClass() {
-    var relatedClass = 'related-' + release;
+    var relatedClass = release ? 'related-' + release : 'related';
 
     if (hasCookieMessage) {
       // correct the related module top position to consider the cookie bar
       relatedClass = relatedClass + '-with-cookie';
-    } else if (release === 'live') {
-      return;
     }
 
-    if ($relatedColumn.length) {
+    if ($relatedColumn.length && (relatedClass !== 'related')) {
       $relatedColumn.addClass(relatedClass);
     }
   };

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -82,7 +82,7 @@ h4 {
   height: 0;
   left: 0;
   position: fixed;
-  top: 7em;
+  top: 9.5em;
   width: 100%;
   z-index: 0;
 
@@ -101,11 +101,16 @@ h4 {
   }
 }
 
-.related-beta-with-cookie {
+.js-enabled .related-positioning {
+  top: 7em;
+}
+
+.beta .related-positioning {
   top: 12em;
 }
-.related-live-with-cookie,
-.related-beta {
+
+.js-enabled .related-with-cookie,
+.js-enabled .related-beta {
   top: 9.5em;
 }
 


### PR DESCRIPTION
The CSS that gives the related box the correct top position should work without JS.

The new code covers the following scenarios:
1. without JS, site is live
2. without JS, site is beta
3. with JS, site is live without cookie set
4. with JS, site is live with cookie set
5. with JS, site is beta without cookie set
6. with JS, site is beta with cookie set
