### PR TITLE
Update the header footer only template

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -1,0 +1,1 @@
+//= require core

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -29,6 +29,7 @@
   }
 
   h2 {
+    @include core-24;
     color: $grey-3;
     margin: 0;
   }

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -5,8 +5,14 @@
 @import "_device-pixels";
 @import "_typography";
 
+@import "_buttons";
+
 /* local styleguide includes */
 @import "styleguide/_colours";
 @import "styleguide/_conditionals2";
 
+
+// basic styles for HTML5 and other elements
+@import "basic";
+@import "accessibility";
 @import "header-footer";

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -21,7 +21,7 @@
     <%= render partial: "fonts" %>
 
     <%= javascript_include_tag 'libs/jquery/jquery-1.7.2.js' %>
-    <%= javascript_include_tag 'application', :defer => 'defer' %>
+    <%= javascript_include_tag local_assigns[:js_file] || 'application', :defer => 'defer' %>
 
     <!--[if lt IE 9]>
       <%= javascript_include_tag 'ie.js' %>

--- a/app/views/root/header_footer_only.html.erb
+++ b/app/views/root/header_footer_only.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'base', locals: { css_file: 'header-footer-only' } %>
+<%= render partial: 'base', locals: { css_file: 'header-footer-only', js_file: 'header-footer-only' } %>


### PR DESCRIPTION
- The titles in the footer were inheriting the core-24 styles from
  elsewhere. Forced them to manually have the core-24 style
- Removed all but the core javascript. This ensures the analytics still
  works.
- Added some extra CSS files to the header footer stylesheet as they are
  required to make the header footer work properly

This will let whitehall (amongst others) then not have to include all of the other JavaScript and CSS that static has.
