### PR TITLE
Fix text in articles being clipped on the left-hand side

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -1,3 +1,5 @@
+@import "_shims";
+
 /*
  * Text styles for articles.
  * It's kind of like typography innit.
@@ -416,6 +418,7 @@ article .info-notice {
   background: none;
   border-left: 10px $grey-8 solid;
   margin-bottom: 1em;
+  @extend %contain-floats;
 }
 
 article .help-notice p,


### PR DESCRIPTION
Text in some articles is drifting off to the left and so being clipped by the article container.

Shown in this problem: https://govuk.zendesk.com/agent/#/tickets/247322
