### PR TITLE
Add title component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -7,3 +7,4 @@
 @import "beta-label";
 @import "govspeak";
 @import "metadata";
+@import "title";

--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -1,0 +1,19 @@
+.govuk-title {
+  margin: $gutter-half 0;
+
+  @include media(tablet){
+    margin: $gutter 0;
+  }
+
+  .context {
+    @include core-24;
+    color: $secondary-text-colour;
+  }
+
+  h1 {
+    @include bold-48;
+  }
+  &.length-long h1 {
+    @include bold-36;
+  }
+}

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -147,3 +147,24 @@
             </li>
           </ol>
         </div>
+- id: "title"
+  name: "Page title"
+  description: "A page title with optional context label"
+  body: |
+    This contains an optional parameter for average title length. The two valid
+    values for this parameter are 'medium' or 'long'. Medium titles are titles
+    where the average is around 30 characters or less. Long titles would have
+    an average length of nearer 50 characters or more.
+
+    On average the titles on government bits of content are 50 charectors. The
+    average for bits of general guidance are nearer 27 charectors long.
+  fixtures:
+    default:
+      title: "My page title"
+    with_context:
+      context: "Publication"
+      title: "My page title"
+    long_title_with_context:
+      context: "Publication"
+      title: "My page title which is often really long and verbose and has lots of extra words it doesn't need"
+      average_title_length: "long"

--- a/app/views/govuk_component/title.raw.html.erb
+++ b/app/views/govuk_component/title.raw.html.erb
@@ -1,0 +1,10 @@
+<%
+  average_title_length ||= :average
+  context ||= false
+%>
+<div class="govuk-title length-<%= average_title_length %>">
+  <% if context %>
+    <p class="context"><%= context %></p>
+  <% end %>
+  <h1><%= title %></h1>
+</div>


### PR DESCRIPTION
Add a component for page titles. The title should be large by default
with an option to make it smaller for longer titles.

On average the titles on government bits of content are twice as long as
those found on general guidance. We shrink the font size down so that
90% of titles will fit onto two lines.

Note: This builds on the work in #486 as that converts the docs to YAML
rather than JSON. That pull request should be merged before this one.
