### PR TITLE
Don't attempt to show satisfaction survey when not present.

### DIFF
--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -42,6 +42,9 @@
       return $('#banner-notification:visible, #global-cookie-message:visible, #global-browser-prompt:visible').length > 0;
     },
     randomlyShowSurveyBar: function () {
+      if ($('#user-satisfaction-survey').length <= 0) {
+        return;
+      }
       if (Math.floor(Math.random() * 50) === 0) {
         userSatisfaction.showSurveyBar();
       }


### PR DESCRIPTION
This has been causing ramdom (1 in 50) failures in our javascript integration tests because they use a minimal layout that doesn't include the satisfaction survey markup (see https://github.com/alphagov/slimmer/blob/master/lib/slimmer/test_template.rb).
