### PR TITLE
Add Universal Analytics snippet

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -32,3 +32,13 @@
     var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
   })();
 </script>
+
+<%# Universal analytics %>
+<script id="ga-ua-params" type="text/javascript">
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+      (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                           m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+  ga('create', 'UA-26179049-7', {'cookieDomain': '.www.gov.uk'});
+  ga('send', 'pageview');
+</script>


### PR DESCRIPTION
In order to migrate to Universal Analytics we need to run the old and new code side by side for a while. Add the snippet and UA bootstrap code.

**Note**: there's no attempt to port any of our custom event code etc. in this PR - that's scheduled for later once we're sure that data is being collected.
