### PR TITLE
Make component generator output YAML

### DIFF
--- a/lib/generators/govuk_component/govuk_component_generator.rb
+++ b/lib/generators/govuk_component/govuk_component_generator.rb
@@ -22,7 +22,7 @@ class GovukComponentGenerator < Rails::Generators::NamedBase
             "default" => {}
         }
       })
-      file.write(JSON.pretty_generate(docs))
+      file.write(docs.to_yaml)
     end
   end
 end


### PR DESCRIPTION
After fixing this generator to read in YAML not JSON, I forgot to fix it to output YAML not JSON. This commit makes the generator write YAML. (whoops)
