### PR TITLE
Configure asset pipeline not to compile assets.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -9,13 +9,13 @@ Static::Application.configure do
   config.action_controller.perform_caching = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this)
-  config.serve_static_assets = true
+  config.serve_static_assets = false
 
   # Compress JavaScripts and CSS
   config.assets.compress = true
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
-  config.assets.compile = true
+  config.assets.compile = false
 
   # Generate digests for assets URLs
   config.assets.digest = true


### PR DESCRIPTION
This will cause it to fail noisily if we reference a non-existent asset,
or one that's not been added to the precompile list.  Setting this would
have meant that the problem fixed in #288 would have been noticed
immediately.

These are the Rails default options.  Looking at the git history, it
would seem that they were changed early on in the development while
stuff was being figured out, and then never set back.
