### PR TITLE
Hide media player for print

### DIFF
--- a/app/assets/stylesheets/core-print.scss
+++ b/app/assets/stylesheets/core-print.scss
@@ -201,7 +201,9 @@ a[href^="#"]:after {
 
 img { max-width: 100% !important; }
 
-.print-link {
+.print-link,
+.player-container,
+.video-transcript-toggle {
   display: none;
 }
 


### PR DESCRIPTION
The media player currently displays when pages are printed.

https://www.pivotaltracker.com/story/show/53705975
