### PR TITLE
Change beta header to beta notice label

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -187,7 +187,6 @@
   display: none; /* shown with JS, always hidden for non-JS */
 }
 
-.beta-notice,
 #global-browser-prompt {
   padding: 0.5em 2em;
 
@@ -232,12 +231,6 @@
     position: absolute;
     right: 0;
   }
-}
-
-
-.beta-notice{
-  background-color: $orange;
-  color: #fff;
 }
 
 #global-breadcrumb {

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,5 @@
 @import "static-pages/error-pages";
 
 @import "multi-step";
+
+@import "beta-notice";

--- a/app/assets/stylesheets/beta-notice.scss
+++ b/app/assets/stylesheets/beta-notice.scss
@@ -1,0 +1,16 @@
+.beta-notice {
+  clear: both;
+  margin:0;
+  @include copy-16;
+
+  span.beta {
+    display: inline-block;
+    background: #f47738;
+    color: #fff;
+    @include bold-16;
+    line-height:1;
+    text-transform: uppercase;
+    padding: 5px 5px 2px 6px;
+    margin-right:10px;
+  }
+}

--- a/app/views/root/beta_notice.html.erb
+++ b/app/views/root/beta_notice.html.erb
@@ -1,3 +1,1 @@
-<div class="beta-notice">
-  <p>We are testing this page in public, so it may contain inaccurate information.</p>
-</div>
+<div class="beta-notice"><span class="beta">beta</span> This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a></div>


### PR DESCRIPTION
Implementing design changes to show a smaller beta label style and change of the text being displayed. Counterpart to https://github.com/alphagov/slimmer/pull/64.
