### PR TITLE
Strip out the `Client-IP` header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem 'unicorn', '4.3.1'
 gem 'aws-ses', :require => 'aws/ses' # Needed by exception_notification
 gem 'exception_notification'
 gem 'logstasher', '0.4.8'
+gem 'rack_strip_client_ip', '0.0.1'
 
 group :assets do
   gem "therubyracer", "0.12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -99,6 +99,7 @@ GEM
       rack
     rack-test (0.6.2)
       rack (>= 1.0)
+    rack_strip_client_ip (0.0.1)
     rails (3.2.18)
       actionmailer (= 3.2.18)
       actionpack (= 3.2.18)
@@ -167,6 +168,7 @@ DEPENDENCIES
   logstasher (= 0.4.8)
   mocha (= 0.13.3)
   plek (= 1.7.0)
+  rack_strip_client_ip (= 0.0.1)
   rails (= 3.2.18)
   sass (= 3.4.2)
   sass-rails (= 3.2.5)


### PR DESCRIPTION
We don't use this header anywhere in our stack, using `X-Forwarded-For` instead. If a request comes in with both headers set, and they don't match, Rails will take this as evidence that someone is trying to spoof their IP address to gain unauthorised access to something.

We could disable this check with a configuration change (see [an example in Signon](https://github.com/alphagov/signonotron2/blob/a4c4c4ecc73a/config/application.rb#L64-69)), but it's less likely to lead to bugs elsewhere in the app if we strip out the `Client-IP` header entirely.  It's also simpler, because it just requires  a single line in the `Gemfile` and doing the dance of Bundler.
