### PR TITLE
Anchor print on the line-end in robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,5 +1,5 @@
 User-agent: *
-Disallow: /*/print
+Disallow: /*/print$
 # Don't allow indexing of search results
 Disallow: /search?
 # We only allow indexing of the licence-finder landing page


### PR DESCRIPTION
In Zendesk #224071 it is noted that Google is warning that URLs like
https://www.gov.uk/government/publications/printing-immform-helpsheet-11
are not being indexed.

This seems to be because the pattern match (which isn't full regex syntax)
is too greedy, matching */print and */printfoo. By anchoring it on the end
of the line with $, it should only match /print

References:
   https://support.google.com/webmasters/answer/156449?hl=en&from=40360&rd=1
