### PR TITLE
Pass default value to GA httpStatusCode variable.

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -14,10 +14,12 @@
   if (window.devicePixelRatio) {
     _gaq.push(['_setCustomVar', 11, 'Pixel Ratio', String(window.devicePixelRatio), 2 ]);
   }
-  // Track status code for failed responses
-  if (window.httpStatusCode) {
-    _gaq.push(['_setCustomVar', 15, 'httpStatusCode', String(window.httpStatusCode), 3 ]);
+  // Track status code
+  if (!window.httpStatusCode) {
+    window.httpStatusCode = '200';
   }
+  _gaq.push(['_setCustomVar', 15, 'httpStatusCode', String(window.httpStatusCode), 3 ]);
+
   // Search result placement tracking, set custom var and destroy the cookie
   if(GOVUK.cookie && GOVUK.cookie('ga_nextpage_params') !== null){
     var customVar = GOVUK.cookie('ga_nextpage_params').split(',');


### PR DESCRIPTION
We track the HTTP status code using the GA custom variable
httpStatusCode for all 4xx and 5xx responses. However, it's
remarkably difficult to filter for "custom variable not set"
in GA [1], and actually we're usually interested in getting
all successful responses, rather than unsuccessful ones.

So, if this is not a 4xx or 5xx response, pass a default value
of 'unset' to GA, to simplify filtering.

[1] http://stackoverflow.com/questions/7972978/google-analytics-exclude-empty-custom-variable-in-a-custom-report