### PR TITLE
Remove padding-left from OGL in footer at small sizes

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -217,6 +217,10 @@
         position: relative;
         padding-left: 53px;
 
+        @include media-down(mobile) {
+          padding-left: 0;
+        }
+
         h2 {
           position: absolute;
           left: 0;


### PR DESCRIPTION
The padding-left is required on big screens, but displays strangely on
mobile.

![screen shot 2013-07-09 at 15 00 03](https://f.cloud.github.com/assets/121219/768451/e024fec6-e89f-11e2-9762-6243445f5530.png)
