### PR TITLE
Top result CSS

### DIFF
--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -282,6 +282,9 @@ form.search-header {
       &.search-result-title {
         @include core-19;
         font-weight: bold;
+        a[rel="external"]::after {
+          content: "\A0\A0\A0\A0\A0\A0";
+        }
       }
     }
 


### PR DESCRIPTION
- styles for top result
- bold for search result titles
- reduce search result description from 19px to 16px
