### PR TITLE
Remove "from gov.uk" on print stylesheet

### DIFF
--- a/app/assets/stylesheets/helpers/_core-print.scss
+++ b/app/assets/stylesheets/helpers/_core-print.scss
@@ -26,10 +26,6 @@ main > header {
     border-bottom: solid 1pt black;
     padding-bottom: 6pt;
     width: 80%;
-
-    &:after {
-      content: " from GOV.UK";
-    }
   }
 
   p {


### PR DESCRIPTION
This fix stems from this issue: 
https://govuk.zendesk.com/agent/#/tickets/764799
which created inconsistencies like"
https://www.gov.uk/lwfans-ceisio-gwaith/print (language inconsistency)
and
https://www.gov.uk/rent-room-in-your-home/print (duplication!)
Roo Reynolds made the decision to remove both "a guide from gov.uk" from the print template, and stop adding "from gov.uk" to the print stylesheet: this fix together with a fix to frontend (https://github.com/alphagov/frontend/pull/626) addresses that.
