### PR TITLE
Fix Open government licence (OGL) logo position in IE6

### DIFF
--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -226,6 +226,10 @@
           padding-left: 0;
         }
 
+        @include ie(6) {
+          zoom: 1;
+        }
+
         h2 {
           position: absolute;
           left: 0;


### PR DESCRIPTION
HayLayout was required to stop it overlapping the description text.
