### PR TITLE
Disallow indexing of 'info' pages

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,6 +11,8 @@ Allow: /business-finance-support-finder
 Disallow: /apply-for-a-licence
 # Don't allow indexing of experimental performance platform dashboards
 Disallow: /performance/experimental/*
+# Don't allow indexing of user needs pages
+Disallow: /info/*
 Sitemap: https://www.gov.uk/sitemap.xml
 Crawl-delay: 0.5
 


### PR DESCRIPTION
[Info pages (which show the user need and key metrics about pages on GOV.UK)](https://github.com/alphagov/info-frontend) shouldn't be indexed, so that they don't compete with real pages.
