### PR TITLE
Exit tracking uses slug in data attribute if available.

### DIFF
--- a/app/assets/javascripts/analytics/tracking.js
+++ b/app/assets/javascripts/analytics/tracking.js
@@ -60,10 +60,15 @@ GOVUK.Analytics.startAnalytics = function () {
     var handleExternalLink = function() {
         if (success) return;
         success = true;
-        var slug = encodeURIComponent(GOVUK.Analytics.getSlug(document.URL, trackingStrategy.slugLocation)),
-            exitLink = '/exit?slug=' + slug + '&format=' + GOVUK.Analytics.Format;
+        var $link = $(this),
+            slug = $link.attr('data-transaction-slug');
 
-        $(this).prop('href', exitLink);
+        // Fall back to URL parsing if the data-attribute wasn't found
+        if (slug === undefined) {
+          slug = GOVUK.Analytics.getSlug(document.URL, trackingStrategy.slugLocation);
+        }
+
+        $link.prop('href', '/exit?slug=' + encodeURIComponent(slug) + '&format=' + GOVUK.Analytics.Format);
     };
 
     var handleInternalLink = function () {

--- a/spec/javascripts/SuccessEventTrackingSpec.js
+++ b/spec/javascripts/SuccessEventTrackingSpec.js
@@ -4,7 +4,7 @@ describe("success event tracking", function () {
         "<a id='guide-internal-link' href='#this-is-a-test'>link</a>" +
         "<a id='guide-external-link' href='http://www.google.com/' rel='external'>link</a>" +
         "<div id='get-started'>" +
-        "<a id='transaction-external-link' href='http://www.google.com/' rel='external'>link</a>" +
+        "<a id='transaction-external-link' href='http://www.google.com/' data-transaction-slug='test-slug' rel='external'>link</a>" +
         "</div>" +
         "</div>");
 
@@ -288,7 +288,7 @@ describe("success event tracking", function () {
 
             var href = $("#transaction-external-link").prop("href");
             var parts = href.split("/");
-            var expected = "exit?slug=&format=transaction";
+            var expected = "exit?slug=test-slug&format=transaction";
             expect(parts[3]).toEqual(expected)
         });
     });


### PR DESCRIPTION
This change makes exit tracking use the slug in the data-transaction-slug attribute on the link if it's available.  If not it will fall back to parsing the URL.

This will fix a number of issues we're seeing with exit tracking where it's not able to get the correct slug from the URL (e.g. mixed case slugs, pages from the google cache etc...)

This relies on the change in alphagov/frontend#419 (it won't break without that change, it'll just continue to use the existing broken behaviour).
