### PR TITLE
Constrain width of report-a-problem form.

### DIFF
--- a/app/assets/stylesheets/_report-a-problem.scss
+++ b/app/assets/stylesheets/_report-a-problem.scss
@@ -6,6 +6,7 @@
   
   clear:both;
   margin: 3em 0 2em 2em;
+  max-width: 38em;
 
   h2 {
     @include core-24;


### PR DESCRIPTION
This will prevent it being unnecessarily wide when used on full-width layouts (eg child benefit tax calculator)
