### PR TITLE
Adjust spacing for removed format names

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -362,7 +362,7 @@ header.page-header {
       background-color: #fff;
       display: block;
       margin: 0 24em 0 0;
-      padding: 1em 2em 2em 2em;
+      padding: 2em 2em 2em 2em;
 
       @include media-down(tablet) {
         margin: 0;


### PR DESCRIPTION
There are various pull requests in to remove the format names from GOV.UK (eg Guide, Quick Answers, Service, etc). See: [frontend](https://github.com/alphagov/frontend/pull/482), [static](https://github.com/alphagov/static/pull/346), [calendars](https://github.com/alphagov/calendars/pull/48), [business-support-finder](https://github.com/alphagov/business-support-finder/pull/49), [smart-answers](https://github.com/alphagov/smart-answers/pull/646) and [licence-finder](https://github.com/alphagov/licence-finder/pull/45).

This update adjusts the spacing above the page's heading after the format name has been removed.
This should only be merged if those other pull requests are merged.
