### PR TITLE
Add cookie JavaScript to header footer template

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -1,2 +1,3 @@
 //= require core
+//= require welcome
 //= require analytics


### PR DESCRIPTION
I believe the cookie warning should be on all pages not just the ones
importing all the JavaScript.
