### PR TITLE
Fix unordered list bullets in smart answers

### DIFF
--- a/app/assets/stylesheets/multi-step.scss
+++ b/app/assets/stylesheets/multi-step.scss
@@ -193,8 +193,6 @@ li.done:hover .undo a {
   }
 
   ul {
-    padding: 0; /* this is so the bullets hang */
-
     label {
       margin-left: 0.25em;
     }
@@ -206,7 +204,8 @@ li.done:hover .undo a {
     /* this is the multiple choice selector */
     &.options {
       list-style: none;
-
+      padding: 0; /* this aligns optional questions with gutter */
+      
       li {
         line-height: 1.5em;
         margin: 0.5em 0;


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/53479985

Fixed unordered list alignment in smart answers.

The bullets for unordered lists in smart answer questions were shifting partially offscreen on smaller screen sizes. Shifted padding reset to target the optional bullets list only.
