### PR TITLE
Fix Last updated on Done page

### DIFF
--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -258,7 +258,8 @@ header.page-header div {
     zoom: 1;
   }
 
-  p{
+  p {
+    @include core-16;
     text-align: left;
 
     @include ie-lte(7) {
@@ -268,7 +269,10 @@ header.page-header div {
     a{
       color: $secondary-text-colour;
     }
-    @include core-16
+
+    &.modified-date {
+      clear: both;
+    }
   }
 }
 


### PR DESCRIPTION
Last updated paragraph on pages like https://www.gov.uk/done/tax-disc is floated left causing the first word to display inline with the feedback form. All styles for the paragraph are generic styles for '.meta-data p' which could affect several apps in many places. So I scoped this simple fix to '.meta-data p' that also have the .modified-date class.

I also moved and closed with ; @include core-16

Before -
![screen shot 2015-02-13 at 13 44 22](https://cloud.githubusercontent.com/assets/1692222/6188182/8947023a-b386-11e4-950c-befce88fe3dc.png)

After -
![screen shot 2015-02-13 at 13 43 52](https://cloud.githubusercontent.com/assets/1692222/6188186/919cb006-b386-11e4-9273-e96a86b0c964.png)



https://www.pivotaltracker.com/story/show/87918506