### PR TITLE
Fix printing issue with selects on Chrome

### DIFF
--- a/app/assets/stylesheets/core-print.scss
+++ b/app/assets/stylesheets/core-print.scss
@@ -16,7 +16,7 @@ body {
   width: 100%;
 }
 
-section > header {
+main > header {
   position: relative;
 
   h1 {
@@ -136,6 +136,10 @@ article {
       @include core-19;
       margin: 14pt 0;
     }
+  }
+
+  select {
+    background: white;
   }
 
   .contact,


### PR DESCRIPTION
The CSS changed here was causing vertical lines spanning the page around selectboxes in Chrome.

This can be seen when printing the following pages:

https://www.gov.uk/maternity-paternity-calculator/y/paternity/yes
https://www.gov.uk/feedback/contact

Also includes changing styles for inclusion of <main> tag into pages.
