### PR TITLE
Remove globalsign verification tag from homepage.

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -2,7 +2,6 @@
 
 <% content_for :head do %>
   <%= render :partial => 'stylesheet', :locals => { :css_file => local_assigns[:css_file] || 'application' } %>
-  <meta name="globalsign-domain-verification" content="EBNTdDOabJx18Bxr9nExLLf5tlRPIWPchRq2CXSm6G">
 <% end %>
 
 <% content_for :inside_header do %>

--- a/test/integration/templates/homepage_test.rb
+++ b/test/integration/templates/homepage_test.rb
@@ -9,8 +9,6 @@ class HomepageTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("title", :text => "GOV.UK - The best place to find government services and information", :visible => :all)
 
       assert page.has_selector?("link[href='/static/application.css']", :visible => :all)
-
-      assert page.has_selector?("meta[name='globalsign-domain-verification'][content='EBNTdDOabJx18Bxr9nExLLf5tlRPIWPchRq2CXSm6G']", :visible => :all)
     end
 
     within "body" do


### PR DESCRIPTION
The verification process has been completed, so this is no longer
needed.

This reverts commit a0b3b4cabadc5aa5e9f07ada1e7c9f749f2c084b.
