### PR TITLE
Set the background colour on the body element instead of html element

### DIFF
--- a/app/assets/stylesheets/basic.scss
+++ b/app/assets/stylesheets/basic.scss
@@ -32,11 +32,8 @@ html, body, div, h1, h2, h3, h4, h5, h6, article, aside, footer, header, hgroup,
   display: block;
 }
 
-html {
-  background: $grey-9;
-}
-
 body {
+  background: $grey-9;
   color: $text-colour;
   line-height: 1.5;
   font-weight: 400;

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -3,8 +3,6 @@
  */
 
 #wrapper {
-  background-color: $grey-9;
-
   @include ie-lte(7) {
     zoom: 1;
   }


### PR DESCRIPTION
This way we can easily override it in other pages in the future rather
than littering our CSS with declarations involving the html element.
