### PR TITLE
Allow campaign articles

### DIFF
--- a/app/assets/stylesheets/static-pages/campaigns.scss
+++ b/app/assets/stylesheets/static-pages/campaigns.scss
@@ -209,15 +209,17 @@ article.campaign {
     padding-right: 1em;
   }
 
-  @include ie-lte(7) {
-    margin: 0 2em;
+  @include ie(8) {
+    margin: 0;
+  }
+
+  @include ie-lte(8) {
     padding-left: 0;
     padding-right: 0;
   }
 
-  @include ie(8) {
-    margin: 0;
-    padding: 2.25em 0 1em;
+  @include ie-lte(7) {
+    margin: 0 2em;
   }
 
   h2:first-child,


### PR DESCRIPTION
CSS to allow the main content in campaign pages to be wrapped in an article tag. This allows campaign pages to use the core GOVUK styles.

The campaign pages have been updated to use these new styles so please merge along with https://github.com/alphagov/frontend/pull/336
