### PR TITLE
Fix skiplink on Homepage to link to the main#content

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -25,7 +25,7 @@
 
     <div id="skiplink-container">
       <div>
-        <a href="#<%= local_assigns[:skip_id] || "content" %>" class="skiplink">Skip to main content</a>
+        <a href="#content" class="skiplink">Skip to main content</a>
       </div>
     </div>
 

--- a/app/views/root/chromeless.html.erb
+++ b/app/views/root/chromeless.html.erb
@@ -20,7 +20,7 @@
   <body<%= content_for?(:body_classes) ? " class=\"#{yield(:body_classes)}\"".html_safe : '' %>>
       <script type="text/javascript">document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
 
-    <a href="#<%= local_assigns[:skip_id] || "content" %>" class="visuallyhidden">Skip to main content</a>
+    <a href="#content" class="visuallyhidden">Skip to main content</a>
 
     <div id="global-cookie-message">
       <p>GOV.UK uses cookies to make the site simpler. <a href="/support/cookies">Find out more about cookies</a></p>

--- a/app/views/root/homepage.html.erb
+++ b/app/views/root/homepage.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'base', locals: { hide_nav: true, skip_id: "homepage"} %>
+<%= render partial: 'base', locals: { hide_nav: true } %>


### PR DESCRIPTION
This was also the only thing using an override for the skiplink destination, so that override function is removed as well.
