### PR TITLE
Remove report-a-problem from 4XX pages

### DIFF
--- a/app/assets/stylesheets/static-pages/error-pages.scss
+++ b/app/assets/stylesheets/static-pages/error-pages.scss
@@ -24,38 +24,6 @@
     }
   }
 
-  .report-a-problem {
-    margin-top: 60px;
-
-    form {
-      @include core-24;
-
-      padding-top: 10px;
-
-      label {
-        display: block;
-
-        @include ie-lte(8) {
-          width: 400px;
-        }
-      }
-
-      input {
-        display: block;
-        margin-bottom: 20px;
-        width: 400px;
-
-        @include media(mobile) {
-          width: 300px;
-        }
-      }
-
-      button {
-        margin-top: 10px;
-      }
-    }
-  }
-
   @include media(mobile) {
     .page-header div {
       padding-left: 1em;

--- a/app/views/root/_four_hundred_error.html.erb
+++ b/app/views/root/_four_hundred_error.html.erb
@@ -14,23 +14,6 @@
     <article role="article" class="group">
       <div class="inner">
         <%= raw local_assigns[:intro] %>
-
-        <div class="report-a-problem">
-          <h2>Help us improve GOV.UK by telling us:</h2>
-          <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">
-            <input id="source" name="source" type="hidden" value="page_not_found">
-            <label for="what_doing">
-              What were you trying to do
-              <input id="what_doing" name="what_doing" type="text" />
-            </label>
-
-            <input type="hidden" id="what_wrong" name="what_wrong" value="broken link (404)" />
-
-            <input type="hidden" name="utf8" value="✓" />
-            <button name="commit" type="submit" class="button">Send</button>
-          </form>
-        </div>
-
       </div>
     </article>
   </div>

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -23,8 +23,6 @@ class Error4XXTest < ActionDispatch::IntegrationTest
 
       within "#wrapper" do
         assert page.has_selector?("h1", :text => "This page cannot be found")
-
-        assert page.has_selector?(".report-a-problem")
       end
 
       within "footer" do


### PR DESCRIPTION
We shouldn't make users fill this out:
- this form captures info that we already know (from fastly or GA)
- this feedback isn't really being used in a consequent manner

This has been agreed with Roo.
