### PR TITLE
Fix broken sticky scrolling on whitehall

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -81,6 +81,7 @@
 .report-a-problem-toggle-wrapper {
   @include outer-block;
   margin-bottom: 30px;
+  clear:both;
 
   .report-a-problem-toggle {
     @include inner-block;


### PR DESCRIPTION
Add clearing to report a problem wrapper.
Without this it's breaking sticky navigation elsewhere in whitehall.
