### PR TITLE
Rename footer sections to be match homepage

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -82,7 +82,7 @@
       <div class="footer-wrapper">
         <div class="footer-categories">
           <div class="footer-explore">
-            <h2>Explore GOV.UK</h2>
+            <h2>Services and information</h2>
 
             <ul>
               <li><a href="/browse/driving">Driving and transport</a></li>
@@ -102,7 +102,7 @@
           </div>
 
           <div class="footer-inside-government">
-            <h2><a href="/government">Inside Government</a></h2>
+            <h2>Departments and policy</h2>
 
             <ul>
               <li><a href="/government/how-government-works">How government works</a></li>


### PR DESCRIPTION
The homepage is changing the naming of the two sections. The footer
should match this.
