### PR TITLE
Remove tracking cookie after it has been recorded

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -19,6 +19,7 @@
     customVar[1] = parseInt(customVar[1], 10);
     customVar[4] = parseInt(customVar[4], 10);
     _gaq.push(customVar);
+    GOVUK.cookie('ga_nextpage_params', null);
   }
 </script>
 <script type="text/javascript">


### PR DESCRIPTION
Otherwise it will be sent on every page ever after search.
