### PR TITLE
Remove list style on change notes history

### DIFF
--- a/app/assets/stylesheets/govuk-component/_document-footer.scss
+++ b/app/assets/stylesheets/govuk-component/_document-footer.scss
@@ -1,6 +1,10 @@
 .govuk-document-footer {
   @include core-16;
 
+  ol {
+    list-style: none;
+  }
+
   p, ol {
     margin-bottom: $gutter-one-third;
 


### PR DESCRIPTION
According to the docs, change note history shouldn't have a list style. This commit adds the declaration to the stylesheet.
