### PR TITLE
Remove redirection for removed asset.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,4 @@ Static::Application.routes.draw do
   match "/apple-touch-icon-72x72.png", :to => "apple_icons#show"
   match "/apple-touch-icon-57x57.png", :to => "apple_icons#show"
   match "/apple-touch-icon-precomposed.png", :to => "apple_icons#show"
-
-  match "/static/overseas-passport/OS_Payment_Instruction.pdf",
-    :to => redirect("#{Plek.current.website_root}/government/publications/overseas-passport-creditdebit-card-payment-authorisation")
 end

--- a/test/integration/asset_redirection_test.rb
+++ b/test/integration/asset_redirection_test.rb
@@ -1,8 +1,0 @@
-require 'integration_test_helper'
-
-class AssetRedirectionTest < ActionDispatch::IntegrationTest
-  should "redirect /static/overseas-passport/OS_Payment_Instruction.pdf to the relevant publication" do
-    get "/static/overseas-passport/OS_Payment_Instruction.pdf"
-    assert_redirected_to "http://www.dev.gov.uk/government/publications/overseas-passport-creditdebit-card-payment-authorisation"
-  end
-end


### PR DESCRIPTION
This is now handled by Nginx, see puppet#571
