### PR TITLE
Remove some calendars styles.

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -650,7 +650,3 @@ article ol.steps {
     }
   }
 }
-
-.clocks-calendar .equal-width {
-  width: 50%;
-}


### PR DESCRIPTION
These have moved to the calendars app (in alphagov/calendars#43).
