### PR TITLE
Track social media shares in Universal analytics

### DIFF
--- a/app/assets/javascripts/analytics/google-analytics-classic-tracker.js
+++ b/app/assets/javascripts/analytics/google-analytics-classic-tracker.js
@@ -92,6 +92,16 @@
     _gaq.push(evt);
   };
 
+  /*
+    https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiSocialTracking
+    network – The network on which the action occurs (e.g. Facebook, Twitter)
+    action – The type of action that happens (e.g. Like, Send, Tweet)
+    target – The text value that indicates the subject of the action
+  */
+  GoogleAnalyticsClassicTracker.prototype.trackSocial = function(network, action, target) {
+    _gaq.push(['_trackSocial', network, action, target]);
+  };
+
   // https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingCustomVariables
   GoogleAnalyticsClassicTracker.prototype.setCustomVariable = function(index, value, name, scope) {
     _gaq.push(['_setCustomVar', index, name, String(value), scope]);

--- a/app/assets/javascripts/analytics/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics/google-analytics-universal-tracker.js
@@ -73,6 +73,22 @@
     sendToGa('send', evt);
   };
 
+  /*
+    https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions
+    network – The network on which the action occurs (e.g. Facebook, Twitter)
+    action – The type of action that happens (e.g. Like, Send, Tweet)
+    target – Specifies the target of a social interaction.
+             This value is typically a URL but can be any text.
+  */
+  GoogleAnalyticsUniversalTracker.prototype.trackSocial = function(network, action, target) {
+    sendToGa('send', {
+      'hitType': 'social',
+      'socialNetwork': network,
+      'socialAction': action,
+      'socialTarget': target
+    });
+  };
+
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/custom-dims-mets
   GoogleAnalyticsUniversalTracker.prototype.setDimension = function(index, value) {
     sendToGa('set', 'dimension' + index, String(value));

--- a/app/assets/javascripts/analytics/tracker.js
+++ b/app/assets/javascripts/analytics/tracker.js
@@ -96,7 +96,13 @@
   Tracker.prototype.trackEvent = function(category, action, options) {
     this.classic.trackEvent(category, action, options);
     this.universal.trackEvent(category, action, options);
-  }
+  };
+
+  Tracker.prototype.trackShare = function(network) {
+    var target = location.pathname;
+    this.classic.trackSocial(network, 'share', target);
+    this.universal.trackSocial(network, 'share', target);
+  };
 
   Tracker.prototype.setDimension = function(index, value, name, scope) {
     var PAGE_LEVEL_SCOPE = 3;

--- a/spec/javascripts/analytics/google-analytics-classic-tracker-spec.js
+++ b/spec/javascripts/analytics/google-analytics-classic-tracker-spec.js
@@ -93,6 +93,17 @@ describe("GOVUK.GoogleAnalyticsClassicTracker", function() {
     });
   });
 
+  describe('when social events are tracked', function() {
+    beforeEach(function() {
+      window._gaq = [];
+    });
+
+    it('sends them to Google Analytics', function() {
+      classic.trackSocial('network', 'action', 'target');
+      expect(window._gaq[0]).toEqual(['_trackSocial', 'network', 'action', 'target']);
+    });
+  });
+
   describe('when setting a custom variable', function() {
     beforeEach(function() {
       // reset queue after setup

--- a/spec/javascripts/analytics/google-analytics-universal-tracker-spec.js
+++ b/spec/javascripts/analytics/google-analytics-universal-tracker-spec.js
@@ -96,6 +96,18 @@ describe("GOVUK.GoogleAnalyticsUniversalTracker", function() {
     });
   });
 
+  describe('when social events are tracked', function() {
+    it('sends them to Google Analytics', function() {
+      universal.trackSocial('network', 'action', 'target');
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', {
+        'hitType': 'social',
+        'socialNetwork': 'network',
+        'socialAction': 'action',
+        'socialTarget': 'target'
+      }]);
+    });
+  });
+
   describe('when setting a custom dimension', function() {
     it('sends the dimension to Google Analytics with the specified index and value', function() {
       universal.setDimension(1, 'value');

--- a/spec/javascripts/analytics/tracker-spec.js
+++ b/spec/javascripts/analytics/tracker-spec.js
@@ -97,4 +97,19 @@ describe("GOVUK.Tracker", function() {
     });
   });
 
+  describe('when tracking social media shares', function() {
+    it('tracks in both classic and universal', function() {
+      window._gaq = [];
+      tracker.trackShare('network');
+
+      expect(window._gaq[0]).toEqual(['_trackSocial', 'network', 'share', jasmine.any(String)]);
+      expect(window.ga.calls.mostRecent().args).toEqual(['send', {
+        hitType: 'social',
+        socialNetwork: 'network',
+        socialAction: 'share',
+        socialTarget: jasmine.any(String)
+      }]);
+    });
+  });
+
 });


### PR DESCRIPTION
* Add interface for classic and universal social media sharing. In universal the network, action and target are all required arguments.
* Create a specific public method on tracker for tracking social network shares (trackShare) which will be used by https://github.com/alphagov/whitehall/blob/master/app/assets/javascripts/application/document-share-links.js (see: https://github.com/alphagov/whitehall/compare/universal-social)

Social tracking docs:
https://developers.google.com/analytics/devguides/collection/gajs/methods/gaJSApiSocialTracking
https://developers.google.com/analytics/devguides/collection/analyticsjs/social-interactions

https://www.pivotaltracker.com/story/show/88174796