### PR TITLE
Bump govuk_template to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,6 @@ gem 'govuk_frontend_toolkit', '0.43.2'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else
-  gem 'govuk_template', '0.6.4'
+  gem 'govuk_template', '0.8.0'
 end
 gem 'gds-api-adapters', '7.18.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -61,7 +61,7 @@ GEM
     govuk_frontend_toolkit (0.43.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.6.4)
+    govuk_template (0.8.0)
       rails (>= 3.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -180,7 +180,7 @@ DEPENDENCIES
   exception_notification
   gds-api-adapters (= 7.18.0)
   govuk_frontend_toolkit (= 0.43.2)
-  govuk_template (= 0.6.4)
+  govuk_template (= 0.8.0)
   jasmine (= 1.1.2)
   logstasher (= 0.4.8)
   mocha (= 0.13.3)

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -5,7 +5,7 @@
     @extend %contain-floats;
 
     @include media(tablet){
-      padding: 0 0 30px;
+      padding: 0 $gutter-half $gutter;
     }
 
     .footer-explore,

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -243,7 +243,6 @@
   }
 
   ol {
-    border-top: 10px solid $mainstream-brand;
     max-width: 960px;
     margin: 0 30px;
     padding: 0.75em 0;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "_conditionals";
 @import "_css3";
 @import "_device-pixels";
+@import "_measurements";
 @import "_typography";
 
 /* local styleguide includes */

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -3,6 +3,7 @@
 @import "_conditionals";
 @import "_css3";
 @import "_device-pixels";
+@import "_measurements";
 @import "_typography";
 @import "design-patterns/_buttons";
 


### PR DESCRIPTION
The new version contains:
- Cookie bar above header
- The blue brand bar on every page by default
- New widths on the footer

Updated the footer padding to compensate for the new footer width and
removed the border on the breadcrumbs to no end up with a double colour
bar at the top of the page.

This shouldn't be merged until the following pull requests have been merged (and possibly deployed):
- [x] [whitehall](https://github.com/alphagov/whitehall/pull/1484)
- [x] [frontend](https://github.com/alphagov/frontend/pull/603)
- [x] [limelight](https://github.com/alphagov/limelight/pull/264) 
