### PR TITLE
Fix URL reference to locator-icon

### DIFF
--- a/app/assets/stylesheets/publisher.scss
+++ b/app/assets/stylesheets/publisher.scss
@@ -514,7 +514,7 @@ aside .page-navigation-closed {
 }
 
 .find-location-for-service, .find-location-for-licence {
-  background: $grey-9 image-url("locator-icon.png") no-repeat 1em 1em;
+  background: $grey-9 image-url("icon-locator.png") no-repeat 1em 1em;
   min-height: 2em;
   line-height: 2;
   margin: 2em -1em 0 -1em;


### PR DESCRIPTION
This was moved in d62aa21084cd39c3c7d980486d495766b3368172.

Fixes https://www.pivotaltracker.com/story/show/72539996

Long term this stuff is in alphagov/govuk_frontend_toolkit now.
