### PR TITLE
Keep article images within the content area

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -646,10 +646,6 @@ article {
   display: block;
   margin: 0 -1em;
   padding-left: 1em;
-
-  @include media-down(tablet) {
-    max-width: 100%;
-  }
 }
 
 .article-container {


### PR DESCRIPTION
Images in publications can currently be larger than the publication container.

https://govuk.zendesk.com/tickets/46958

This was already dealt with in the /foreign-travel-advice section so making that fix more global.
