### PR TITLE
Make content and related float rather than using absolute positioning

### DIFF
--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -48,7 +48,6 @@ h4 {
 
 /*
  * Related box
- * this related stuff needs re-examining - might be a bit over the top
  */
 .related-container {
   @include grid-column(1/3, $full-width: desktop);

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -278,10 +278,10 @@ article {
 }
 
 .article-container.group .beta-label {
-  margin: 0 0 20px 30px;
+  margin: 0 0 20px;
 
   @include media(mobile) {
-      margin: 0 0 10px 15px;
+      margin: 0 0 10px;
     }
 }
 

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -8,33 +8,16 @@ body {
 }
 
 #wrapper {
-  background-color: $white;
-  @include ie-lte(7) {
-    zoom: 1;
+  @extend %site-width-container;
+}
+.grid-row {
+  @extend %grid-row;
+
+  main#content {
+    @include grid-column( 2/3, $full-width: desktop );
   }
 }
 
-.inner {
-  margin: 0 auto;
-  padding: 1em;
-  position: relative;
-}
-
-main#content,
-section#content {
-  margin: 0 auto;
-  max-width: 1020px;
-  position: relative;
-  display:block;
-
-  @include ie-lte(7) {
-    width: 960px;
-  }
-
-  @include media-down(mobile) {
-    max-width: auto;
-  }
-}
 
 p {
   @include core-19;
@@ -67,85 +50,13 @@ h4 {
  * Related box
  * this related stuff needs re-examining - might be a bit over the top
  */
-.related-positioning {
-  height: 0;
-  left: 0;
-  position: absolute;
-  top: 9.5em;
-  width: 100%;
-  z-index: 0;
-
-  @include ie-lte(8) {
-    z-index: 0;
-  }
-
-  @include ie-lte(7) {
-    position: absolute !important;
-  }
-
-  @include media-down(tablet) {
-    position: static;
-    top: auto;
-    height: auto;
-  }
-}
-
-.js-enabled .related-positioning {
-  top: 7em;
-}
-
-.beta .related-positioning {
-  top: 12em;
-}
-
-.js-enabled .related-with-cookie,
-.js-enabled .related-beta {
-  top: 9.5em;
-}
-
 .related-container {
-  position: relative;
-  height: 0;
-  margin: 0 auto;
-  max-width: 1020px;
-  z-index: 50;
-
-  @include ie-lte(8) {
-    width: 960px;
-  }
-
-  @include media-down(tablet) {
-    max-width: auto;
-    height: auto;
-  }
+  @include grid-column(1/3, $full-width: desktop);
+  margin-top: 40px;
 }
-
 .related {
-  position: absolute;
-  right: 1.75em;
-  margin: 3em 0 0 0;
-  width: 18.75em;
   border-top: 10px solid $mainstream-brand;
-
-  @include media-down(tablet) {
-    position: static;
-    right: auto;
-    width: auto;
-  }
-
-  .inner {
-    background-color: $white;
-    padding: 0.5em 1em 0 0;
-    width: auto;
-
-    @include media-down(tablet) {
-      padding-left: 2em;
-    }
-
-    @include media-down(mobile) {
-      padding-left: 1em;
-    }
-  }
+  padding-top: 5px;
 
   nav {
     margin-bottom: 1.25em;
@@ -224,17 +135,14 @@ h4 {
     }
 
   }
-
   .return-to-top {
     @include core-16;
-    margin-bottom: 0.5em;
-    position: absolute;
-    left: -9999em;
+    margin: 0.25em 0 0;
+    padding: 0.75em 0;
 
-    @include media-down(mobile) {
-      position: static;
-      margin: 0.25em 0 0;
-      padding: 0.75em 0;
+    @include media(desktop){
+      position: absolute;
+      left: -9999em;
     }
   }
 }
@@ -243,38 +151,27 @@ h4 {
  * Page headers
  */
 
-header.page-header {
-    div {
-      background-color: #fff;
+header.page-header div {
+  @include media(tablet){
+    margin-top: 30px;
+    margin-bottom: 30px;
+  }
+
+  h1 {
+    @include heading-48;
+    background-repeat: no-repeat;
+    color: $text-colour;
+    font-weight: 600;
+
+    span {
+      @include core-27($line-height: 1);
       display: block;
-      margin: 0;
-      padding:0;
+      margin-bottom: 0.25em;
+      text-shadow: none;
+      color: $secondary-text-colour ;
 
-      @include media(tablet) {
-        padding: 2em 2em 2em 2em;
-        margin: 0;
-      }
-
-      @include media(desktop) {
-        margin: 0 24em 0 0;
-      }
-
-      h1 {
-        @include heading-48;
-        background-repeat: no-repeat;
-        color: $text-colour;
-        font-weight: 600;
-
-        span {
-          @include core-27($line-height: 1);
-          display: block;
-          margin-bottom: 0.25em;
-          text-shadow: none;
-          color: $secondary-text-colour ;
-
-        @include ie-lte(8) {
-          height: 1%;
-        }
+      @include ie-lte(8) {
+        height: 1%;
       }
     }
   }
@@ -298,62 +195,6 @@ body.full-width {
   }
 }
 
-#wrapper.service header.page-header div,
-#wrapper.licence header.page-header div,
-#wrapper.video header.page-header div,
-#wrapper.answer header.page-header div,
-#wrapper.guide header.page-header div {
-  padding-left: 2em;
-
-  h1 {
-    margin-left: 0;
-
-    @include ie(6) {
-      position: relative;
-      z-index: 1;
-      zoom: 1;
-    }
-
-  }
-
-  @include media-down(mobile) {
-    padding-left: 1em;
-    padding-right: 1em;
-  }
-}
-
-#wrapper.programme header.page-header div,
-#wrapper.service header.page-header div {
-
-
-  @include media-down(mobile) {
-    padding-left: 1em;
-  }
-}
-
-#wrapper.programme header.page-header div,
-#wrapper.service header.page-header div,
-#wrapper.licence header.page-header div,
-#wrapper.video header.page-header div {
-  @include media($min-width: 1182px) {
-    padding-left: 0;
-
-    h1 {
-      padding-left: 32px;
-    }
-  }
-}
-
-#wrapper.answer header.page-header div,
-#wrapper.guide header.page-header div {
-  @include media($min-width: 1132px) {
-    padding-left: 0;
-
-    h1 {
-      padding-left: 32px;
-    }
-  }
-}
 
 /* Business support format */
 .business_support article.tab-pane {
@@ -427,54 +268,6 @@ article {
       height: auto;
     }
   }
-
-  .inner {
-    padding: 0 0 2em 2em;
-    width: auto;
-  }
-
-  @include media-down(tablet) {
-    min-height: 0;
-
-    .inner {
-      padding: 0 2em 1em 2em;
-    }
-  }
-
-  @include media-down(mobile) {
-    .inner {
-      padding: 0 1em 1em 1em;
-    }
-  }
-}
-
-#wrapper.answer,
-#wrapper.transaction,
-#wrapper.local_transaction{
-  article{
-    .inner{
-      padding-right:10em;
-      padding-right:0;
-
-      @include media-down(mobile) {
-        padding-right: 1em;
-      }
-    }
-  }
-}
-
-#wrapper.guide,
-#wrapper.programme{
-  article{
-    .inner{
-      padding-right:3em;
-      padding-right:0;
-
-      @include media-down(mobile) {
-        padding-right: 1em;
-      }
-    }
-  }
 }
 
 #wrapper.travel-advice p img {
@@ -488,11 +281,6 @@ article {
 }
 
 .article-container {
-  background-color: #fff;
-  margin-right: 22.25em;
-  min-height: 35em;
-  max-width: 38em;
-
   /* Make webkit browsers contain the margin-bottom of report-a-problem */
   .travel-advice & {
     padding-bottom: 0.01em;
@@ -520,12 +308,6 @@ article {
 .meta-data {
   @include core-16;
   color: $secondary-text-colour;
-  margin-left: 2em;
-  background-color:transparent;
-
-  .inner {
-    padding: 0 2em 0 0;
-  }
 
   @include ie-lte(7) {
     width: 60%;
@@ -546,22 +328,6 @@ article {
       color: $secondary-text-colour;
     }
     @include core-16
-  }
-
-  @include media-down(mobile) {
-    margin-left: 1em;
-
-    .inner {
-      padding: 0 1em;
-    }
-
-    p {
-      margin-top: 0;
-
-      &.print-link a {
-        padding-left: 0;
-      }
-    }
   }
 }
 
@@ -587,12 +353,6 @@ article {
     a, a:link, a:visited {
       padding-bottom:4px;
     }
-  }
-}
-
-.modified-date {
-  @include media-down(mobile) {
-    width:40%;
   }
 }
 

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -62,23 +62,6 @@ h4 {
   margin-bottom: 0.25em;
 }
 
-/*
- * Locate me styles
- */
-
-#global-locator-form {
-  label,
-  .ask_location {
-    display: inline;
-
-    &.hidden { display: none; }
-  }
-
-  .found_location p,
-  .finding_location p {
-    margin: 0em;
-  }
-}
 
 /*
  * Related box

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -240,44 +240,6 @@ h4 {
 }
 
 /*
- * Legacy sources thang
- */
-
-#legacy-sources {
-  margin-top: 1em;
-  display: none;
-
-  @include media-down(tablet) {
-    margin: 1em 2em 0em;
-  }
-
-  @include media-down(mobile) {
-    margin-left: 1em;
-    margin-right: 1em;
-  }
-
-  p {
-	  font-size: 1em;
-    margin-bottom: 0;
-	  padding: 0;
-	  color: black;
-  }
-
-  ul {
-	  margin: 0;
-	  padding: 0;
-	  overflow:hidden;
-  }
-
-  li {
-    text-indent: -5000px;
-    float: left;
-    background-repeat: no-repeat;
-    display: none;
-  }
-}
-
-/*
  * Page headers
  */
 

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -177,25 +177,6 @@ header.page-header div {
   }
 }
 
-body.full-width {
-  header.page-header div,
-  .article-container,
-  article {
-    margin-right: 0;
-  }
-
-  header.page-header div {
-    padding-left: 30px;
-    padding-right: 30px;
-
-    @include media(mobile) {
-      padding-left: 15px;
-      padding-right: 15px;
-    }
-  }
-}
-
-
 /* Business support format */
 .business_support article.tab-pane {
   width: auto;

--- a/app/assets/stylesheets/helpers/_multi-step.scss
+++ b/app/assets/stylesheets/helpers/_multi-step.scss
@@ -50,7 +50,7 @@
 .upcoming-questions ol {
   background-color: #fff;
   margin: 0;
-  padding: 0 0 0 1em;
+  padding: 0;
   position: relative;
   z-index: 1;
 
@@ -148,7 +148,7 @@ li.done:hover .undo a {
 .step.current {
   background-color: #fff;
   margin-right: 15em;
-  padding: 0 10em 1em 2em;
+  padding: 0 10em 1em 0;
   position: relative;
 
   @include media-down(tablet) {

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -29,15 +29,11 @@
     overflow: hidden;
 
     @include media(tablet) {
-      margin: 0 0 2.5em 2em;
+      margin: 0 0 2.5em;
     }
 
     @include ie(6) {
       zoom: 1;
-    }
-
-    .inner {
-      padding: 0;
     }
 
     @include media-down(mobile) {
@@ -59,15 +55,6 @@
   header div {
     padding-bottom: 1em;
   }
-
-  article {
-    margin: 0;
-
-    .inner {
-      margin-left: 0;
-      padding: 0 10em 0 2em;
-    }
-  }
 }
 
 .video-guide {
@@ -88,13 +75,6 @@
   width: 100%;
 }
 
-.multi-page article .inner {
-  padding: 0 2em 0 2em;
-
-  @include media-down(mobile) {
-    padding: 0 1em 1em;
-  }
-}
 .licence article .inner {
   padding-top: 0;
 }

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -424,12 +424,12 @@ aside .page-navigation-closed {
   background-color: $panel-colour;
   min-height: 2em;
   line-height: 2;
-  margin: 2em -1em 0 -1em;
+  margin: 2em 0;
   padding: 1em 0.75em 1em 1em;
   position: relative;
 
   @include media-down(mobile) {
-    margin: 1.2em -1em;
+    margin: 1.2em 0;
     padding-left: 1em;
     padding-right: 1em;
     .postcode {

--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -8,8 +8,6 @@
   margin-bottom: 60px;
 
   .report-a-problem-inner {
-    @include inner-block;
-
     .report-a-problem-content {
       max-width: 35em;
     }
@@ -82,8 +80,4 @@
   @include outer-block;
   margin-bottom: 30px;
   clear:both;
-
-  .report-a-problem-toggle {
-    @include inner-block;
-  }
 }

--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -314,9 +314,8 @@ article .advisory {
 }
 
 article .intro {
-  background-color: transparent;
-  margin: 0 -1em 1.5em -1em;
-  padding: 1em 1em 1em 1em;
+  margin-bottom: 1.5em;
+  padding-bottom: 1em;
 
   p:first-child {
     margin-top: 0;

--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -176,7 +176,7 @@ article table {
   border-collapse: collapse;
   border-spacing: 0;
   margin: 1em 0 2em;
-  width: 105.95%;
+  width: 100%;
 
   caption {
     @include bold-24;

--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -1,8 +1,6 @@
 <%# Whilst they are both in use, this and the test copy in slimmer should be kept in sync %>
 <% if artefact and (artefact.related_artefacts.any? or (artefact.related_external_links and artefact.related_external_links.any?)) %>
-
-<!-- related -->
-<div class="related-positioning">
+  <!-- related -->
   <div class="related-container">
 
     <div class="related" id="related">
@@ -58,6 +56,5 @@
     </div>
 
   </div>
-</div>
 <!-- end related -->
 <% end %>


### PR DESCRIPTION
Originally the related sidebar was designed to scroll with the page. This was removed quite some time ago but the code was all left so that it would still be possible to re-enable it.

This cleans that up and removes the position absolute elements. It also uses the new grid-layout mixins to layout the `<main>` and `<div class="related">` elements.

I would like to get feedback on this approach and probably take over preview with this change for a bit before we merge as it is quite a large change to most pages on GOV.UK.

----

Dev review:

- [x] [smart answers](https://github.com/alphagov/smart-answers/issues/1404)
- [x] [frontend](https://github.com/alphagov/frontend/issues/729)
- [x] [calendars](https://github.com/alphagov/calendars/issues/79)
- [x] [calculators](https://github.com/alphagov/calculators/issues/107)
- [x] [licence-finder](https://github.com/alphagov/licence-finder/issues/55)
- [x] [business-support-finder](https://github.com/alphagov/business-support-finder/issues/72)
- [x] [contacts-frontend](https://github.com/alphagov/contacts-frontend/issues/21)