### PR TITLE
Repair 'fix' for analytics scroll tracker non-interaction flag

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -121,7 +121,7 @@
     for ( var i=0; i<this.trackedNodes.length; i++ ) {
       if ( this.trackedNodes[i].isVisible() && !this.trackedNodes[i].alreadySeen ) {
         this.trackedNodes[i].alreadySeen = true;
-        GOVUK.sendToAnalytics(["_trackEvent"].concat(this.trackedNodes[i].eventData).concat([true]));
+        GOVUK.sendToAnalytics(["_trackEvent"].concat(this.trackedNodes[i].eventData).concat([0, true]));
         // Last 'true' sets non-interaction flag
         // https://developers.google.com/analytics/devguides/collection/gajs/eventTrackerGuide#non-interaction
       }

--- a/spec/javascripts/analytics/scroll-tracker-spec.js
+++ b/spec/javascripts/analytics/scroll-tracker-spec.js
@@ -43,8 +43,8 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToPercent(60);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(2);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "25", true] ]);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "50", true] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "25", 0, true] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Percent", "50", 0, true] ]);
     });
   });
 
@@ -71,7 +71,7 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToShowHeadingNumber(1);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(1);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the first heading", true] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(0)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the first heading", 0, true] ]);
 
       scrollToShowHeadingNumber(2);
 
@@ -80,7 +80,7 @@ describe("GOVUK.ScrollTracker", function() {
       scrollToShowHeadingNumber(3);
 
       expect(GOVUK.sendToAnalytics.calls.count()).toBe(2);
-      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the third heading", true] ]);
+      expect(GOVUK.sendToAnalytics.calls.argsFor(1)).toEqual([ ["_trackEvent", "ScrollTo", "Heading", "This is the third heading", 0, true] ]);
     });
   });
 


### PR DESCRIPTION
The analytics scroll tracker failed to set the non-interaction flag, and so
was having an influence on the bounce rate of tracked pages. A previous
commit tried to correct that, but missed one of the google analytics
event paramaters.

Story: https://www.pivotaltracker.com/story/show/73607116
