### PR TITLE
Allow CMA finders to be indexed

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,8 +9,5 @@ Allow: /licence-finder
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
-# Prevent access to CMA cases until 31st March
-Disallow: /cma-cases
-Disallow: /cma-cases/
 Sitemap: https://www.gov.uk/sitemap.xml
 Crawl-delay: 0.5


### PR DESCRIPTION
They are still blocked by X-Robots-Tag headers sent by
specialist-frontend and finder-frontend.

https://www.pivotaltracker.com/story/show/68209348

@evilstreak 
