### PR TITLE
Add YouTube account verification file

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -20,6 +20,7 @@ namespace :router do
       %w(/robots.txt exact),
       %w(/fonts prefix),
       %w(/google991dec8b62e37cfb.html exact),
+      %w(/googlef35857dca8b812e7.html exact),
       %w(/apple-touch-icon.png exact static),
       %w(/apple-touch-icon-144x144.png exact),
       %w(/apple-touch-icon-114x114.png exact),

--- a/public/googlef35857dca8b812e7.html
+++ b/public/googlef35857dca8b812e7.html
@@ -1,0 +1,1 @@
+google-site-verification: googlef35857dca8b812e7.html


### PR DESCRIPTION
We need to validate our YouTube account so we can embed deep links in the annotations.

The primary use case for this is linking out to help or transaction start pages from instructional videos hosted on YouTube, e.g link to the passport application process from a video about the transaction.

Requested directly by Kim T in comms and James T.
