### PR TITLE
IE7 incorrectly targeted

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -269,7 +269,7 @@ article .summary h2,
 .mainstream .ancillary .summary h2 {
   line-height: 1.35em;
 
-  @include ie-lte(7) {
+  @include ie(6) {
     height: 2.75em;
   }
 }


### PR DESCRIPTION
This fix is for browsers that do not support
min-height and treat height as a minimum (IE6).
IE7 supports min-height.

Noted in https://govuk.zendesk.com/agent/#/tickets/72969
