### PR TITLE
Bump frontend toolkit gem to latest version MERGE AFTER https://github.com/alphagov/govuk_template/pull/94

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk_frontend_toolkit', '1.6.0'
+gem 'govuk_frontend_toolkit', '1.6.2'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (1.6.0)
+    govuk_frontend_toolkit (1.6.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.9.0)
@@ -160,7 +160,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 7.18.0)
-  govuk_frontend_toolkit (= 1.6.0)
+  govuk_frontend_toolkit (= 1.6.2)
   govuk_template (= 0.9.0)
   jasmine (= 2.0.2)
   jasmine-jquery-rails


### PR DESCRIPTION
MERGE AFTER https://github.com/alphagov/govuk_template/pull/94

Which includes the latest updates for reset the font for print stylesheets. Which is a font fix for browser and printer issues reported by users.

https://www.agileplannerapp.com/boards/105200/cards/4633
