### PR TITLE
Use inline-block on page navigation links

### DIFF
--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -1,3 +1,5 @@
+@import "_shims.scss";
+
 /* visited link colour overrides */
 #content.multi-page li a:visited,
 #content.multi-page .pagination li a:visited,
@@ -232,7 +234,7 @@ aside .page-navigation {
     }
 
     a {
-      display: block;
+      @include inline-block;
       padding: 0.25em 1em 0.25em 0;
 
       @include ie-lte(7) {


### PR DESCRIPTION
Assumption: display:block was being used to enable the vertical padding
to apply. This occasionally causes layout errors (see zendesk 
ticket 543226). "Fix" this by making anchors inline-block.

Side effects: page navigation link hit zone no longer continues
ridiculously far to the right.
