### PR TITLE
Always hide the global browser prompt, regardless of JS

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -349,9 +349,12 @@
 /* Global cookie message
    Global browser prompt message */
 
-.js-enabled #global-cookie-message,
-.js-enabled #global-browser-prompt {
-  display: none; /* shown with JS */
+.js-enabled #global-cookie-message {
+  display: none; /* shown with JS, always on for non-JS */
+}
+
+#global-browser-prompt {
+  display: none; /* shown with JS, always hidden for non-JS */
 }
 
 #global-cookie-message,


### PR DESCRIPTION
ZenDesk Ticket 86304

This always hides the browser prompt by default, regardless of if JS is enabled or not.

Currently is JS is not enabled the user will always see the "Upgrade your browser" message. If JS isn't on we can't make any guesses or figure out which browser they are on, so rather than bug a user with the message, let's just hide it.

The user in the ZenDesk ticket above is a Firefox user who browses without JS, and he was seing the upgrade message all the time (without JS you can't dismiss it). Clearly this isn't good.
