### PR TITLE
Format non-link footer metadata like links

### DIFF
--- a/app/assets/stylesheets/govuk-component/_document-footer.scss
+++ b/app/assets/stylesheets/govuk-component/_document-footer.scss
@@ -30,12 +30,14 @@
     }
   }
 
-  .history-information span,
-  .related-information a {
-    display: block;
+
+  .definition {
     @include bold-24;
     margin-top: 5px;
-    text-decoration: none;
+    display: block;
+    a {
+      text-decoration: none;
+    }
   }
 
   .change-notes {

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -19,14 +19,14 @@
   <h2 class="visuallyhidden">Document information</h2>
   <div class="history-information">
     <% if local_assigns.include?(:published) && published %>
-      <p>Published: <span class="published"><%= published %></span></p>
+      <p>Published: <span class="published definition"><%= published %></span></p>
     <% end %>
     <% if local_assigns.include?(:updated) && updated %>
-      <p>Updated: <span class="updated"><%= updated %></span></p>
+      <p>Updated: <span class="updated definition"><%= updated %></span></p>
     <% end %>
     <% if other_dates.present? %>
       <% other_dates.each do |title, date| %>
-        <p><%= title %>: <span class="other-date"><%= date %></span></p>
+        <p><%= title %>: <span class="other-date definition"><%= date %></span></p>
       <% end %>
     <% end %>
     <% if history.any? %>
@@ -45,15 +45,33 @@
   </div>
   <div class="related-information">
     <% if from.any? %>
-    <p>From: <span class="from"><%= from.join(' ').html_safe %></span></p>
+      <p>From: <span class="from">
+        <% from.each do |definition| %>
+          <span class="definition">
+            <%= definition.html_safe %>
+          </span>
+        <% end %>
+      </p>
     <% end %>
     <% if part_of.any? %>
-      <p>Part of: <span class="part-of"><%= part_of.join(' ').html_safe %></span></p>
+      <p>Part of: <span class="part-of">
+        <% part_of.each do |definition| %>
+        <span class="definition">
+          <%= definition.html_safe %>
+        </span>
+        <% end %>
+      </p>
     <% end %>
     <% if other.present? %>
-      <% other.each do |title, definition| %>
-        <% definition = Array(definition) %>
-        <p><%= title %>: <span class="other"><%= definition.join(' ').html_safe %></span></p>
+      <% other.each do |title, definitions| %>
+        <% definitions = Array(definitions) %>
+        <p><%= title %>: <span class="other">
+          <% definitions.each do |definition| %>
+            <span class="definition">
+              <%= definition.html_safe %>
+            </span>
+          <% end %>
+        </span></p>
       <% end %>
     <% end %>
   </div>


### PR DESCRIPTION
With certain document formats, we want to show metadata that doesn't link anywhere. This commit changes the specificity of the selector to target spans and moves the text decoration: none to just act on `<a>` tags.

Before:
![screen shot 2014-12-17 at 16 11 55](https://cloud.githubusercontent.com/assets/449004/5474199/78b754ee-8607-11e4-8589-1875ba179836.png)

After:
![screen shot 2014-12-17 at 16 11 50](https://cloud.githubusercontent.com/assets/449004/5474203/7ca59444-8607-11e4-82ff-efe44290c66f.png)
