### PR TITLE
Pass optional message to Beta Banner

### DIFF
--- a/app/views/govuk_component/beta_label.raw.html.erb
+++ b/app/views/govuk_component/beta_label.raw.html.erb
@@ -1,6 +1,12 @@
 <div class="govuk-beta-label">
   <p>
     <strong class="phase-tag">Beta</strong>
-    <span>This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a></span>
+    <span>
+      <% if local_assigns.include?(:message) %>
+        <%= raw message %>
+      <% else %>
+        This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a>
+      <% end %>
+    </span>
   </p>
 </div>

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -1,8 +1,10 @@
 - id: "beta_label"
   name: "Beta Banner"
-  description: "A banner than indicates content is in a beta phase"
+  description: "A banner than indicates content is in a beta phase with an explanation"
   fixtures:
     default: {}
+    message: 
+      message: "This is an optional different message to explain what Beta means in this context"
 - id: "metadata"
   name: "Metadata block"
   description: "To display relvent metadata about organisations and tags for a document"


### PR DESCRIPTION
In certain instances, the default text for the Beta Banner doesn't work. This commit adds the ability to pass the message in as a local to the partial.
