### PR TITLE
Apply footer border to _top_, not bottom

### DIFF
--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -2,7 +2,7 @@
 
 #footer {
   // Replaces the 1px #a1acb2 border from govuk_template
-  border-bottom: 10px solid $mainstream-brand;
+  border-top: 10px solid $mainstream-brand;
 
   .footer-categories {
     @extend %contain-floats;


### PR DESCRIPTION
This was meant to migrate the wide blue bar from #wrapper to
footer, but that should be on the top
