### PR TITLE
Make application CSS/JS extend header_footer_only CSS/JS

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,16 +1,11 @@
+//= require header-footer-only
+
 //= require libs/jquery/jquery-ui-1.8.16.custom.min
-//= require libs/jquery/plugins/jquery.base64
 //= require libs/jquery/plugins/jquery.player.min
 //= require libs/suchi/isOld.js
 //= require govuk_toolkit
-//= require user-satisfaction-survey
-//= require core
-//= require report-a-problem
 //= require geo-locator
 //= require jquery.history
 //= require jquery.tabs
 //= require mobile
 //= require browser-check
-//= require analytics
-//= require vendor/polyfills/bind
-//= require govuk/selection-buttons

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,6 @@
 /* govuk_frontend_toolkit includes */
-@import "colours";
-@import "conditionals";
-@import "css3";
-@import "device-pixels";
-@import "grid_layout";
-@import "measurements";
-@import "typography";
+@import "header-footer-only";
+
 @import "shims";
 @import "design-patterns/buttons";
 
@@ -13,19 +8,15 @@
 @import "styleguide/conditionals2";
 
 /* styles */
-@import "helpers/alpha-label";
 @import "helpers/buttons";
 @import "helpers/core";
 @import "helpers/ancillary-pages";
-@import "helpers/beta-label";
 @import "helpers/footer";
 @import "helpers/header";
 @import "helpers/multi-step";
 @import "helpers/notifications";
 @import "helpers/organisations";
 @import "helpers/publisher";
-@import "helpers/report-a-problem";
 @import "helpers/text";
-@import "govuk-component/component";
 
 @import "static-pages/error-pages";


### PR DESCRIPTION
All of the CSS/JS modules included in the application 'layout' are
also included in header_footer_only - and only those modules - so
this makes application share exactly those modules by importing
header footer only.

This helps avoid bugs like https://github.com/alphagov/static/pull/458

Also by treating each layout as an extension of an existing layout,
layering new features on top, then we can easily add new kinds
of layout in the future.
