### PR TITLE
Pull out report-a-problem CSS to give whitehall access

### DIFF
--- a/app/assets/stylesheets/_report-a-problem.scss
+++ b/app/assets/stylesheets/_report-a-problem.scss
@@ -1,0 +1,38 @@
+.js-enabled .report-a-problem-container{
+  display:none;
+}
+
+.report-a-problem-container{
+  @include core-19;
+  clear:both;
+  background-color:#D5E8F3;
+  margin: 3em 0 2em 1.75em;
+  padding: 0.5em 1em 1em 1em;
+
+  p {
+    margin: 1em 0;
+  }
+  div{
+    width:98%;
+    padding-top:0.5em;
+    text-align:right;
+
+    .button{
+      margin-right: -0.5em;
+      @include button;
+    }
+  }
+  label{
+    padding:0 0 0.5em 0;
+    display:block;
+    input{
+      margin:0;
+      display:block;
+      width:98%;
+    }
+  }
+
+  @include media-down(mobile) {
+    margin: 0 1em 2em 1em;
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -24,6 +24,7 @@
 @import "notifications";
 @import "organisations";
 @import "publisher";
+@import "_report-a-problem";
 
 @import "static-pages/error-pages";
 

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -1106,41 +1106,6 @@ article {
   }
 }
 
-.js-enabled .report-a-problem-container{
-  display:none;
-}
-
-.report-a-problem-container{
-  @include core-19;
-  clear:both;
-  background-color:#D5E8F3;
-  margin: 3em 0 2em 1.75em;
-  padding: 0.5em 1em 1em 1em;
-
-  div{
-    width:98%;
-    padding-top:0.5em;
-    text-align:right;
-
-    .button{
-      margin-right: -0.5em;
-    }
-  }
-  label{
-    padding:0 0 0.5em 0;
-    display:block;
-    input{
-      margin:0;
-      display:block;
-      width:98%;
-    }
-  }
-
-  @include media-down(mobile) {
-    margin: 0 1em 2em 1em;
-  }
-}
-
 /* bunting lol */
 .epic-bunting {
   width: 100%;

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -4,6 +4,7 @@
 @import "_css3";
 @import "_device-pixels";
 @import "_typography";
+@import "design-patterns/_buttons";
 
 /* local styleguide includes */
 @import "styleguide/_colours";
@@ -13,3 +14,4 @@
 @import "basic";
 @import "accessibility";
 @import "header-footer";
+@import "_report-a-problem";


### PR DESCRIPTION
Whitehall doesn't make use of core, but we now need the CSS for the feedback form. This makes it available in both header-footer-only.scss and application.scss
