### PR TITLE
Add bottom padding to organisation on campaigns

### DIFF
--- a/app/assets/stylesheets/static-pages/campaigns.scss
+++ b/app/assets/stylesheets/static-pages/campaigns.scss
@@ -4,10 +4,24 @@ section.campaign {
     padding-bottom: 3em;
   }
 
+  article.campaign,
   #extra-links {
-    float: left;
-    margin-left: 1em;
-    max-width: 960px;
+    max-width: 662px;
+
+    @include media(mobile) {
+      width: auto;
+      padding-right: 0;
+    }
+
+   @include ie(6) {
+      width: 662px;
+    }
+  }
+
+  #extra-links {
+    margin: 0 1em;
+    overflow: hidden;
+    border-top: solid 1px $grey-6;
 
     @include ie(6) {
       width:928px;
@@ -30,7 +44,6 @@ section.campaign {
     display: block;
     max-width: 960px;
     margin: 0 auto;
-    padding-bottom: 2.5em;
     background-color: #fff;
 
     @include ie-lte(7) {
@@ -60,20 +73,15 @@ section.campaign {
       }
 
       @include ie(6) {
-        width: 500px;
+        width: 700px;
       }
     }
-
-    p {
-      max-width: 662px;
-    }
-
   }
 }
 
 .campaign-image {
   position: relative;
-  float: left;
+  clear: both;
   width: 100%;
   height: 300px;
 
@@ -116,7 +124,6 @@ section.campaign {
 
     @include media ($max-width: 900px) {
       position: static;
-      float: left;
       width: auto;
       padding: 2em 0 0 1em;
     }
@@ -163,13 +170,11 @@ section.campaign {
 }
 
 article.campaign {
+  float: none;
   height: auto;
   min-height: 0;
-  width: auto;
-  max-width: 95%;
   margin: 0 1em;
   padding: 0 2em 1em 0;
-  border-bottom: solid 1px $grey-6;
 
   h2:first-of-type {
     margin-top: 1.5em;
@@ -180,6 +185,10 @@ ul.links {
   list-style: none;
   margin: 0;
   padding: 0;
+
+  @include ie(6) {
+    list-style-image: none;
+  }
 
   li {
     margin: 0;


### PR DESCRIPTION
This is to make sure there is always space between the organisation and
the campaign imagery, if the main heading for the campaign is only one
line.
