### PR TITLE
Put the 'mainstream' footer blue bar on #footer not #wrapper

### DIFF
--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -9,8 +9,6 @@ body {
 
 #wrapper {
   background-color: $white;
-  border-bottom: 10px solid $mainstream-brand;
-
   @include ie-lte(7) {
     zoom: 1;
   }

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -1,6 +1,9 @@
 /* Global footer */
 
 #footer {
+  // Replaces the 1px #a1acb2 border from govuk_template
+  border-bottom: 10px solid $mainstream-brand;
+
   .footer-categories {
     @extend %contain-floats;
 


### PR DESCRIPTION
This is so we can use the new govuk_frontend_toolkit grid
helpers directly on #wrapper, without the 'footer' blue
bar also being constrained to the grid container width.

By moving the blue bar to #footer, it will always be 100%
width, maintaining the current design.

There is one visual regression, in the current design
the 10px blue bar is applied above the footers 1px grey
bar, but in the new version the blue bar replaces it
entirely.

I debated doing some selector gymnastics to keep the 1px
bar as well, but after a discuss with Mark H. we agreed
that is was barely perceivable and fine to be replaced.

**Before**
![screenshot 2014-10-22 12 08 49](https://cloud.githubusercontent.com/assets/63201/4735156/eaed324c-59dc-11e4-8d58-d3f640265f44.png)

**After**
![screenshot 2014-10-22 12 08 36](https://cloud.githubusercontent.com/assets/63201/4735149/e04e326e-59dc-11e4-8b4a-470a763ac85e.png)
