### PR TITLE
Add worldwide link to the footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -79,10 +79,11 @@
             <h2>Explore GOV.UK</h2>
 
             <ul>
-              <li><a href="/browse/driving">Driving, transport and travel</a></li>
+              <li><a href="/browse/driving">Driving and transport</a></li>
               <li><a href="/browse/benefits">Benefits</a></li>
               <li><a href="/browse/business">Businesses and self-employed</a></li>
               <li><a href="/browse/employing-people">Employing people</a></li>
+              <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
               <li><a href="/browse/education">Education and learning</a></li>
               <li><a href="/browse/working">Working, jobs and pensions</a></li>
               <li><a href="/browse/housing">Housing and local services</a></li>
@@ -100,6 +101,7 @@
             <ul>
               <li><a href="/government/how-government-works">How government works</a></li>
               <li><a href="/government/organisations">Departments</a></li>
+              <li><a href="/government/world">Worldwide</a></li>
               <li><a href="/government/topics">Topics</a></li>
               <li><a href="/government/policies">Policies</a></li>
               <li><a href="/government/publications">Publications</a></li>


### PR DESCRIPTION
Also added Passports, travel and living abroad and updated Driving, transport and travel to Driving and transport which matches the list on gov.uk homepage

https://www.pivotaltracker.com/story/show/46828713
