### PR TITLE
Fix format issues with report a problem/page meta

### DIFF
--- a/app/assets/stylesheets/multi-step.scss
+++ b/app/assets/stylesheets/multi-step.scss
@@ -1,4 +1,5 @@
 /* This is basically Smart Answers & Licence Finder & Finance Finder */
+@import "_shims";
 
 /*
  * questions
@@ -270,8 +271,8 @@ li.done:hover .undo a {
   }
 }
 
-.smart_answer .meta-data {
-  background: #fff;
+.smart_answer .article-container {
+  @extend %contain-floats
 }
 
 /*


### PR DESCRIPTION
Fix for the issue described in story 44632475 & https://govuk.zendesk.com/tickets/64197.

Because it was missing the .group class the div.article-container element was not containing the report and problem and page meta correctly.
