### PR TITLE
Serve govuk-component documentation as JSON

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -1,7 +1,7 @@
 class RootController < ApplicationController
   layout false
 
-  before_filter :validate_template_param
+  before_filter :validate_template_param, :except => [:govuk_component_docs]
 
   rescue_from ActionView::MissingTemplate, :with => :error_404
 
@@ -13,6 +13,11 @@ class RootController < ApplicationController
 
   def raw_govuk_component_template
     render_raw_template("govuk_component", params[:template])
+  end
+
+  def govuk_component_docs
+    component_doc = JSON.parse(File.read(File.join(Rails.root, 'app', 'views', 'govuk_component', 'docs.json')))
+    render :json => component_doc
   end
 
   NON_LAYOUT_TEMPLATES = %w(

--- a/app/views/govuk_component/docs.json
+++ b/app/views/govuk_component/docs.json
@@ -1,0 +1,8 @@
+[
+  {
+    "id": "beta_label",
+    "name": "Beta Banner",
+    "description": "A banner than indicates content is in a beta phase",
+    "fixtures": {}
+  }
+]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Static::Application.routes.draw do
   controller "root", :format => false do
     get "/templates/:template.raw.html.erb" => :raw_root_template
     get "/templates/govuk_component/:template.raw.html.erb" => :raw_govuk_component_template
+    get "/templates/govuk_component/docs" => :govuk_component_docs
     get "/templates/:template.html.erb" => :template
   end
 


### PR DESCRIPTION
Previously this documentation was stored in the govuk_component_guide app and was
frequently out of sync with static, or failed if pointing at a different static
endpoint.

It's used to generate the living documentation of https://github.com/alphagov/govuk_component_guide

This moves the documentation into static and exposes it as an API-like endpoint,
so that the documentation data could be auto generated in the future, rather than
a static file.

The major change here is moving the docs data into static so it stays in sync, and is exposed by a reliable endpoint. The way it's structured internally can easily be changed in the future.
