### PR TITLE
Updating link for /browse/housing in the footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -56,7 +56,7 @@
       <ul>
         <li><a href="/browse/employing-people">Employing people</a></li>
         <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-        <li><a href="/browse/housing">Housing and local services</a></li>
+        <li><a href="/browse/housing-local-services">Housing and local services</a></li>
         <li><a href="/browse/tax">Money and tax</a></li>
         <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
         <li><a href="/visas-immigration">Visas and immigration</a></li>


### PR DESCRIPTION
The browse category has been renamed to /browse/housing-local-services.

I'll also update the following:
- https://github.com/alphagov/spotlight/blob/master/app/server/templates/page-components/footer_top.html
- https://github.com/alphagov/government-service-design-manual/blob/master/_includes/layouts/_footer_top.html
- https://github.com/alphagov/transformation-dashboard/blob/master/_includes/layouts/_footer_top.html
- https://github.com/alphagov/fco-services-node/blob/master/views/partials/_footer_top.ejs
