### PR TITLE
Remove the 418 error page

### DIFF
--- a/app/views/root/418.html.erb
+++ b/app/views/root/418.html.erb
@@ -1,6 +1,0 @@
-<%= render partial: "error_page", locals: {
-    title: "This is a government website - 418",
-    heading: "I am not a coffee pot",
-    intro: "<p>I am a government website.</p>",
-    status_code: 418
-} %>


### PR DESCRIPTION
As I understand it, this was only ever intended for use while migrating content from Directgov and Business Link to GOV.UK: Redirector used this to indicate "content will be here by launch". We've now launched, [Bouncer](https://github.com/alphagov/bouncer) has replaced Redirector (and no longer supports the 418 status code), and our logs show nothing has served a 418 response in at least the last month.

A 418 code is only correct for Web servers that are teapots, in line with [RFC 2324](http://tools.ietf.org/html/rfc2324#section-2.3.2). I am confident GOV.UK has not been a teapot at any point since launch.