### PR TITLE
Set decimal lists as such in the CSS

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -558,11 +558,12 @@ article ul.view-maps {
 article ol.steps {
   padding-left: 0;
   margin-left: 0;
+  overflow: hidden;
 
   > li {
     background-position: 0 0.87em;
     background-repeat: no-repeat;
-    list-style-type: none;
+    list-style-type: decimal;
     margin-left: 0;
     padding: 0.75em 0 0.75em 2.2em;
 
@@ -578,7 +579,6 @@ article ol.steps {
     }
 
     @include ie-lte(8) {
-      list-style-type: decimal;
       margin-left: 1.5em;
       padding-left: 0;
     }


### PR DESCRIPTION
Ordered lists require `list-style-type` to be set to `decimal` to be correctly recognised by screenreaders.

As explained here: https://www.pivotaltracker.com/story/show/50635799
