### PR TITLE
Stop robots indexing experimental dashboards

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -9,5 +9,7 @@ Allow: /licence-finder
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
+# Don't allow indexing of experimental performance platform dashboards
+Disallow: /performance/experimental/*
 Sitemap: https://www.gov.uk/sitemap.xml
 Crawl-delay: 0.5


### PR DESCRIPTION
While dashboards are being developed and need to be shared externally,
we are storing these in the experimental directory. As these have not
offically 'gone live' we want don't want robots picking them up.
