### PR TITLE
Bunting fixes

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -1222,6 +1222,10 @@ article {
   top: 6.1em;
   overflow: visible;
 
+  @include media-down(tablet) {
+    display: none;
+  }
+
   span {
     background-image: image-url("bunting.png");
     background-color: transparent;


### PR DESCRIPTION
- Drop the bunting below the breadcrumbs and behind the content.
- Don't show the bunting on mobile or tablets (you couldn't see much anyway but it occasionally poked through the top of the breadcrumbs)
