### PR TITLE
Add RTL display option on metadata component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -2,6 +2,11 @@
   @include core-14;
   @extend %contain-floats;
 
+  &.direction-rtl {
+    direction: rtl;
+    text-align: start;
+  }
+
   dt {
     float: left;
     clear: left;
@@ -12,6 +17,15 @@
       padding-right: $gutter-one-third;
     }
   }
+  &.direction-rtl dt {
+    float: right;
+    clear: right;
+    @include media(tablet){
+      padding-left: $gutter-one-third;
+      padding-right: 0;
+    }
+  }
+
   dd {
     float: left;
     width: 55%;
@@ -19,5 +33,8 @@
     @include media(tablet){
       width: 70%;
     }
+  }
+  &.direction-rtl dd {
+    float: right;
   }
 }

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -28,6 +28,11 @@
           - "<a href='/government/topics/arts-and-culture'>Arts and culture</a>"
           - "<a href='/government/topics/sports-and-leisure'>Sports and leisure</a>"
         "Applies to": "England"
+    basic_rtl:
+      direction: "rtl"
+      from: "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>"
+      history: "Updated 2 weeks ago"
+      part_of: "<a href='/government/topics/environment'>Environment</a>"
 - id: "govspeak"
   name: "Govspeak content"
   description: "To display long form text which has been converted from markdown"

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -6,8 +6,11 @@
   part_of = Array(part_of)
 
   other ||= nil
+
+  direction_class = ""
+  direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
-<div class="govuk-metadata">
+<div class="govuk-metadata<%= direction_class %>">
   <dl>
     <% if from.any? %>
       <dt>From:</dt>


### PR DESCRIPTION
Add an option to the metadata component to display in RTL for languages
which use RTL text such as Arabic.

This would look like this in the guide:

![screen shot 2014-12-01 at 13 52 52](https://cloud.githubusercontent.com/assets/35035/5246485/742f0e88-7961-11e4-984e-6824f446e145.png)
