### PR TITLE
Move footer list item width into media query

### DIFF
--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -72,11 +72,11 @@
       @include media(tablet){
         float: left;
         width: 33.33%;
-      }
 
-      ul {
-        li {
-          width: 100%;
+        ul {
+          li {
+            width: 100%;
+          }
         }
       }
     }


### PR DESCRIPTION
On mobile devices this was causing the page to be wider than the width
of the viewport. This was due to the element having 100% width with
padding on the element. Moving the width into a media query will mean
the 100% is only applied on desktop which is where it is needed as it is
overriding the 50% width the other footer list items need.

Thanks @alextea for finding the bug.

![screen shot 2014-11-28 at 11 39 40](https://cloud.githubusercontent.com/assets/35035/5227448/48db154e-76f3-11e4-9ed2-37222660380b.png)
