### PR TITLE
Remove legacy page heading styles

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -435,8 +435,7 @@ body.full-width {
     padding-left: 0;
 
     h1 {
-      margin-left: -96px;
-      padding-left: 128px;
+      padding-left: 32px;
     }
   }
 }
@@ -447,8 +446,7 @@ body.full-width {
     padding-left: 0;
 
     h1 {
-      margin-left: -96px;
-      padding-left: 128px;
+      padding-left: 32px;
     }
   }
 }


### PR DESCRIPTION
CSS still existed to give enough space on the left
of headings for format icons.
