### PR TITLE
Add the cookie functions to the header footer js

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -1,3 +1,4 @@
 //= require core
+//= require cookie-functions
 //= require welcome
 //= require analytics


### PR DESCRIPTION
This was removed from `welcome.js` in aafedc98 but wasn't added to the
header footer js. There really needs to be a proper refactor of the way we
do cookies but this should be enough to get rid of the errors we are
seeing at the moment.
