### PR TITLE
Bump govuk_template to latest version (0.10.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,6 @@ gem 'govuk_frontend_toolkit', '1.6.2'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else
-  gem 'govuk_template', '0.9.1'
+  gem 'govuk_template', '0.10.0'
 end
 gem 'gds-api-adapters', '7.18.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
     govuk_frontend_toolkit (1.6.2)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_template (0.9.1)
+    govuk_template (0.10.0)
       rails (>= 3.1)
     hike (1.2.3)
     i18n (0.6.9)
@@ -173,7 +173,7 @@ DEPENDENCIES
   exception_notification
   gds-api-adapters (= 7.18.0)
   govuk_frontend_toolkit (= 1.6.2)
-  govuk_template (= 0.9.1)
+  govuk_template (= 0.10.0)
   image_optim (= 0.17.1)
   jasmine (= 2.0.2)
   jasmine-jquery-rails


### PR DESCRIPTION
This will update the OGL link & text to refer to version 3.
