### PR TITLE
Progressively enhance browser warning

### DIFF
--- a/app/assets/javascripts/browser-check.js
+++ b/app/assets/javascripts/browser-check.js
@@ -5,11 +5,21 @@
 
 $(function() {
   "use strict";
+  function browserWarning() {
+    var container = $('<div id="global-browser-prompt"></div>'),
+        text = $('<p>For a safer, faster, better experience online you should upgrade your browser.</p>'),
+        findMoreLink = $('<a href="/support/browsers">Find out more about browsers</a>'),
+        closeLink = $('<a href="#" class="dismiss" title="Dismiss this message">Close</a>');
+
+    return container.append(text.append(findMoreLink, closeLink));
+  }
+
   // we don't show the message when the cookie warning is also there
   if (getCookie('seen_cookie_message')) {
     if (suchi.isOld(navigator.userAgent)) {
       if(getCookie('govuk_not_first_visit') !== null && getCookie('govuk_browser_upgrade_dismissed') === null){
-        var $prompt = $("#global-browser-prompt");
+        var $prompt = browserWarning();
+        $('#global-cookie-message').after($prompt);
         $prompt.show();
         $prompt.on("click", ".dismiss", function(e) {
           $prompt.hide();

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -51,9 +51,7 @@
       <p>GOV.UK uses cookies to make the site simpler. <a href="/support/cookies">Find out more about cookies</a></p>
     </div>
 
-    <div id="global-browser-prompt">
-      <p>For a safer, faster, better experience online you should upgrade your browser. <a href="/support/browsers">Find out more about browsers</a> <a href="#" class="dismiss" title="Dismiss this message">Close</a></p>
-    </div>
+    <% # the browser warning has moved to Javascript. If you want it to appear somewhere else, please modify the Javascript. %>
 
     <section id="user-satisfaction-survey">
       <div class="wrapper">


### PR DESCRIPTION
The browser warning isn't correctly progressively enhanced because it appears in the DOM yet is really only visible if JS is working (it's not visible if CSS is available).

This makes the warning only available when JS has loaded by moving the entire DOM construct to JS and creating it dynamically.
