### PR TITLE
Make document footer component handle rtl content

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk_frontend_toolkit', '2.0.1'
+gem 'govuk_frontend_toolkit', '3.1.0'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (2.0.1)
+    govuk_frontend_toolkit (3.1.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.10.1)
@@ -172,7 +172,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 7.18.0)
-  govuk_frontend_toolkit (= 2.0.1)
+  govuk_frontend_toolkit (= 3.1.0)
   govuk_template (= 0.10.1)
   image_optim (= 0.17.1)
   jasmine (= 2.0.2)

--- a/app/assets/stylesheets/govuk-component/_document-footer.scss
+++ b/app/assets/stylesheets/govuk-component/_document-footer.scss
@@ -2,11 +2,22 @@
   @extend %grid-row;
   @include core-16;
 
+  &.direction-rtl {
+    direction: rtl;
+    text-align: start;
+  }
+
   .history-information {
     @include grid-column( 1 / 3 );
   }
+  &.direction-rtl .history-information {
+    @include grid-column( 1 / 3, $float: right );
+  }
   .related-information {
     @include grid-column( 2 / 3 );
+  }
+  &.direction-rtl .related-information {
+    @include grid-column( 2 / 3, $float: right );
   }
 
   p, ol {

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -225,3 +225,8 @@
       part_of:
         - "<a href='/government/topics/energy'>Energy</a>"
         - "<a href='/government/topics/environment'>Environment</a>"
+    basic_rtl:
+      direction: "rtl"
+      published: '20 January 2012'
+      from: "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"
+      part_of: "<a href='/government/topics/energy'>Energy</a>"

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -11,8 +11,11 @@
   other ||= nil
 
   other_dates ||= nil
+
+  direction_class = ""
+  direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
-<div class="govuk-document-footer grid-row">
+<div class="govuk-document-footer<%= direction_class %>">
   <h2 class="visuallyhidden">Document information</h2>
   <div class="history-information">
     <p>Published: <span class="published"><%= published %></span></p>


### PR DESCRIPTION
For RTL content change the text direction and swap the floats so the
reading edge is the other side of the page. There will be a future bit
of work for adding translations to the strings in the component.

This is dependant on [this enhancement](https://github.com/alphagov/govuk_frontend_toolkit/pull/151) making it into the 
govuk_frontend_toolkit. It will need to be amend to use that once it is
available.
