### PR TITLE
fix 'report-a-problem' for whitehall

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -1,5 +1,6 @@
 //= require user-satisfaction-survey
 //= require welcome
 //= require core
+//= require report-a-problem
 //= require cookie-functions
 //= require analytics


### PR DESCRIPTION
Pull request #311 moved 'report-a-problem'-related code out of 'core.js'
into a separate file. This meant that the code was no longer being included
in `header-footer-only.js`, which is used by Whitehall, thus breaking the
'report-a-problem' widget.
