### PR TITLE
Make image_optim development group only

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,10 @@ group :assets do
   gem 'uglifier'
   gem 'sass', '3.4.2'
   gem 'sass-rails', '3.2.5'
-  gem 'image_optim'
+end
+
+group :development do
+  gem 'image_optim', '0.17.1'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -174,7 +174,7 @@ DEPENDENCIES
   gds-api-adapters (= 7.18.0)
   govuk_frontend_toolkit (= 1.6.2)
   govuk_template (= 0.9.1)
-  image_optim
+  image_optim (= 0.17.1)
   jasmine (= 2.0.2)
   jasmine-jquery-rails
   logstasher (= 0.4.8)


### PR DESCRIPTION
We don't need this Gem to compile assets, it's for convenience only.

This should fix the failing builds caused by #479.
