### PR TITLE
Fix some typos in the component documentation

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -7,7 +7,7 @@
       message: "This is an optional different message to explain what Beta means in this context which can take <a href='https://www.gov.uk'>HTML</a>"
 - id: "metadata"
   name: "Metadata block"
-  description: "To display relvent metadata about organisations and tags for a document"
+  description: "To display relevant metadata about organisations and tags for a document"
   fixtures:
     from_only:
       from: "<a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>"
@@ -183,8 +183,8 @@
     where the average is around 30 characters or less. Long titles would have
     an average length of nearer 50 characters or more.
 
-    On average the titles on government bits of content are 50 charectors. The
-    average for bits of general guidance are nearer 27 charectors long.
+    On average the titles on government bits of content are 50 characters. The
+    average for bits of general guidance are nearer 27 characters long.
   fixtures:
     default:
       title: "My page title"


### PR DESCRIPTION
These are just some spelling error typos, but were distracting when reading the documentation.
