### PR TITLE
Remove the Chrome Frame meta tag

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -3,7 +3,6 @@
 <!--[if lt IE 9]><html class="lte-ie8 <%= html_classes %>" lang="en"><![endif]-->
 <!--[if gt IE 8]><!--><html lang="en" class="<%= html_classes %>"><!--<![endif]-->
   <head>
-    <meta http-equiv="X-UA-Compatible" content="chrome=1">
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
     <title><%= content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %></title>


### PR DESCRIPTION
We already set the correct HTTP header so this is not required. Reverses #195.

Sorry - this was a case of crossed wires on my part, didn't realise we were already setting the HTTP Header.
