### PR TITLE
Fix 2-line guide parts

### DIFF
--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -241,12 +241,15 @@ aside .page-navigation {
         float: left;
       }
 
-      &:hover span.part-title {
-        color: #2E3191;
+      span {
+        cursor: pointer;
       }
 
-      span.part-description {
-        color: #2E3191;
+      &:hover span.part-title, 
+      &:focus span.part-title, 
+      &:hover span.part-description, 
+      &:focus span.part-description {
+        color: $link-hover-colour;
       }
     }
 
@@ -277,8 +280,8 @@ aside .page-navigation {
       }
 
       &.part-description {
-        color: $grey-0;
         line-height: 1.25;
+        display: block;
         clear: left;
       }
 


### PR DESCRIPTION
The first part of a country page in travel advice has two lines but they currently appear on one.

As described here: https://www.pivotaltracker.com/story/show/52458735
