### PR TITLE
Add instructions for running static locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,18 @@ Other related repositories:
 To run the unit tests in batch use the jasmine:ci rake task, but it must be run in the test environment: `RAILS_ENV=test rake jasmine:ci`.
 
 Alternatively to run tests in browser: `RAILS_ENV=test rake jasmine`
+
+##Running Locally
+
+If you'd like to run static locally, and keep all its asset links pointing to
+the same local instance, you'll need to set `PLEK_SERVICE_STATIC_URI`, which is
+the host used for static assets (even on static).
+
+Otherwise it defaults to `static.dev.gov.uk`, which won't exist if you're
+just running this repo locally, without the rest of the GOV.UK stack.
+
+To run this app locally, and have it point at its own assets, run it like this:
+
+```
+PLEK_SERVICE_STATIC_URI=0.0.0.0:3013 ./startup.sh
+```


### PR DESCRIPTION
In particular how to have static point at it's own assets, not default to
static.dev.gov.uk, which won't exist unless you're running our whole VM stack.

This makes it easier for:
- new devs seeing how static works
- external contributors
- developers of apps that depend on static (eg, may use slimmer)
