### PR TITLE
Ie8 width

### DIFF
--- a/app/assets/stylesheets/core.scss
+++ b/app/assets/stylesheets/core.scss
@@ -89,12 +89,11 @@ h4 {
 .related-positioning {
   height: 0;
   left: 0;
-  position: fixed;
   position: absolute;
   top: 9.5em;
   width: 100%;
   z-index: 0;
-
+  
   @include ie-lte(8) {
     z-index: 0;
   }
@@ -128,20 +127,15 @@ h4 {
   height: 0;
   margin: 0 auto;
   max-width: 1020px;
-  position: relative;
   z-index: 50;
 
-  @include ie-lte(7) {
+  @include ie-lte(8) {
     width: 960px;
   }
 
   @include media-down(tablet) {
     max-width: auto;
     height: auto;
-
-    @include ie-lte(7) {
-      width: auto;
-    }
   }
 }
 
@@ -149,7 +143,6 @@ h4 {
   position: absolute;
   right: 1.75em;
   margin: 3em 0 0 0;
-  width: 15em;
   width: 18.75em;
   border-top: 10px solid $mainstream-brand;
 


### PR DESCRIPTION
This fixes the header and footer in ie8 which, at browser widths, were compressing with the page width and wrapping badly.

This also fixes the .related-positioning sidebar in ie8 which is absolutely positioned but had no min width so was moving with the browser width to cover the content in <main>

Also removed a few CSS rules that weren't being used.
