### PR TITLE
Add chromeless wrapper template

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -7,16 +7,7 @@
 
     <title><%= content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <script type="text/javascript">
-      (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
-    </script>
-
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag local_assigns[:css_file] || 'application' %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag local_assigns[:css_file] || 'application-ie6' %><![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag local_assigns[:css_file] || 'application-ie7' %><![endif]-->
-    <!--[if IE 8]><%= stylesheet_link_tag local_assigns[:css_file] || 'application-ie8' %><![endif]-->
-
-    <%= stylesheet_link_tag "print", :media => "print" %>
+    <%= render partial: 'stylesheet', locals: { css_file: local_assigns[:css_file] || 'application' } %>
 
     <%= render partial: "fonts" %>
 
@@ -24,19 +15,7 @@
       <%= javascript_include_tag 'ie.js' %>
     <![endif]-->
 
-    <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
-
-    <!-- For third-generation iPad with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= asset_path "apple-touch-icon-144x144.png" %>">
-    <!-- For iPhone with high-resolution Retina display: -->
-    <link rel="apple-touch-icon-precomposed" sizes="114x114" href="<%= asset_path "apple-touch-icon-114x114.png" %>">
-    <!-- For first- and second-generation iPad: -->
-    <link rel="apple-touch-icon-precomposed" sizes="72x72" href="<%= asset_path "apple-touch-icon-72x72.png" %>">
-    <!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
-    <link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-57x57.png" %>">
-
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="og:image" content="<%= asset_path "opengraph-image.png" %>">
+    <%= render partial: "icons" %>
 
     <%= render partial: 'javascript', locals: { js_file: local_assigns[:js_file] || 'application' } unless local_assigns[:js_at_the_end] %>
   </head>
@@ -125,23 +104,7 @@
 
         </nav>
 
-        <div class="footer-meta">
-          <nav>
-            <ul>
-              <li><a href="/support">Support</a></li>
-              <li><a href="/support/cookies">Cookies</a></li>
-              <li><a href="/feedback">Feedback</a></li>
-              <li><a href="/cymraeg">Cymraeg</a></li>
-              <li>Built by the <a href="http://digital.cabinetoffice.gov.uk/">Government Digital Service</a></li>
-            </ul>
-
-            <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/">Open Government Licence</a>, except where otherwise stated</p>
-          </nav>
-
-          <div class="copyright">
-            <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a>
-          </div>
-        </div>
+        <%= render partial: 'footer_meta' %>
       </div>
     </footer>
 

--- a/app/views/root/_footer_meta.html.erb
+++ b/app/views/root/_footer_meta.html.erb
@@ -1,0 +1,17 @@
+<div class="footer-meta">
+  <nav>
+    <ul>
+      <li><a href="/support">Support</a></li>
+      <li><a href="/support/cookies">Cookies</a></li>
+      <li><a href="/feedback">Feedback</a></li>
+      <li><a href="/cymraeg">Cymraeg</a></li>
+      <li>Built by the <a href="http://digital.cabinetoffice.gov.uk/">Government Digital Service</a></li>
+    </ul>
+
+    <p>All content is available under the <a href="http://www.nationalarchives.gov.uk/doc/open-government-licence/">Open Government Licence</a>, except where otherwise stated</p>
+  </nav>
+
+  <div class="copyright">
+    <a href="http://www.nationalarchives.gov.uk/information-management/our-services/crown-copyright.htm">&copy; Crown Copyright</a>
+  </div>
+</div>

--- a/app/views/root/_icons.html.erb
+++ b/app/views/root/_icons.html.erb
@@ -1,0 +1,13 @@
+<link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
+
+<!-- For third-generation iPad with high-resolution Retina display: -->
+<link rel="apple-touch-icon-precomposed" sizes="144x144" href="<%= asset_path "apple-touch-icon-144x144.png" %>">
+<!-- For iPhone with high-resolution Retina display: -->
+<link rel="apple-touch-icon-precomposed" sizes="114x114" href="<%= asset_path "apple-touch-icon-114x114.png" %>">
+<!-- For first- and second-generation iPad: -->
+<link rel="apple-touch-icon-precomposed" sizes="72x72" href="<%= asset_path "apple-touch-icon-72x72.png" %>">
+<!-- For non-Retina iPhone, iPod Touch, and Android 2.1+ devices: -->
+<link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-57x57.png" %>">
+
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="og:image" content="<%= asset_path "opengraph-image.png" %>">

--- a/app/views/root/_stylesheet.html.erb
+++ b/app/views/root/_stylesheet.html.erb
@@ -1,0 +1,13 @@
+<%
+  css_file = local_assigns[:css_file] || 'application'
+%>
+<script type="text/javascript">
+  (function(){if(navigator.userAgent.match(/IEMobile\/10\.0/)){var d=document,c="appendChild",a=d.createElement("style");a[c](d.createTextNode("@-ms-viewport{width:auto!important}"));d.getElementsByTagName("head")[0][c](a);}})();
+</script>
+
+<!--[if gt IE 8]><!--><%= stylesheet_link_tag css_file %><!--<![endif]-->
+<!--[if IE 6]><%= stylesheet_link_tag "#{css_file}-ie6" %><![endif]-->
+<!--[if IE 7]><%= stylesheet_link_tag "#{css_file}-ie7" %><![endif]-->
+<!--[if IE 8]><%= stylesheet_link_tag "#{css_file}-ie8" %><![endif]-->
+
+<%= stylesheet_link_tag "print", :media => "print" %>

--- a/app/views/root/chromeless.html.erb
+++ b/app/views/root/chromeless.html.erb
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<% html_classes = content_for?(:html_classes) ? "#{yield(:html_classes)}" : ''%>
+<!--[if lt IE 9]><html class="lte-ie8 <%= html_classes %>" lang="en"><![endif]-->
+<!--[if gt IE 8]><!--><html lang="en" class="<%= html_classes %>"><!--<![endif]-->
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+
+    <title><%= content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %></title>
+
+    <%= render partial: 'stylesheet', locals: { css_file: 'header-footer-only' } %>
+
+    <!--[if lt IE 9]>
+      <%= javascript_include_tag 'ie.js' %>
+    <![endif]-->
+
+    <%= render partial: "icons" %>
+  </head>
+  <body<%= content_for?(:body_classes) ? " class=\"#{yield(:body_classes)}\"".html_safe : '' %>>
+      <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    <a href="#<%= local_assigns[:skip_id] || "content" %>" class="visuallyhidden">Skip to main content</a>
+
+    <div id="global-cookie-message">
+      <p>GOV.UK uses cookies to make the site simpler. <a href="/support/cookies">Find out more about cookies</a></p>
+    </div>
+
+    <div id="wrapper" class="group">
+      <%= yield :content %>
+    </div>
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+      <div class="footer-wrapper">
+        <%= render partial: 'footer_meta' %>
+      </div>
+    </footer>
+    <%= render partial: 'javascript', locals: { js_file: 'header-footer-only' } %>
+  </body>
+</html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,5 +16,6 @@ Static::Application.routes.draw do
   match "/templates/503.html.erb", :to => "root#503"
   match "/templates/504.html.erb", :to => "root#504"
   match "/templates/header_footer_only.html.erb", :to => "root#header_footer_only"
+  match "/templates/chromeless.html.erb", :to => "root#chromeless"
   match "/templates/beta_notice.html.erb", :to => "root#beta_notice"
 end


### PR DESCRIPTION
We need a chromeless wrapper template for html-publications. However,
these should still retain the actual footer, the cookie notice and the
analytics tracking. I have tried to split out the core parts of the
template that this shares with base so there is little repitition.

I also noticed a bug where if you set a custom css filename you wouldn't
get IE fallback stylesheets and would just get the moden browser version
for all IE's. This fixes that issue also.
