### PR TITLE
Fix for smart answer module using new styles

### DIFF
--- a/app/assets/stylesheets/multi-step.scss
+++ b/app/assets/stylesheets/multi-step.scss
@@ -242,8 +242,9 @@ li.done:hover .undo a {
 
 #wrapper.smart_answer {
   .next-steps {
-    right: -15em;
-    top: 2em;
+    right: -24em;
+    top: 0;
+    margin-top: 2em;
 
     .inner {
       padding-top: 0.5em;


### PR DESCRIPTION
The next steps module in the results section of some smart answers was broken by the new styles brought in by https://github.com/alphagov/static/pull/253

Reported by a user:

https://govuk.zendesk.com/agent/#/tickets/138814
