### PR TITLE
Increase font size in tables for legibility

### DIFF
--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -215,16 +215,6 @@ article td {
   }
 }
 
-/* reduce table font size on very small screens */
-@media screen and (max-width: 320px) {
-  article th, article td {
-    @include core-14($tabular-numbers: true);
-  }
-  article td small {
-    font-size: 12px;
-  }
-}
-
 article th {
   line-height: 1.25em;
   text-align: left;


### PR DESCRIPTION
_NB:_ Needs review from designers (hello @antimega)
- Introduces NTA Tabular Numbers as the primary font-face for `<th>` and `<td>`
- Increases font size to core-16
- Mobile view is core-16 with NTA Tabular Numbers
  - Will reduce down to 14px, there may be edge cases where this is 'too big', though it appears that there is a significant amount of application layer css addressing this for specific pages e.g. https://www.gov.uk/vehicle-tax-rate-tables

![](http://cl.ly/image/0K2g0I2A2a07/Screen%20Shot%202014-12-03%20at%2010.21.02.png)

![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)![](http://cl.ly/image/063x2q2w2t37/Screen%20Shot%202014-12-03%20at%2010.29.47.png)

![](http://cl.ly/image/0I2t1v0l3K0S/Screen%20Shot%202014-12-03%20at%2010.26.35.png)
