### PR TITLE
Fix broken JS dependency in header_footer_only

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -3,3 +3,5 @@
 //= require core
 //= require report-a-problem
 //= require analytics
+//= require vendor/polyfills/bind
+//= require govuk/selection-buttons


### PR DESCRIPTION
Selectable JS is included in core.js, but assumes the FET+dep is already
in scope, which is setup for application, but not header_footer_only.

Introduced in https://github.com/alphagov/static/pull/449/
