### PR TITLE
Send HTTP status codes back to Google Analytics.

### DIFF
--- a/app/views/root/400.html.erb
+++ b/app/views/root/400.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "error_page", locals: {
     title: "Bad request - 400",
     heading: "Bad request",
-    intro: ''
+    intro: '',
+    status_code: 400
 } %>

--- a/app/views/root/404.html.erb
+++ b/app/views/root/404.html.erb
@@ -3,5 +3,6 @@
     heading: "Page not found",
     intro: '<p>If you entered a web address please check it was correct.</p>
 
-            <p>You can also <a href="/search">search GOV.UK</a> or <a href="/">browse from the homepage</a> to find the information you need.</p>'
+            <p>You can also <a href="/search">search GOV.UK</a> or <a href="/">browse from the homepage</a> to find the information you need.</p>',
+    status_code: 404
 } %>

--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "error_page", locals: {
     title: "Page not found - 406",
     heading: "The page you are looking for can't be found",
-    intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
+    intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>',
+    status_code: 406
 } %>

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -2,5 +2,6 @@
     title: "Page no longer here - 410",
     heading: "The page you are looking for is no longer here",
     intro: '<p>It may have been moved or replaced.</p>
-      <p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>'
+      <p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>',
+    status_code: 410
 } %>

--- a/app/views/root/418.html.erb
+++ b/app/views/root/418.html.erb
@@ -1,5 +1,6 @@
 <%= render partial: "error_page", locals: {
     title: "This is a government website - 418",
     heading: "I am not a coffee pot",
-    intro: "<p>I am a government website.</p>"
+    intro: "<p>I am a government website.</p>",
+    status_code: 418
 } %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -26,6 +26,12 @@
       </div>
     </article>
   </div>
+
+<% if status_code %>
+  <script type="text/javascript">
+    window.httpStatusCode = '<%= status_code %>';
+  </script>
+<% end %>
 </main>
 <% end %>
 

--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -14,6 +14,10 @@
   if (window.devicePixelRatio) {
     _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
   }
+  // Track status code for failed responses
+  if (window.httpStatusCode) {
+    _gaq.push(['_setCustomVar', 15, 'httpStatusCode', String(window.httpStatusCode), 3 ]);
+  }
   // Search result placement tracking, set custom var and destroy the cookie
   if(GOVUK.cookie && GOVUK.cookie('ga_nextpage_params') !== null){
     var customVar = GOVUK.cookie('ga_nextpage_params').split(',');


### PR DESCRIPTION
For 4xx or 5xx responses, send the HTTP status code as a custom variable
to Google Analytics. This will be useful both for the /info pages
application and for search analytics.

Explicitly add status codes as local variable in 4xx responses, since
they weren't recorded before.