### PR TITLE
Widen 2nd column of guide parts for numbers >9

### DIFF
--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -329,6 +329,10 @@ aside .page-navigation {
       }
     }
   }
+
+  ol[start] li {
+    margin-left: 1.8em;
+  }
 }
 
 aside .page-navigation-open {


### PR DESCRIPTION
The space allocated to guide part numbers does not support those greater than 9 (correction on the number given in the commit message). There are guides with more than 9 parts so this is breaking.

This gives the 2nd column more space.
