### PR TITLE
Bump toolkit & apply fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,4 +28,4 @@ end
 gem 'plek', '1.3.1'
 gem 'jasmine', '1.1.2'
 
-gem 'govuk_frontend_toolkit', '0.19.1'
+gem 'govuk_frontend_toolkit', '0.20.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     execjs (1.4.0)
       multi_json (~> 1.0)
     ffi (1.1.5)
-    govuk_frontend_toolkit (0.19.1)
+    govuk_frontend_toolkit (0.20.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     hike (1.2.1)
@@ -166,7 +166,7 @@ DEPENDENCIES
   aws-ses
   capybara (= 1.1.0)
   exception_notification
-  govuk_frontend_toolkit (= 0.19.1)
+  govuk_frontend_toolkit (= 0.20.0)
   jasmine (= 1.1.2)
   lograge (~> 0.1.0)
   mocha (= 0.13.3)

--- a/app/assets/stylesheets/static-pages/campaigns.scss
+++ b/app/assets/stylesheets/static-pages/campaigns.scss
@@ -74,7 +74,7 @@ section.campaign {
       margin: 0.833em 0 0.312em; 
       max-width: 700px;
 
-      @include media ($max-width: 900px) {
+      @include media ($max-width: 900px, $ignore-for-ie: true) {
         width: 70%;
         margin-left: 0.333em;
       }
@@ -83,10 +83,6 @@ section.campaign {
         padding: 0.5em;
         margin-left: 0;
         width: auto;
-      }
-
-      @include ie(8) {
-        margin-left: 0;
       }
 
       @include ie-lte(7) {
@@ -107,7 +103,7 @@ section.campaign {
   width: 100%;
   height: 300px;
 
-  @include media ($max-width: 900px) {
+  @include media ($max-width: 900px, $ignore-for-ie: true) {
     position: static;
     height: auto;
   }
@@ -144,18 +140,10 @@ section.campaign {
     width: 240px;
     background-color: #fff;
 
-    @include media ($max-width: 900px) {
+    @include media ($max-width: 900px, $ignore-for-ie: true) {
       position: static;
       width: auto;
       padding: 2em 1em 0;
-    }
-
-    @include ie-lte(7) {
-      padding: 2em 2em 0;
-    }
-
-    @include ie(8) {
-      padding: 2em 0 0;
     }
 
     h2 {
@@ -204,7 +192,7 @@ article.campaign {
     margin-right: 0;
   }
 
-  @include media ($max-width: 900px) {
+  @include media ($max-width: 900px, $ignore-for-ie: true) {
     padding-left: 1em;
     padding-right: 1em;
   }
@@ -214,7 +202,6 @@ article.campaign {
   }
 
   @include ie-lte(8) {
-    padding-left: 0;
     padding-right: 0;
   }
 


### PR DESCRIPTION
The latest toolkit changes the media mixin so
the styles in media-queries don't get dumped into
the main block for IE<9.

This updates the toolkit and removes overwrites for the above condition on campaign pages.
