### PR TITLE
Add govuk_component template and styles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk_frontend_toolkit', '0.43.2'
+gem 'govuk_frontend_toolkit', '1.4.0'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (0.43.2)
+    govuk_frontend_toolkit (1.4.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.8.1)
@@ -160,7 +160,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 7.18.0)
-  govuk_frontend_toolkit (= 0.43.2)
+  govuk_frontend_toolkit (= 1.4.0)
   govuk_template (= 0.8.1)
   jasmine (= 2.0.2)
   jasmine-jquery-rails

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,6 +26,7 @@
 @import "helpers/publisher";
 @import "helpers/report-a-problem";
 @import "helpers/text";
+@import "govuk-component/component";
 
 @import "static-pages/error-pages";
 

--- a/app/assets/stylesheets/govuk-component/_beta-label.scss
+++ b/app/assets/stylesheets/govuk-component/_beta-label.scss
@@ -1,0 +1,3 @@
+.govuk-beta-label {
+  @include phase-banner($state: beta);
+}

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -1,0 +1,7 @@
+// Container file for all govuk-component specific styling
+
+// Component specifc govuk_frontend_toolkit includes
+@import "design-patterns/alpha-beta";
+
+// Components styles
+@import "beta-label";

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -17,3 +17,4 @@
 @import "helpers/footer";
 @import "helpers/header";
 @import "helpers/report-a-problem";
+@import "govuk-component/component";

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -5,12 +5,14 @@ class RootController < ApplicationController
 
   rescue_from ActionView::MissingTemplate, :with => :error_404
 
-  caches_page :template, :raw_template
+  caches_page :template, :raw_root_template, :raw_govuk_component_template
 
-  def raw_template
-    file_path = Rails.root.join("app", "views", "root", "#{params[:template]}.raw.html.erb")
-    error_404 and return unless File.exists?(file_path)
-    render :text => File.read(file_path)
+  def raw_root_template
+    render_raw_template("root", params[:template])
+  end
+
+  def raw_govuk_component_template
+    render_raw_template("govuk_component", params[:template])
   end
 
   NON_LAYOUT_TEMPLATES = %w(
@@ -32,6 +34,12 @@ class RootController < ApplicationController
   end
 
   private
+
+  def render_raw_template(prefix, file_name)
+    file_path = Rails.root.join("app", "views", prefix, "#{file_name}.raw.html.erb")
+    error_404 and return unless File.exists?(file_path)
+    render :text => File.read(file_path)
+  end
 
   def validate_template_param
     # Allow alphanumeric and _ in template filenames.

--- a/app/views/govuk_component/beta_label.raw.html.erb
+++ b/app/views/govuk_component/beta_label.raw.html.erb
@@ -1,0 +1,6 @@
+<div class="govuk-beta-label">
+  <p>
+    <strong class="phase-tag">Beta</strong>
+    <span>This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a></span>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Static::Application.routes.draw do
 
   controller "root", :format => false do
-    get "/templates/:template.raw.html.erb" => :raw_template
+    get "/templates/:template.raw.html.erb" => :raw_root_template
+    get "/templates/govuk_component/:template.raw.html.erb" => :raw_govuk_component_template
     get "/templates/:template.html.erb" => :template
   end
 

--- a/test/integration/templates_test.rb
+++ b/test/integration/templates_test.rb
@@ -53,6 +53,20 @@ class TemplatesTest < ActionDispatch::IntegrationTest
       assert_equal 404, last_response.status
     end
 
+    should "return the raw component files" do
+      get "/templates/govuk_component/beta_label.raw.html.erb"
+      expected = File.read(Rails.root.join("app", "views", "govuk_component", "beta_label.raw.html.erb"))
+      assert_equal expected, last_response.body
+    end
+
+    should "404 for non-existent component templates" do
+      get "/templates/govuk_component/foo.raw.html.erb"
+      assert_equal 404, last_response.status
+
+      get "/templates/govuk_component/wrapper.raw.html.erb"
+      assert_equal 404, last_response.status
+    end
+
     should "404 for invalid template names without looking at the filesystem" do
       File.expects(:exists?).never
       [


### PR DESCRIPTION
For use as a shared partial which can be loaded by any application.
- Add new route and controller action for govuk_component templates
  Separate from the existing templates so it is clear as to what is for
  use as a component
- Use a elements sass file for all elements styling so it can be easily
  included between both the header_footer_only stylesheet and the
  application stylesheet
- Include beta-label as an example component
- Bump the toolkit for the new beta label styling

Related pull request against slimmer so the template can be used in other applications: https://github.com/alphagov/slimmer/pull/76
