### PR TITLE
Move selectable Sass into header footer stylesheet

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -18,3 +18,8 @@
 @import "helpers/header";
 @import "helpers/report-a-problem";
 @import "govuk-component/component";
+
+// This should be a component in the future. As the JavaScript and current
+// implementation existing in multiple apps would need to be updated to make
+// that change just make it available globally for the moment.
+@import "helpers/selectable";

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -24,7 +24,7 @@
 
 
 .get-started .button {
-  @include bold-24($line-height: (16 / 24)); 
+  @include bold-24($line-height: (16 / 24));
   padding: 0.45em 0.5em 0.45em 0.5em;
   display: inline-block;
 
@@ -118,65 +118,3 @@ input{
   }
 }
 
-
-// Large hit area
-// Radio buttons & checkboxes
-
-//scoped to label to reduce the possibility of class name clash
-label.selectable {
-  display: block;
-  float: none;
-  clear: left;
-  position: relative;
-
-  background: $panel-colour;
-  border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
-
-  cursor: pointer; // Encourage clicking on block labels
-
-  @include media(tablet) {
-    float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
-  }
-
-  &:hover {
-    border-color: $black;
-  }
-
-  // Position checkbox within label, to allow text to wrap
-  input {
-    position: absolute;
-    top: 18px;
-    left: $gutter-half;
-    cursor: pointer;
-  }
-}
-
-
-// Use inline, to sit block labels next to each other
-.inline .selectable {
-  clear: none;
-  margin-right: $gutter-half;
-}
-
-// Only if JavaScript is enabled
-
-// Add focus styles to block labels
-.js-enabled .focused {
-  outline: 3px solid $yellow;
-}
-
-// Remove focus styles from radio and checkbox inputs
-.js-enabled .selectable input:focus {
-  outline: none;
-}
-
-// Add selected state to block labels
-.js-enabled .selected {
-  background: $white;
-  border-color: $black;
-}

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -1,0 +1,61 @@
+// Large hit area
+// Radio buttons & checkboxes
+
+//scoped to label to reduce the possibility of class name clash
+label.selectable {
+  display: block;
+  float: none;
+  clear: left;
+  position: relative;
+
+  background: $panel-colour;
+  border: 1px solid $panel-colour;
+  padding: (18px $gutter $gutter-half $gutter*1.5);
+  margin-top: 10px;
+  margin-bottom: 10px;
+
+  cursor: pointer; // Encourage clicking on block labels
+
+  @include media(tablet) {
+    float: left;
+    margin-top: 5px;
+    margin-bottom: 5px;
+  }
+
+  &:hover {
+    border-color: $black;
+  }
+
+  // Position checkbox within label, to allow text to wrap
+  input {
+    position: absolute;
+    top: 18px;
+    left: $gutter-half;
+    cursor: pointer;
+  }
+
+  // Use inline, to sit block labels next to each other
+  .inline & {
+    clear: none;
+    margin-right: $gutter-half;
+  }
+
+  // Only if JavaScript is enabled
+  .js-enabled & {
+    // Remove focus styles from radio and checkbox inputs
+    input:focus {
+      outline: none;
+    }
+
+    // Add selected state to block labels
+    &.selected {
+      background: $white;
+      border-color: $black;
+    }
+
+    // Add focus styles to block labels
+    &.focused {
+      outline: 3px solid $yellow;
+    }
+  }
+}


### PR DESCRIPTION
Ideally this would be a component with matching markup. However, the
JavaScript to power this and applications currently using this would
need updating to match a component namespace.

As the JavaScript is already served in the header_footer_only JavaScript
file, move the Sass into header_footer_only as well.

Also better scope the Sass during the move so that it is all nested
within the `label.selectable` selector. This will enable switching the
code to a proper component much easier in the future.
