### PR TITLE
Use SelectionButtons live selector, for JS/AJAX content

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -36,8 +36,8 @@ $(document).ready(function() {
   }
 
   // for radio buttons and checkboxes
-  var $buttons = $("label.selectable input[type='radio'], label.selectable input[type='checkbox']");
-  new GOVUK.SelectionButtons($buttons);
+  var buttonsSelector = "label.selectable input[type='radio'], label.selectable input[type='checkbox']";
+  new GOVUK.SelectionButtons(buttonsSelector);
 });
 
 


### PR DESCRIPTION
Some GOV.UK pages, like Smart Answers, load content via JS, including
radio buttons or checkboxes. These will be added to the DOM after the
selector is run and the resulting elements are passed to SelectionButtons

SelectionButtons can also take a string selector and use document
events (https://github.com/alphagov/govuk_frontend_toolkit/pull/139/)
so use that and any JS loaded content  will get the behaviour too.

@robmckinnon spotted this in https://github.com/alphagov/smart-answers/pull/1419, but it's better to fix it in the app we're applying it (otherwise we'll run into versioning problems eventually) 