### PR TITLE
Fix appearance of tabs within content-block

### DIFF
--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -379,7 +379,8 @@ header.page-header div {
   }
 
   ol,
-  ul {
+  ul,
+  .tabs-nav {
     float: left;
     list-style: none;
     margin: 0;
@@ -398,7 +399,8 @@ header.page-header div {
     }
   }
 
-  li {
+  li,
+  .tabs-nav li {
     @include core-16;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
When we changed the default styling of text content to use an element
with a class of `content-block` rather than just using an article we
increased the specificity of the CSS selector. This means that the
standard list styling was overriding some of the styles which were being
added by the tab styles. This adds an extra selector to the tabs styles
so it now has a greater specificity than the standard list styling.

I have added an extra selector rather than just changing the selectors
because due to the way the JavaScript works it does checks on the styles
of the elements before it adds in the extra classes to work out if the
tabs should be shown as tabs or an accordion.

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>
<img src="https://cloud.githubusercontent.com/assets/35035/6167043/d20d86de-b2ae-11e4-8f2c-0b2091ef04dc.png">
</td>
<td>
<img src="https://cloud.githubusercontent.com/assets/35035/6167047/dae670ea-b2ae-11e4-9508-88bf4edbbe69.png">
</td>
</tr>
</table>