### PR TITLE
Mark the beta_label template as a non-layout template

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -16,6 +16,7 @@ class RootController < ApplicationController
   NON_LAYOUT_TEMPLATES = %w(
     barclays_epdq
     beta_notice
+    beta_label
     campaign
     print
     proposition_menu


### PR DESCRIPTION
Include `beta_label` (added in #383) as part of the `NON_LAYOUT_TEMPLATES` list, so that we don't show the GOV.UK wrapper around it when we include it in other pages.
