### PR TITLE
Add __canary__ for checking availability

### DIFF
--- a/public/__canary__
+++ b/public/__canary__
@@ -1,0 +1,1 @@
+Tweet tweet


### PR DESCRIPTION
Before we serve assets from a separate CDN than the rest of GOV.UK, we need
to ensure we have a way to monitor availability. For GOV.UK, we monitor from
nine different locations around the world. We should follow this pattern for
serving assets.

On GOV.UK, we use `__canary__`, which is an app which responds a bit like a
GOV.UK app would do. It isn't cached at the CDN level, so the response comes
directly from origin. For assets, this was considered too heavyweight, so
the workaround was to create a text file which we can check for the
inclusion of a string within. Nimsoft doesn't allow us to check for a HTTP
response code, which isn't too great.

This commit adds that file.
