### PR TITLE
Move all JavaScript to the end of the page

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -2,8 +2,6 @@
 
 <% content_for :head do %>
   <%= render :partial => 'stylesheet', :locals => { :css_file => local_assigns[:css_file] || 'application' } %>
-
-  <%= render :partial => 'javascript', :locals => { :js_file => local_assigns[:js_file] || 'application' } unless local_assigns[:js_at_the_end] %>
 <% end %>
 
 <% content_for :inside_header do %>
@@ -83,5 +81,5 @@
   <%= render :partial => "footer_support_links" %>
 <% end %>
 <% content_for :body_end do %>
-  <%= render :partial => 'javascript', :locals => { :js_file => local_assigns[:js_file] || 'application' } if local_assigns[:js_at_the_end] %>
+  <%= render :partial => 'javascript', :locals => { :js_file => local_assigns[:js_file] || 'application' } %>
 <% end %>

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,3 +1,3 @@
 <%= javascript_include_tag 'libs/jquery/jquery-1.7.2.js' %>
-<%= javascript_include_tag local_assigns[:js_file] || 'application', :defer => 'defer' %>
+<%= javascript_include_tag local_assigns[:js_file] || 'application' %>
 <%= render partial: "google_analytics" %>

--- a/app/views/root/header_footer_only.html.erb
+++ b/app/views/root/header_footer_only.html.erb
@@ -1,5 +1,4 @@
 <%= render partial: 'base', locals: {
   css_file: 'header-footer-only',
-  js_file: 'header-footer-only',
-  js_at_the_end: true,
+  js_file: 'header-footer-only'
 } %>

--- a/app/views/root/wrapper_with_js_last.html.erb
+++ b/app/views/root/wrapper_with_js_last.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: 'base', locals: { js_at_the_end: true } %>


### PR DESCRIPTION
Reasons for moving it to the bottom include:
- that it is considered best practice to put JavaScript at the bottom of the page
- some work I am doing requires `GOVUK.cookie` to be available before we execute `_ga.push(['_trackPageview'])` this moves the tracking code below the inclusion of `govuk_template.js` which has that function in it

As far as I can tell all of our JavaScript is deferred till after domReady anyway by wrapping it in a jQuery call so this doesn't actually have any effects there. The only thing this might effect is how quickly the call to GA is made after page load, but again, as far as I can tell the tracking beacons aren't sent till after domReady.
