### PR TITLE
Bump govuk_template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ gem 'govuk_frontend_toolkit', '0.43.2'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else
-  gem 'govuk_template', '0.6.1'
+  gem 'govuk_template', '0.6.2'
 end
 gem 'gds-api-adapters', '7.18.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     govuk_frontend_toolkit (0.43.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.6.1)
+    govuk_template (0.6.2)
       rails (>= 3.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -180,7 +180,7 @@ DEPENDENCIES
   exception_notification
   gds-api-adapters (= 7.18.0)
   govuk_frontend_toolkit (= 0.43.2)
-  govuk_template (= 0.6.1)
+  govuk_template (= 0.6.2)
   jasmine (= 1.1.2)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)


### PR DESCRIPTION
New shiny includes:
- Apple and opengraph images in transport not Gill
- Standard colours from frontend_toolkit
- Text rather than image for ogl logo
