### PR TITLE
Bump therubyracer to 0.11.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :router do
 end
 
 group :assets do
-  gem "therubyracer", "~> 0.9.4"
+  gem "therubyracer", "0.11.4"
   gem 'uglifier'
   gem 'sass', '3.2.0'
   gem 'sass-rails', '3.2.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,7 +67,7 @@ GEM
     journey (1.0.4)
     json (1.7.7)
     kgio (2.7.4)
-    libv8 (3.3.10.4)
+    libv8 (3.11.8.17)
     libwebsocket (0.1.5)
       addressable
     lograge (0.1.2)
@@ -112,6 +112,7 @@ GEM
     rake (10.0.3)
     rdoc (3.12.2)
       json (~> 1.4)
+    ref (1.0.5)
     router-client (2.0.3)
       builder
       null_logger
@@ -140,8 +141,9 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    therubyracer (0.9.10)
-      libv8 (~> 3.3.10)
+    therubyracer (0.11.4)
+      libv8 (~> 3.11.8.12)
+      ref
     thor (0.17.0)
     tilt (1.3.6)
     treetop (1.4.12)
@@ -176,6 +178,6 @@ DEPENDENCIES
   sass (= 3.2.0)
   sass-rails (= 3.2.5)
   shoulda (= 2.11.3)
-  therubyracer (~> 0.9.4)
+  therubyracer (= 0.11.4)
   uglifier
   unicorn (= 4.3.1)


### PR DESCRIPTION
Older versions have issues installing if a newer version of libv8 is installed (even though it depends on the older version).  See https://github.com/cowboyd/therubyracer/issues/166 for details.

I'm not sure whether we actually need therubyracer given that node is installed on all the servers...
