### PR TITLE
Don't minify analytics initialisers in template

### DIFF
--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -1,5 +1,7 @@
 <script id="ga-params">
-  var GOVUK=GOVUK||{},_gaq=_gaq||[];GOVUK.Analytics=GOVUK.Analytics||{};
+  window.GOVUK = window.GOVUK || {};
+  window._gaq = window._gaq || [];
+  GOVUK.Analytics = GOVUK.Analytics || {};
   <%#
     Slimmer inserts custom variables here
     https://github.com/alphagov/slimmer/blob/master/lib/slimmer/processors/google_analytics_configurator.rb


### PR DESCRIPTION
In IE8 and below the minified inline javascript was inadvertently wiping out the GOVUK object, causing JS errors.

We aren’t sure exactly why it was wiping out the object, but by removing `var` and referring to window the error is eliminated.

Fix discovered by @edds after some excellent sleuthing.