### PR TITLE
Size hi res icon correctly

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -388,7 +388,7 @@ article .help-notice {
 
   @include device-pixel-ratio() {
     background-image: image-url("icon-important-2x.png");
-    background-size: 29px 24px;
+    background-size: 34px 34px;
   }
 
   p {


### PR DESCRIPTION
Stops [this happening](https://s3.amazonaws.com/prod.tracker2/resource/22301288/photo.PNG?AWSAccessKeyId=AKIAIKWOAN6H4H3QMJ6Q&Expires=1377789795&Signature=A5gKhUupBc%2FFADb921J3vm7L3JA%3D) on retina displays
