### PR TITLE
Don't pad the Report A Problem link and form

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -1,5 +1,9 @@
 #wrapper {
   @extend %site-width-container;
+
+  .report-a-problem-toggle, .report-a-problem-inner {
+    padding: 0;
+  }
 }
 .grid-row {
   @extend %grid-row;


### PR DESCRIPTION
This commit removes the padding on the Report A Problem Link and Form to keep it in line with the grid layout.
