### PR TITLE
Move search role onto input rather than the form

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -35,10 +35,10 @@
             <a href="#search" class="search-toggle js-header-toggle">Search</a>
           </div>
 
-          <form id="search" class="site-search" action="/search" method="get" role="search">
+          <form id="search" class="site-search" action="/search" method="get">
             <div class="content">
               <label for="site-search-text">Search</label>
-              <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
+              <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus" role="search">
               <input class="submit" type="submit" value="Search" />
             </div>
           </form>


### PR DESCRIPTION
From Léonie:

> [Search is] being said three times, but it isn't the toggle that's doing
> it. It's the search role on the &lt;form&gt; element, the text label, and the
> search type of the <input> element.
> 
> For the moment the triple announcement is a fairly edge case, but as
> more screen readers start to support both ARIA and HTML5 it'll become
> much more common. Best bet is to reduce the announcements down to two
> by applying the search role to the <input> element.
