### PR TITLE
Redirect requests for /favicon.ico to the actual asset location.

### DIFF
--- a/app/controllers/icon_redirects_controller.rb
+++ b/app/controllers/icon_redirects_controller.rb
@@ -1,4 +1,4 @@
-class AppleIconsController < ApplicationController
+class IconRedirectsController < ApplicationController
   def show
     redirect_to view_context.asset_path(request.fullpath.to_s[1..-1]), :status => 301
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,10 +6,11 @@ Static::Application.routes.draw do
   end
 
   # Icon redirects
-  get "/apple-touch-icon.png", :to => "apple_icons#show"
-  get "/apple-touch-icon-144x144.png", :to => "apple_icons#show"
-  get "/apple-touch-icon-114x114.png", :to => "apple_icons#show"
-  get "/apple-touch-icon-72x72.png", :to => "apple_icons#show"
-  get "/apple-touch-icon-57x57.png", :to => "apple_icons#show"
-  get "/apple-touch-icon-precomposed.png", :to => "apple_icons#show"
+  get "/favicon.ico", :to => "icon_redirects#show"
+  get "/apple-touch-icon.png", :to => "icon_redirects#show"
+  get "/apple-touch-icon-144x144.png", :to => "icon_redirects#show"
+  get "/apple-touch-icon-114x114.png", :to => "icon_redirects#show"
+  get "/apple-touch-icon-72x72.png", :to => "icon_redirects#show"
+  get "/apple-touch-icon-57x57.png", :to => "icon_redirects#show"
+  get "/apple-touch-icon-precomposed.png", :to => "icon_redirects#show"
 end

--- a/test/integration/icon_redirects_test.rb
+++ b/test/integration/icon_redirects_test.rb
@@ -1,0 +1,21 @@
+require_relative "../integration_test_helper"
+
+class IconRedirectsTest < ActionDispatch::IntegrationTest
+
+  [
+    'favicon.ico',
+    'apple-touch-icon.png',
+    'apple-touch-icon-144x144.png',
+    'apple-touch-icon-114x114.png',
+    'apple-touch-icon-72x72.png',
+    'apple-touch-icon-57x57.png',
+    'apple-touch-icon-precomposed.png',
+  ].each do |file|
+    should "redirect #{file} to the asset path" do
+      get "/#{file}"
+      assert_equal 301, last_response.status
+      # In development and test mode the asset pipeline doesn't add the hashes to the URLs
+      assert_equal "http://example.org/static/#{file}", last_response.location
+    end
+  end
+end


### PR DESCRIPTION
Some older browsers ignore the favicon <link> tag, and request the favicon from
http://<site_hostname>/favicon.ico.  This redirects those requests to the
actual favicon location instead of filling up the logs with 404s
