### PR TITLE
Fix references to a search box "below"

### DIFF
--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "four_hundred_error", locals: {
     title: "Page not found - 406",
     heading: "The page you are looking for can't be found",
-    intro: '<p>Please check that you have entered the correct web address, or try using the search box below or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
+    intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
 } %>

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -2,5 +2,5 @@
     title: "Page no longer here - 410",
     heading: "The page you are looking for is no longer here",
     intro: '<p>It may have been moved or replaced.</p>
-      <p>Please check that you have entered the correct web address, or try using the search box below or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
+      <p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
 } %>


### PR DESCRIPTION
The only search box on these pages is (now) above.