### PR TITLE
Hide browser upgrade bar for print

### DIFF
--- a/app/assets/stylesheets/core-print.scss
+++ b/app/assets/stylesheets/core-print.scss
@@ -278,6 +278,7 @@ body nav,
 .loading_location,
 .location_error,
 #global-cookie-message,
+#global-browser-prompt,
 .report-a-problem-toggle,
 .report-a-problem-container {
   display: none !important;


### PR DESCRIPTION
The bar currently appears on the print view, this stops it doing so.
