### PR TITLE
Check existance of user survey before calling it

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -173,7 +173,9 @@ $(document).ready(function() {
     }
   }());
 
-  GOVUK.userSatisfaction.randomlyShowSurveyBar();
+  if(window.GOVUK && GOVUK.userSatisfaction){
+    GOVUK.userSatisfaction.randomlyShowSurveyBar();
+  }
 });
 
 


### PR DESCRIPTION
As the user survey code isn't included in the header-footer template
this causes a javascript error on every page load. This should stop the
init being called if it hasn't been loaded onto the page.
