### PR TITLE
Update SelectionButtons to new interface

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -37,7 +37,7 @@ $(document).ready(function() {
 
   // for radio buttons and checkboxes
   var $buttons = $("label.selectable input[type='radio'], label.selectable input[type='checkbox']");
-  GOVUK.selectionButtons($buttons);
+  new GOVUK.SelectionButtons($buttons);
 });
 
 


### PR DESCRIPTION
Version 2.0.0 of the govuk_frontend_toolkit deprecated the old interface
to SelectionButtons. This now uses the new style.
