### PR TITLE
Add an ID to the options-container

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -278,6 +278,7 @@
     default:
       key: "market_sector"
       title: "Market sector"
+      options_container_id: "list_of_sectors"
       options:
         - value: "aerospace"
           label: "Aerospace"
@@ -324,6 +325,7 @@
     with_option_pre_checked:
       key: "with_checked_value_set"
       title: "List of options"
+      options_container_id: "list_of_vegetables"
       options:
         - value: "potatoes"
           label: "Potatoes"
@@ -339,6 +341,7 @@
       key: "with_aria-control_set"
       title: "List of options"
       aria_controls_id: "js-update-region-id"
+      options_container_id: "list_of_countries"
       options:
         - value: "britain"
           label: "Britain"

--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -2,7 +2,7 @@
   <div class="container-head js-container-head">
     <div class='option-select-label'><%= title %></div>
   </div>
-  <div class='options-container'>
+  <div class='options-container' id='<%= options_container_id %>'>
     <div class='js-auto-height-inner'>
       <% options.each do | option |%>
 


### PR DESCRIPTION
In the future I'll be adding an `aria-controls={options-container-id}` to the `.container-head` of this component. `aria-controls` exposes the relationship between `.container-head` and `.options-container` to accessibility APIs.

For this reason it is important that the `.options-container` actually has an `#id` so I'm adding it here.

Adding a non-optional value like this to a component would normally be a breaking change, however there are no bits of GOV.UK using this component yet so it's fine.