### PR TITLE
Add 400 error template

### DIFF
--- a/app/views/root/400.html.erb
+++ b/app/views/root/400.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "four_hundred_error", locals: {
+    title: "Bad request - 400",
+    heading: "Bad request",
+    intro: ''
+} %>


### PR DESCRIPTION
It's unlikely real users will ever see this page, but it's worth including just in case. We definitely serve 400s from other parts of the stack in reaction to badly formed requests.

This is to support alphagov/whitehall#1038.
