### PR TITLE
Fix typo in the component metadata docs: 'relvent' -> 'relevant'

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -7,7 +7,7 @@
       message: "This is an optional different message to explain what Beta means in this context which can take <a href='https://www.gov.uk'>HTML</a>"
 - id: "metadata"
   name: "Metadata block"
-  description: "To display relvent metadata about organisations and tags for a document"
+  description: "To display relevant metadata about organisations and tags for a document"
   fixtures:
     from_only:
       from: "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"


### PR DESCRIPTION
- I was just reading https://gdstechnology.blog.gov.uk/2014/12/11/govuk-living-style-guide/ and came across http://govuk-component-guide.herokuapp.com/component/metadata with this typo.
