### PR TITLE
Allow for other metadata and dates in Footer

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -187,6 +187,18 @@
       part_of:
         - "<a href='/government/topics/energy'>Energy</a>"
         - "<a href='/government/topics/environment'>Environment</a>"
+    with_other_metadata:
+      published: "20 January 2012"
+      from:
+        - "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"
+        - "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>"
+      other:
+        "Consultation type": "<a href='/government/publications'>Open</a>"
+    with_other_dates:
+      published: "20 January 2012"
+      other_dates:
+        "Date opened": "1 February 2012"
+        "Date closed": "1 March 2013"
     updated:
       published: '20 January 2012'
       updated: '24 January 2012'

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -7,6 +7,10 @@
 
   history ||= []
   history = Array(history)
+
+  other ||= nil
+
+  other_dates ||= nil
 %>
 <div class="govuk-document-footer grid-row">
   <h2 class="visuallyhidden">Document information</h2>
@@ -14,6 +18,11 @@
     <p>Published: <span class="published"><%= published %></span></p>
     <% if local_assigns.include?(:updated) && updated %>
       <p>Updated: <span class="updated"><%= updated %></span></p>
+    <% end %>
+    <% if other_dates.present? %>
+      <% other_dates.each do |title, date| %>
+        <p><%= title %>: <span class="other-date"><%= date %></span></p>
+      <% end %>
     <% end %>
     <% if history.any? %>
       <div class="change-notes" id="history">
@@ -35,6 +44,12 @@
     <% end %>
     <% if part_of.any? %>
       <p>Part of: <span class="part-of"><%= part_of.join(' ').html_safe %></span></p>
+    <% end %>
+    <% if other.present? %>
+      <% other.each do |title, definition| %>
+        <% definition = Array(definition) %>
+        <p><%= title %>: <span class="other"><%= definition.join(' ').html_safe %></span></p>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
With the document footer, we want the ability to pass in other parts of metadata to the Footer. This commit takes the same approach as the metadata blocks - you pass in an other (or other dates) hash and it presents it in the same way.

Screenshot:
![screen shot 2014-12-02 at 11 08 08](https://cloud.githubusercontent.com/assets/449004/5261620/8693a252-7a13-11e4-8688-fb4ba8648883.png)
