### PR TITLE
Fix missing step icons

### DIFF
--- a/app/assets/stylesheets/text.scss
+++ b/app/assets/stylesheets/text.scss
@@ -596,10 +596,10 @@ article ol.steps {
 
     @for $i from 1 through 14 {
       &:nth-child(#{$i}) {
-        background-image: image-url("icon-step-#{$i}.png");
+        background-image: image-url("icon-steps/icon-step-#{$i}.png");
 
         @include device-pixel-ratio() {
-          background-image: image-url("icon-step-#{$i}-2x.png");
+          background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
           background-size: 24px 24px;
         }
       }


### PR DESCRIPTION
The numbered step icons were missing locally, but thanks to @edds this update fixes the broken path.
