### PR TITLE
Explain that the Beta Banner can take HTML

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -1,10 +1,10 @@
 - id: "beta_label"
   name: "Beta Banner"
-  description: "A banner than indicates content is in a beta phase with an explanation"
+  description: "A banner than indicates content is in a beta phase with an optional explanation"
   fixtures:
     default: {}
     message: 
-      message: "This is an optional different message to explain what Beta means in this context"
+      message: "This is an optional different message to explain what Beta means in this context which can take <a href='https://www.gov.uk'>HTML</a>"
 - id: "metadata"
   name: "Metadata block"
   description: "To display relvent metadata about organisations and tags for a document"


### PR DESCRIPTION
With the option to add a different message for the Beta Banner the user can pass in HTML. This commit explains in the Docs that passing HTML in the message is possible.
