### PR TITLE
Remove abbreviation explanation in print CSS

### DIFF
--- a/app/assets/stylesheets/core-print.scss
+++ b/app/assets/stylesheets/core-print.scss
@@ -195,10 +195,6 @@ a[href^="#"]:after {
     content: "";
 }
 
-abbr[title]:after {
-  content: " (" attr(title) ")";
-}
-
 img { max-width: 100% !important; }
 
 .print-link {


### PR DESCRIPTION
Abbreviations currently have the term they represent added afterwards in brackets in the print styles. This is clashing with our usage, as explained in this ticket:

https://govuk.zendesk.com/agent/#/tickets/73349

Removing this style aligns our usage across media to that specified in the styleguide:

https://www.gov.uk/designprinciples/styleguide#abbreviations-and-acronyms
