### PR TITLE
[do-not-merge] Stop using custom fonts on print sheets

### DIFF
--- a/app/assets/stylesheets/helpers/_core-print.scss
+++ b/app/assets/stylesheets/helpers/_core-print.scss
@@ -3,6 +3,10 @@ html {
   font-size: 62.5%;
 }
 
+body {
+  font-family: Helvetica, Arial, sans-serif;
+}
+
 #logo {
   @include core-48;
   font-size: 28pt;


### PR DESCRIPTION
Experimenting with switching fonts back to Helvetica, Arial, sans-serif for printing to avoid issues with browser compatibility/OS-specific problems/printer driver broken replacement fonts. 
