### PR TITLE
Use property as attribute not name for og tags

### DIFF
--- a/app/views/root/_icons.html.erb
+++ b/app/views/root/_icons.html.erb
@@ -10,4 +10,4 @@
 <link rel="apple-touch-icon-precomposed" href="<%= asset_path "apple-touch-icon-57x57.png" %>">
 
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="og:image" content="<%= asset_path "opengraph-image.png" %>">
+<meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">


### PR DESCRIPTION
The [open graph protocol](http://ogp.me/) says the meta tags should use the property
attribute to define the property it is defining.
