### PR TITLE
Change URL in humans.txt to one that doesn't 404

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,1 +1,1 @@
-GOV.UK is built by a team of developers and content designers at the Government Digital Service in London. If you'd like to join us, see http://digital.cabinetoffice.gov.uk/working-for-gds.
+GOV.UK is built by a team of developers and content designers at the Government Digital Service in London. If you'd like to join us, see https://gds.blog.gov.uk/jobs.

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,1 +1,1 @@
-GOV.UK is built by a team of developers and content designers at the Government Digital Service in London. If you'd like to join us, see https://gds.blog.gov.uk/jobs.
+GOV.UK is built by a team at the Government Digital Service in London. If you'd like to join us, see https://gds.blog.gov.uk/jobs.


### PR DESCRIPTION
The previous URL was presumably the jobs page. This commit changes it to be the current one. 

I also have a bit of an issue with `developers and content designers` but thought I'd see how controversial that might be before changing it to something that reflects all the disciplines.