### PR TITLE
Add example for non link metadata in footer

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -3,7 +3,7 @@
   description: "A banner than indicates content is in a beta phase with an optional explanation"
   fixtures:
     default: {}
-    message: 
+    with_message:
       message: "This is an optional different message to explain what Beta means in this context which can take <a href='https://www.gov.uk'>HTML</a>"
 - id: "metadata"
   name: "Metadata block"
@@ -221,6 +221,10 @@
       other_dates:
         "Date opened": "1 February 2012"
         "Date closed": "1 March 2013"
+    non_link_metadata_only:
+      other:
+        "Registration number": '01234'
+        "Another thing": 'This other thing'
     updated:
       published: '20 January 2012'
       updated: '24 January 2012'
@@ -247,6 +251,9 @@
       part_of:
         - "<a href='/government/topics/energy'>Energy</a>"
         - "<a href='/government/topics/environment'>Environment</a>"
+      other:
+        "Registration number": '01234'
+        "Another thing": 'This other thing'
     basic_rtl:
       direction: "rtl"
       published: '20 January 2012'


### PR DESCRIPTION
With the change in 00c26ed we should show what non link metadata in the document footer looks like. This commit adds an example in the docs. Screenshots:

![screen shot 2014-12-19 at 11 15 26](https://cloud.githubusercontent.com/assets/449004/5503567/6544df84-8770-11e4-8d20-cfdd7b6bea71.png)
![screen shot 2014-12-19 at 11 15 19](https://cloud.githubusercontent.com/assets/449004/5503569/67ba7a80-8770-11e4-9b04-3ed0e2be82be.png)
