### PR TITLE
Sets non-interaction flag for scroll analytics events

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -116,7 +116,9 @@
     for ( var i=0; i<this.trackedNodes.length; i++ ) {
       if ( this.trackedNodes[i].isVisible() && !this.trackedNodes[i].alreadySeen ) {
         this.trackedNodes[i].alreadySeen = true;
-        GOVUK.sendToAnalytics(["_trackEvent"].concat(this.trackedNodes[i].eventData));
+        GOVUK.sendToAnalytics(["_trackEvent"].concat(this.trackedNodes[i].eventData).concat([true]));
+        // Last 'true' sets non-interaction flag
+        // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#non-interaction
       }
     }
   };

--- a/spec/javascripts/analytics/scroll-tracker-spec.js
+++ b/spec/javascripts/analytics/scroll-tracker-spec.js
@@ -43,8 +43,8 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToPercent(60);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(2);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "25"] ]);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "50"] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "25", true] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "50", true] ]);
     });
   });
 
@@ -52,7 +52,7 @@ describe("GOVUK.ScrollTracker", function() {
     var FIXTURE = "\
       <h1>This is the first <span>heading</span></h1>\
       <h2>This is the second heading</h2>\
-      <h4>
+      <h4>\
         This is the third&nbsp;heading  \
       </h4>";
 
@@ -71,7 +71,7 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToShowHeadingNumber(1);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(1);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the first heading"] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the first heading", true] ]);
 
       scrollToShowHeadingNumber(2);
 
@@ -80,7 +80,7 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToShowHeadingNumber(3);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(2);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the third heading"] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the third heading", true] ]);
     });
   });
 


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/73607116

Before, ScrollTo events were not being flagged as non-interaction events,
so google was factoring them into bounce rates. This flags ScrollTo events
as non-interactive to fix this.

Info on non-interactive flag:
https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#non-interaction
