### PR TITLE
Fixed a JS error related to cookies with a value of 'null'.

### DIFF
--- a/app/assets/javascripts/analytics/events-cookie-handler.js
+++ b/app/assets/javascripts/analytics/events-cookie-handler.js
@@ -8,7 +8,7 @@ GOVUK.Analytics.internalSiteEvents = function () {
 
     var loadCookie = function () {
         var value = GOVUK.cookie(COOKIE_NAME);
-        if (value) {
+        if (value && value != 'null') {
             value = jQuery.parseJSON(jQuery.base64Decode(value));
         } else {
             value = [];


### PR DESCRIPTION
/analytics/events-cookie-handler.js was throwing an error when trying to consume a cookie who's value had been set to 'null'.  This fixes that.
