### PR TITLE
Add annotations support for DWP YouTube channel

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -19,6 +19,7 @@ namespace :router do
       %w(/humans.txt exact),
       %w(/robots.txt exact),
       %w(/fonts prefix),
+      %w(/google6db9c061ce178960.html exact), # DWP YouTube annotations
       %w(/google991dec8b62e37cfb.html exact),
       %w(/googlef35857dca8b812e7.html exact),
       %w(/apple-touch-icon.png exact static),

--- a/public/google6db9c061ce178960.html
+++ b/public/google6db9c061ce178960.html
@@ -1,0 +1,1 @@
+google-site-verification: google6db9c061ce178960.html


### PR DESCRIPTION
In order to link directly from YouTube videos to GOV.UK the account holder needs to associate a site with their content. This is done via the standard Google site verification method.

[More info on how associated sites are registered](https://support.google.com/youtube/answer/2887282?hl=en-GB).
