### PR TITLE
__canary__ is now in Puppet

### DIFF
--- a/public/__canary__
+++ b/public/__canary__
@@ -1,1 +1,0 @@
-Tweet tweet


### PR DESCRIPTION
Since https://github.gds/gds/puppet/pull/2288, the **canary** has been in the
Nginx configuration in Puppet. We don't need this file as well as that one, as
the Nginx configuration is serving the content (and setting it to be JSON,
much like the **canary** on GOV.UK).

Removes the file to avoid confusion. Cc: @dcarley 
