### PR TITLE
Track when we show the browser upgrade prompt

### DIFF
--- a/app/assets/javascripts/browser-check.js
+++ b/app/assets/javascripts/browser-check.js
@@ -20,6 +20,7 @@ $(function() {
         var $prompt = browserWarning();
         $('#global-cookie-message').after($prompt);
         $prompt.show();
+        window._gaq && _gaq.push(['_trackEvent', 'browser-check', 'prompt-shown', '', 1, true]);
         $prompt.on("click", ".dismiss", function(e) {
           $prompt.hide();
           // the warning is dismissable for 4 weeks, for users who are not in a


### PR DESCRIPTION
At the moment it's getting quite a lot of negative feedback, and knowing who actually
sees it will help use decide how to respond to that.

We've been inferring this from traffic to the /help/browsers page, but that only captures
users who are clicking on the banner. This will record exactly who sees it.
