### PR TITLE
Adds error tracking through analytics to static

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -4,3 +4,4 @@
 //= require analytics/print-tracking
 //= require analytics/print-intent
 //= require analytics/scroll-tracker
+//= require analytics/error-tracking

--- a/app/assets/javascripts/analytics/error-tracking.js
+++ b/app/assets/javascripts/analytics/error-tracking.js
@@ -1,0 +1,24 @@
+// Extension to track errors using google analytics as a data store.
+(function() {
+
+    "use strict";
+    var trackJavaScriptError = function (e) {
+      var errorSource = e.filename + ': ' + e.lineno;
+      _gaq.push([
+        '_trackEvent',
+        'JavaScript Error',
+        e.message,
+        errorSource,
+        true //nonInteractive so bounce rate isn't affected
+      ]);
+    };
+
+    if (window.addEventListener) {
+      window.addEventListener('error', trackJavaScriptError, false);
+    } else if (window.attachEvent) {
+      window.attachEvent('onerror', trackJavaScriptError);
+    } else {
+      window.onerror = trackJavaScriptError;
+    }
+
+}());

--- a/app/assets/javascripts/analytics/error-tracking.js
+++ b/app/assets/javascripts/analytics/error-tracking.js
@@ -9,7 +9,8 @@
         'JavaScript Error',
         e.message,
         errorSource,
-        true //nonInteractive so bounce rate isn't affected
+        1, // Set our value to 1, though we could look to tally session errors here
+        true // nonInteractive so bounce rate isn't affected
       ]);
     };
 

--- a/app/assets/javascripts/analytics/error-tracking.js
+++ b/app/assets/javascripts/analytics/error-tracking.js
@@ -1,25 +1,25 @@
 // Extension to track errors using google analytics as a data store.
 (function() {
 
-    "use strict";
-    var trackJavaScriptError = function (e) {
-      var errorSource = e.filename + ': ' + e.lineno;
-      _gaq.push([
-        '_trackEvent',
-        'JavaScript Error',
-        e.message,
-        errorSource,
-        1, // Set our value to 1, though we could look to tally session errors here
-        true // nonInteractive so bounce rate isn't affected
-      ]);
-    };
+  "use strict";
+  var trackJavaScriptError = function (e) {
+    var errorSource = e.filename + ': ' + e.lineno;
+    _gaq.push([
+      '_trackEvent',
+      'JavaScript Error',
+      e.message,
+      errorSource,
+      1, // Set our value to 1, though we could look to tally session errors here
+      true // nonInteractive so bounce rate isn't affected
+    ]);
+  };
 
-    if (window.addEventListener) {
-      window.addEventListener('error', trackJavaScriptError, false);
-    } else if (window.attachEvent) {
-      window.attachEvent('onerror', trackJavaScriptError);
-    } else {
-      window.onerror = trackJavaScriptError;
-    }
+  if (window.addEventListener) {
+    window.addEventListener('error', trackJavaScriptError, false);
+  } else if (window.attachEvent) {
+    window.attachEvent('onerror', trackJavaScriptError);
+  } else {
+    window.onerror = trackJavaScriptError;
+  }
 
 }());


### PR DESCRIPTION
- We don't track frontend javascript errors at all at the moment, this should be remedied quickly.
- There are about a thousand ways to slice this issue, and there are lots of factors that complicate the way we deliver tracking (do we run our own error server? do we pay for a service? What about ajax events?) but a quick bootstrap solution would be to use google analytics, as we are already using it to track non-error events.
- Not sure what support < ie8 is like for error events, happy to take some advice here
