### PR TITLE
Add an example of many long footer metadata items

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -254,6 +254,11 @@
       other:
         "Registration number": '01234'
         "Another thing": 'This other thing'
+    many_items_and_long:
+     part_of:
+        - "<a href='#'>Buying and managing government goods and services more efficiently and effectively</a>"
+        - "<a href='#'>Promoting social action: encouraging and enabling people to play a more active part in society</a>"
+        - "<a href='#'>Improving the transparency and accountability of government and its services</a>"
     basic_rtl:
       direction: "rtl"
       published: '20 January 2012'


### PR DESCRIPTION
Follow up to https://github.com/alphagov/static/pull/488, adding a more complex/problematic example.

This was originally reported in https://github.com/alphagov/whitehall/issues/1839

It's a pretty reasonable example of content that requires more design
handling than some of the simpler examples here.

Longer term we'll start separating out demonstrative examples from
what are, effectivetely, visual regression examples. But in the mean
time we should continue capturing them

![screenshot 2015-01-08 16 53 09](https://cloud.githubusercontent.com/assets/63201/5666353/ddee0690-9756-11e4-85f7-589f80bb5e14.png)
