### PR TITLE
Add class to clear feedback form on whitehall

### DIFF
--- a/app/views/root/report_a_problem.raw.html.erb
+++ b/app/views/root/report_a_problem.raw.html.erb
@@ -1,5 +1,5 @@
 <!-- report_a_problem -->
-<p class="report-a-problem-toggle"><a href="">Is there anything wrong with this page?</a></p>
+<p class="report-a-problem-toggle js-footer"><a href="">Is there anything wrong with this page?</a></p>
 <div class="report-a-problem-container">
   <p>Help us improve GOV.UK by telling us:</p>
   <form accept-charset="UTF-8" action="/feedback" method="post">


### PR DESCRIPTION
This is to clear the toggle link from stick-at-top content on whitehall.
