### PR TITLE
Enhance YouTube videos in govspeak content

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,5 @@
 //= require header-footer-only
 
-//= require libs/jquery/jquery-ui-1.8.16.custom.min
-//= require libs/jquery/plugins/jquery.player.min
 //= require libs/suchi/isOld.js
 //= require govuk_toolkit
 //= require geo-locator

--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -1,0 +1,52 @@
+//= require libs/jquery/jquery-ui-1.8.16.custom.min
+//= require libs/jquery/plugins/jquery.player.min
+
+(function ($) {
+  window.GOVUK = window.GOVUK || {};
+
+  function parseYoutubeVideoId(string){
+    if(string.indexOf('youtube.com') > -1){
+      var i, _i, part, parts, params = {};
+      parts = string.split('?');
+      if (parts.length === 1){
+        return;
+      }
+      parts = parts[1].split('&');
+      for(i=0,_i=parts.length; i<_i; i++){
+        part = parts[i].split('=');
+        params[part[0]] = part[1];
+      }
+      return params.v;
+    }
+    if(string.indexOf('youtu.be') > -1){
+      var parts = string.split('/');
+      return parts.pop();
+    }
+  }
+
+  function enhanceYoutubeVideoLinks($el){
+    $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
+      var $link = $(this),
+          videoId = parseYoutubeVideoId($link.attr('href')),
+          $holder = $('<span class="media-player" />'),
+          $captions = $link.siblings('.captions');
+
+      if(typeof videoId !== 'undefined'){
+        $link.parent().replaceWith($holder);
+
+        $holder.player({
+          id: 'youtube-'+i,
+          media: videoId,
+          captions: $captions.length > 0 ? $captions.attr('href') : null,
+          url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+        });
+      }
+    });
+  }
+
+  GOVUK.enhanceYoutubeVideoLinks = enhanceYoutubeVideoLinks;
+
+  $(function(){
+    GOVUK.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+  });
+})(jQuery);

--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -5,3 +5,4 @@
 //= require analytics
 //= require vendor/polyfills/bind
 //= require govuk/selection-buttons
+//= require govuk-component/govspeak-enhance-youtube-video-links

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -1,3 +1,6 @@
+// Video player styles from frontend toolkit
+@import "../design-patterns/media-player";
+
 .govuk-govspeak {
   h2:first-child,
   h3:first-child,
@@ -323,5 +326,9 @@
         margin: 10px 0;
       }
     }
+  }
+
+  .media-player {
+    @include media-player;
   }
 }


### PR DESCRIPTION
Govspeak that contains links to youtube videos should be expanded into
an accessible video player. This adds the styles for the video player
and adds the JavaScript to identify the appropriate youtube links and
turn them into video players.

Moved the includes for jQueryUI and the player jQuery plugin into the
govspeak video component JavaScript file. This ensures that all the
dependencies are loaded.
