### PR TITLE
Track the clicks on the related box jump link

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -80,6 +80,13 @@ $(document).ready(function() {
       }
     }
   }
+
+  $('.skip-to-related').click(function(e){
+    if(!window.hasClickedSkipToRelated){
+      window.hasClickedSkipToRelated = true;
+      _gaq && _gaq.push(['_trackEvent', 'ms_related_box', 'skip', 'clicked', 0, true]);
+    }
+  });
 });
 
 


### PR DESCRIPTION
There is a link which is only shown to mobile users to jump to the
related box at the bottom of the page. In order to determine if that
link is needed we want to gather some stats on on if anyone actually
clicks it.

This will send an analytics event which we can then view later. The plan
is to only run this for a week or two before we will remove it again.
