### PR TITLE
Correct link to GDS blog

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -4,5 +4,5 @@
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
   <li><a href="/cymraeg">Cymraeg</a></li>
-  <li>Built by the <a href="http://digital.cabinetoffice.gov.uk/">Government Digital Service</a></li>
+  <li>Built by the <a href="https://gds.blog.gov.uk/">Government Digital Service</a></li>
 </ul>


### PR DESCRIPTION
We've moved our blog from http://digital.cabinet-office.gov.uk/ to
https://gds.blog.gov.uk/

This should update the GOV.UK footer to reflect that.
