### PR TITLE
Use latest govuk_template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ gem 'govuk_frontend_toolkit', '0.42.0'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else
-  gem 'govuk_template', '0.4.0'
+  gem 'govuk_template', '0.6.1'
 end
 gem 'gds-api-adapters', '7.18.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     govuk_frontend_toolkit (0.42.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.4.0)
+    govuk_template (0.6.1)
       rails (>= 3.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -180,7 +180,7 @@ DEPENDENCIES
   exception_notification
   gds-api-adapters (= 7.18.0)
   govuk_frontend_toolkit (= 0.42.0)
-  govuk_template (= 0.4.0)
+  govuk_template (= 0.6.1)
   jasmine (= 1.1.2)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)


### PR DESCRIPTION
Changes in this version include:
- Fix IE8 JavaScript error which is thrown on every page load
- Use visited link colour for visited links

You can look at the files in `source/` to see the actual changes:
https://github.com/alphagov/govuk_template/compare/v0.4.1...v0.6.1
