### PR TITLE
Revert "Move search role onto input rather than the form"

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -35,10 +35,10 @@
             <a href="#search" class="search-toggle js-header-toggle">Search</a>
           </div>
 
-          <form id="search" class="site-search" action="/search" method="get">
+          <form id="search" class="site-search" action="/search" method="get" role="search">
             <div class="content">
               <label for="site-search-text">Search</label>
-              <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus" role="search">
+              <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
               <input class="submit" type="submit" value="Search" />
             </div>
           </form>


### PR DESCRIPTION
This reverts commit a11375899bbd3b4a123ee53ded8d8c8020b665f9.

From Léonie:

> The problem is that ARIA overrides the native semantics of HTML. In this
> case the ARIA search role overrides the native role of the input
> element.  This could mean that some ATs (screen readers etc.) might not
> report the presence of the input correctly, because all they're aware of
> is the search landmark (in ARIA terms a landmark is a region containing
> a group of related elements).

Untill we have a better solution we should undo the changes we made.
