### PR TITLE
Make proposition menu more legible

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -37,7 +37,7 @@
         }
       }
       .header-logo {
-        margin: 3px 0 2px;
+        margin: 5px 0 2px;
       }
       .site-search {
         float: right;
@@ -297,10 +297,13 @@
         content: " \25B2";
       }
     }
+    #proposition-menu {
+      margin-top: 5px;
+    }
     #proposition-links {
       clear: both;
       @extend %contain-floats;
-      margin: 0;
+      margin: 2px 0 0 0;
       padding: 0;
 
       .js-enabled & {


### PR DESCRIPTION
I propose we make the proposition header white at all times as not all
propositions or services will have colours that pass accessibility 
contrast tests against black. I also propose we increase the size of 
the links to 19px as they are very small and difficult to read at 
present (and may also present accessibility challenges).
