### PR TITLE
Add explicit margins on footer elements

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -204,7 +204,7 @@
         @include core-16($line-height: (24/16), $line-height-640: (24/16));
         display: inline-block;
         list-style: none;
-        margin-top: 0;
+        margin: 0 0 1em;
         padding: 0;
 
         @include ie-lte(7) {
@@ -232,6 +232,7 @@
         @include core-16;
         display: block;
         clear: left;
+        margin: 1em 0;
       }
     
       @include ie-lte(7) {


### PR DESCRIPTION
They currently rely on browser defaults. This explicity sets them for
situtations the browser defaults are changed.
