### PR TITLE
Remove rems in favour of pixels

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -8,7 +8,6 @@
     max-width: 60em;
     margin: 0 auto;
     padding: 60px 1em 0 1em;
-    padding: 6rem 1em 0 1em;
 
     @include ie-lte(7) {
       width: 928px; /* we want the width for IE to max out at 960px total (including padding) */
@@ -16,7 +15,6 @@
 
     @include media-down(mobile) {
       padding-top: 20px;
-      padding-top: 2rem;
     }
   }
 
@@ -39,13 +37,11 @@
     float: left;
 
     padding: 0 0 60px 0;
-    padding: 0 0 6rem 0;
 
     width: 100%;
 
     @include media-down(mobile) {
       padding: 20px 0;
-      padding: 2rem 0;
     }
 
     .footer-explore {
@@ -58,7 +54,6 @@
         display: block;
         
         margin: 0 0 30px 0;
-        margin: 0 0 3rem 0;
 
         width: 100%;
       }
@@ -72,13 +67,10 @@
       border-width: 1px 0 0 0;
 
       margin: 20px 0 0 0;
-      margin: 2rem 0 0 0;
 
       padding: 20px 0 0 0;
-      padding: 2rem 0 0 0;
 
       min-height: 210px;
-      min-height: 21rem;
 
       vertical-align: top;
 
@@ -94,7 +86,6 @@
         clear: left;
 
         margin: 0 0 15px 0;
-        margin: 0 0 1.5rem 0;
 
         width: 45.5%;
 
@@ -145,7 +136,6 @@
 
         @include media-down(mobile) {
           margin: 20px 0 0 0;
-          margin: 2rem 0 0 0;
 
           width: 100%;
         }
@@ -181,10 +171,8 @@
     border-width: 1px 0 0 0;
 
     margin: 60px 0 0 0;
-    margin: 6rem 0 0 0;
 
     padding: 30px 0 60px;
-    padding: 3rem 0 6rem;
 
     @include media-down(mobile) {
       margin: 0;
@@ -209,7 +197,7 @@
 
         li {
           display: inline-block;
-          margin: 0 1.5rem 0 0;
+          margin: 0 15px 0 0;
 
           @include ie-lte(7) {
             display: inline;
@@ -291,7 +279,6 @@
         display: block;
 
         padding: 115px 0 0 0;
-        padding: 11.5rem 0 0 0;
 
         background: transparent image-url("govuk-crest.png") no-repeat 100% 0;
         text-align: right;
@@ -313,7 +300,6 @@
         padding: 0;
 
         margin: 30px 0 0 0;
-        margin: 3rem 0 0 0;
 
         a {
           text-align: center;

--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -181,7 +181,6 @@ h4 {
 
     @include media-down(mobile) {
       font-size: 17px;
-      font-size: 1.7rem;
       margin-bottom: 0.625em;
     }
   }
@@ -451,15 +450,15 @@ body.full-width {
 }
 
 /* Business support format */
-.business_support article.tab-pane { 
-  width: auto; 
+.business_support article.tab-pane {
+  width: auto;
 }
 .business_support .support-info {
   background: #E1E8E8;
   border-left: 1px solid #BBB;
 }
-.business_support section.support-info:last-child { 
-  border-bottom: 1px dotted #BBB; 
+.business_support section.support-info:last-child {
+  border-bottom: 1px dotted #BBB;
 }
 .business_support .support-info h2 {
   @include core-16($line-height: 1.25);
@@ -493,7 +492,6 @@ body.full-width {
 
 .relevant-authority {
   margin: 0 0 20px 84px;
-  margin: 0 0 2rem 8.4rem;
 
   h2 {
     margin: 0;
@@ -503,12 +501,10 @@ body.full-width {
 .licence .intro form {
   ul {
     padding-left: 12px;
-    padding-left: 1.2rem;
   }
   li { list-style: none;
     label {
       padding-left: 5px;
-      padding-left: 0.5rem;
     }
   }
 }
@@ -827,9 +823,7 @@ article {
 
   @include media-down(mobile) {
     bottom: 20px;
-    bottom: 2rem;
     right: 16px;
-    right: 1.6rem;
   }
 }
 
@@ -868,7 +862,6 @@ article {
     @include media-down(mobile) {
       float: none;
       margin: 0 -16px;
-      margin: 0 -1.6rem;
     }
   }
 
@@ -906,7 +899,6 @@ article {
         height: auto;
         line-height: 3.5em;
         padding: 0 16px;
-        padding: 0 1.6rem;
         text-align: left;
         margin-bottom: 0;
         border-bottom: 1px solid $grey-6;
@@ -951,7 +943,7 @@ article {
   }
 }
 
-/* give tabs the whole width of the central column in 2-column grids */ 
+/* give tabs the whole width of the central column in 2-column grids */
 #wrapper.answer article .inner .nav-tabs,
 #wrapper.transaction article .inner .nav-tabs,
 #wrapper.local_transaction article .inner .nav-tabs {
@@ -1014,7 +1006,7 @@ article {
       @include core-24($line-height: (45 / 24), $line-height-640: (45 / 17));
       background: #FFF image-url('accordian-arrow.png') no-repeat 100% -2px;
       display: block;
-      padding: 0 1.6rem;
+      padding: 0 16px;
       position: relative;
       text-align: left;
       text-decoration:underline;

--- a/app/assets/stylesheets/organisations.scss
+++ b/app/assets/stylesheets/organisations.scss
@@ -1,7 +1,6 @@
 @mixin organisation-logo-19 {
   font-family: $Helvetica-Regular;
   font-size: 19px;
-  font-size: 1.9rem;
   line-height: (20/19); /* 20px */
   font-weight: 400;
   text-transform: none;
@@ -14,27 +13,23 @@
   width: auto;
 
   @include media-down(mobile) {
-    font-size: 1.3rem;
+    font-size: 13px;
     line-height: (15/13);
     background-image: image-url("coa-default-18.gif");
   }
 
   span {
     padding-top: 30px;
-    padding-top: 3rem;
     margin-left: 10px;
-    margin-left: 1rem;
     display: block;
 
     @include media-down(mobile) {
       padding-top: 23px;
-      padding-top: 2.3rem;
     }
   }
 
   &.single-line {
     padding: 5px 0 5px 45px;
-    padding: 0.5rem 0 0.5rem 4.5rem;
     background-position: 8px 50%;
 
     span {
@@ -44,7 +39,6 @@
 
     @include media-down(mobile) {
       padding: 1px 0 1px 31px;
-      padding: 0.1rem 0 0.1rem 3.1rem;
       background-position: 5px 50%;
     }
   }

--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -119,7 +119,6 @@
     @include media-down(mobile) {
       a span {
         line-height: 40px;
-        line-height: 4rem;
       }
     }
   }
@@ -160,13 +159,11 @@ aside .show-all-parts {
   border-width: 1px 0;
 
   padding: 0 16px;
-  padding: 0 1.6rem;
   display: none;
 
   @include media-down(mobile) {
     display: block;
     background: transparent image-url("accordian-arrow.png") 100% 6px no-repeat;
-    background-position: 100% 0.6rem;
   }
 
   @include device-pixel-ratio() {
@@ -182,7 +179,6 @@ aside .show-all-parts {
 
   &.show-all-parts-open {
     background-position: 100% -40px;
-    background-position: 100% -4rem;
     border-bottom: none;
   }
 }
@@ -520,7 +516,6 @@ aside .page-navigation-closed {
 
   @include media-down(mobile) {
     margin: 1.2em -1em;
-    margin: 2rem -1.6rem;
     padding-left: 1em;
     padding-right: 1em;
   }
@@ -533,9 +528,7 @@ aside .page-navigation-closed {
 
     @include media-down(mobile) {
       margin-left: -2.5em;
-      margin-left: -4rem;
       padding-right: 2.5em;
-      padding-right: 4rem;
     }
   }
 

--- a/app/assets/stylesheets/static-pages/error-pages.scss
+++ b/app/assets/stylesheets/static-pages/error-pages.scss
@@ -29,13 +29,11 @@
 
   .report-a-problem {
     margin-top: 60px;
-    margin-top: 6rem;
 
     form {
       @include core-24;
 
       padding-top: 10px;
-      padding-top: 1rem;
 
       label {
         display: block;
@@ -48,7 +46,6 @@
       input {
         display: block;
         margin-bottom: 20px;
-        margin-bottom: 2rem;
         width: 400px;
 
         @include media(mobile) {
@@ -58,7 +55,6 @@
 
       button {
         margin-top: 10px;
-        margin-top: 1rem;
       }
     }
   }

--- a/app/assets/stylesheets/styleguide/_typography.scss
+++ b/app/assets/stylesheets/styleguide/_typography.scss
@@ -14,10 +14,6 @@
 //  _ Style name refers to graphic style rather than semantic use
 //
 //      font-size: 45px;
-//      font-size: 4.5rem;
-//      _ Font-sizing in rems to avoid issues with relative sizing
-//        and DOM context. Font-size in pixels as fallback for
-//        older browsers.
 //
 //      line-height: 1.1555555556;
 //      _ Unit-less, relative leading value.
@@ -31,13 +27,10 @@
 //        to default values) will increase the robustness of the style.
 //
 //      padding-top: 7px;
-//      padding-top: 0.7rem;
 //      padding-bottom: 5px;
-//      padding-bottom: 0.5rem;
 //      _ Set top and bottom padding values to ensure an appropriate
 //        vertical measure before & after the text, ideally sitting it
-//        on the 8px baseline grid. Rem sizing will allow the
-//        whitespace to scale proportionally along with the text.
+//        on the 8px baseline grid.
 //  }
 
 // CORE FONTS - NEW TRANSPORT
@@ -45,7 +38,6 @@
 @mixin core-48($line-height: (50 / 48), $line-height-640: (30 / 25)) {
   font-family: $NTA-Light;
   font-size: 48px;
-  font-size: 4.8rem;
   @include print {
     font-size: 18pt;
   }
@@ -54,7 +46,7 @@
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 2.5rem;
+    font-size: 25px;
     line-height: $line-height-640;
   }
 }
@@ -63,12 +55,10 @@
 @mixin heading-48 {
   @include core-48;
   padding-top: 12px;
-  padding-top: 1.2rem;
   padding-bottom: 8px;
-  padding-bottom: 0.8rem;
   @media (max-width: 640px) {
-    padding-top: 0.8rem;
-    padding-bottom: 0.7rem;
+    padding-top: 8px;
+    padding-bottom: 7px;
   }
 }
 
@@ -76,13 +66,12 @@
 @mixin core-36($line-height: (42 / 36), $line-height-640: (30 / 25)) {
   font-family: $NTA-Light;
   font-size: 36px;
-  font-size: 3.6rem;
   line-height: $line-height;
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 2.5rem;
+    font-size: 25px;
     line-height: $line-height-640;
   }
 }
@@ -90,13 +79,12 @@
 @mixin core-27($line-height: (30 / 27), $line-height-640: (25 / 19)) {
   font-family: $NTA-Light;
   font-size: 27px;
-  font-size: 2.7rem;
   line-height: $line-height;
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 1.9rem;
+    font-size: 19px;
     line-height: $line-height-640;
   }
 }
@@ -105,25 +93,22 @@
 @mixin heading-27 {
   @include core-27;
   padding-top: 3px;
-  padding-top: 0.3rem;
   padding-bottom: 2px;
-  padding-bottom: 0.2rem;
   @media (max-width: 640px) {
-    padding-top: 0.7rem;
-    padding-bottom: 0.3rem;
+    padding-top: 7px;
+    padding-bottom: 3px;
   }
 }
 
 @mixin core-24($line-height: (30 / 24), $line-height-640: (25 / 17)) {
   font-family: $NTA-Light;
   font-size: 24px;
-  font-size: 2.4rem;
   line-height: $line-height;
   font-weight: 400;
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 1.7rem;
+    font-size: 17px;
     line-height: $line-height-640;
   }
 }
@@ -132,12 +117,10 @@
 @mixin copy-24 {
   @include core-24;
   padding-top: 3px;
-  padding-top: 0.3rem;
   padding-bottom: 2px;
-  padding-bottom: 0.2rem;
   @media (max-width: 640px) {
-    padding-top: 0.7rem;
-    padding-bottom: 0.7rem;
+    padding-top: 7px;
+    padding-bottom: 7px;
   }
 }
 
@@ -146,17 +129,15 @@
   @include core-24;
   padding-top: 0;
   padding-bottom: 12px;
-  padding-bottom: 1.2rem;
   @media (max-width: 640px) {
     padding-top: 0;
-    padding-bottom: 0.8rem;
+    padding-bottom: 8px;
   }
 }
 
 @mixin core-19($line-height: (25 / 19), $line-height-640: (20 / 13)) {
   font-family: $NTA-Light;
   font-size: 19px;
-  font-size: 1.9rem;
   @include print {
     font-size:14pt;
   }
@@ -165,7 +146,7 @@
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 1.3rem;
+    font-size: 13px;
     line-height: $line-height-640;
   }
 }
@@ -174,19 +155,16 @@
 @mixin copy-19 {
   @include core-19;
   padding-top: 7px;
-  padding-top: 0.7rem;
   padding-bottom: 3px;
-  padding-bottom: 0.3rem;
   @media (max-width: 640px) {
-    padding-top: 0.6rem;
-    padding-bottom: 0.4rem;
+    padding-top: 6px;
+    padding-bottom: 4px;
   }
 }
 
 @mixin core-16($line-height: (20 / 16), $line-height-640: (20 / 13)) {
   font-family: $NTA-Light;
   font-size: 16px;
-  font-size: 1.6rem;
   @include print {
     font-size: 12pt;
   }
@@ -195,7 +173,7 @@
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 1.3rem;
+    font-size: 13px;
     line-height: $line-height-640;
   }
 }
@@ -204,19 +182,16 @@
 @mixin pullout-aside-16 {
   @include core-16;
   padding-top: 5px;
-  padding-top: 0.5rem;
   padding-bottom: 5px;
-  padding-bottom: 0.5rem;
   @media (max-width: 640px) {
-    padding-top: 0.6rem;
-    padding-bottom: 0.4rem;
+    padding-top: 6px;
+    padding-bottom: 4px;
   }
 }
 
 @mixin core-14($line-height: (20 / 14), $line-height-640: (15 / 12)) {
   font-family: $NTA-Light;
   font-size: 14px;
-  font-size: 1.4rem;
   @include print {
     font-size: 11pt;
   }
@@ -226,7 +201,7 @@
   letter-spacing: 0;
   text-transform: none;
   @media (max-width: 640px) {
-    font-size: 1.2rem;
+    font-size: 12px;
     line-height: $line-height-640;
   }
 }
@@ -235,11 +210,9 @@
 @mixin caption-button-14 {
   @include core-14;
   padding-top: 6px;
-  padding-top: 0.6rem;
   padding-bottom: 4px;
-  padding-bottom: 0.4rem;
   @media (max-width: 640px) {
-    padding-top: 0.4rem;
-    padding-bottom: 0.1rem;
+    padding-top: 4px;
+    padding-bottom: 1px;
   }
 }

--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -100,7 +100,6 @@ article li {
 
   @include media-down(mobile) {
     margin-left: 16px;
-    margin-left: 1.6rem;
     padding-left: 0;
   }
 
@@ -224,7 +223,7 @@ article td {
 /* reduce table font size on very small screens */
 @media screen and (max-width: 320px) {
   article th, article td, article td small {
-    font-size: 1rem;
+    font-size: 10px;
   }
 }
 
@@ -481,7 +480,7 @@ article .form-download {
 }
 
 article .address {
-  background: $grey-9;  
+  background: $grey-9;
   margin: 0.75em 0 1.5em 0;
   padding: 1em 0 1em 2em;
   min-width: 35%;


### PR DESCRIPTION
We were never really benifiting from using rems as we never changed our
base font-size.

Using rems was causing issues with firefox due to the way it has
implemented minimum font size. In firefox the minimum font-size ensures
no element can have a font-size lower than the specified size. This was
causing the html element to have a font-size bigger than the 10px we
were expecting. This caused some display issues for those users.
