### PR TITLE
Add new Beta Label

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,3 +26,5 @@
 @import "static-pages/error-pages";
 
 @import "multi-step";
+
+@import "beta-label";

--- a/app/assets/stylesheets/beta-label.scss
+++ b/app/assets/stylesheets/beta-label.scss
@@ -1,0 +1,16 @@
+.beta-label {
+  clear: both;
+  margin:0;
+  @include copy-16;
+
+  span.beta {
+    display: inline-block;
+    background: #f47738;
+    color: #fff;
+    @include bold-16;
+    line-height:1;
+    text-transform: uppercase;
+    padding: 5px 5px 2px 6px;
+    margin-right:10px;
+  }
+}

--- a/app/views/root/beta_label.html.erb
+++ b/app/views/root/beta_label.html.erb
@@ -1,0 +1,1 @@
+<div class="beta-label"><span class="beta">beta</span> This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a></div>


### PR DESCRIPTION
Following on from https://github.com/alphagov/slimmer/pull/64, it was decided to add the Beta Label and slowly phase out Beta Notice. Counterpart to https://github.com/alphagov/slimmer/pull/65.
