### PR TITLE
Hide the 'Report a problem' link when JS is off

### DIFF
--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -52,10 +52,14 @@ var ReportAProblem = {
 }
 
 $(document).ready(function() {
-  // toggle for reporting a problem (on all content pages)
-  $('.report-a-problem-toggle a').on('click', function() {
+  // Add in the toggle link for reporting a problem at the bottom of the page
+  var $toggleLink = $('<p>', {class: 'report-a-problem-toggle js-footer'}).append('<a href="">Is there anything wrong with this page?</a>');
+  $toggleLink.insertBefore('.report-a-problem-container');
+
+  // Add a click handler for the toggle
+  $toggleLink.on('click', function() {
     $('.report-a-problem-container').toggle();
-      return false;
+    return false;
   });
 
   // form submission for reporting a problem

--- a/app/views/root/report_a_problem.raw.html.erb
+++ b/app/views/root/report_a_problem.raw.html.erb
@@ -1,5 +1,4 @@
 <!-- report_a_problem -->
-<p class="report-a-problem-toggle js-footer"><a href="">Is there anything wrong with this page?</a></p>
 <div class="report-a-problem-container">
   <h2>Help us improve GOV.UK</h2>
   <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">


### PR DESCRIPTION
Currently when you have JavaScript disabled, you can see the HTML form to send feedback, but you also have the toggle link visible. Because that element doesn't contain an href, it reloads the current page.

This commit changes the behaviour so that the toggle link is hidden using CSS but then displayed on page load using JavaScript.
