### PR TITLE
Add method to set user satisfaction survey URL

### DIFF
--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -51,6 +51,11 @@
       if (Math.floor(Math.random() * 50) === 0) {
         userSatisfaction.showSurveyBar();
       }
+    },
+    setSurveyUrl: function(href) {
+      var takeSurvey = document.getElementById('take-survey');
+      takeSurvey.setAttribute('href', href);
+      userSatisfaction.appendCurrentPathToSurveyUrl();
     }
   };
 


### PR DESCRIPTION
In whitehall we want to add different surveys for some pages. It could be possible to make this a slimmer processor so anything could set an arbitrary user satisfaction survey, but the survey is displayed using JavaScript anyway, so configuring it using GOVUK.userSatisfaction seems like a neater solution.

Thoughts?
