### PR TITLE
Add a component for /government navigation

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -40,6 +40,13 @@
       from: "<a href='/government/organisations/cabinet-office'>Cabinet Office</a>"
       history: "Updated 2 weeks ago"
       part_of: "<a href='/government/topics/environment'>Environment</a>"
+- id: "government_navigation"
+  name: "Government navigation"
+  description: "Navigation placed in the header by Slimmer and used by pages which sit under the /government path. This is a markup only component and is not available for preview here. It can be passed a string to mark a link as being active."
+  fixtures:
+    default: {}
+    with_active_item:
+      active: "departments"
 - id: "govspeak"
   name: "Govspeak content"
   description: "To display long form text which has been converted from markdown"

--- a/app/views/govuk_component/government_navigation.raw.html.erb
+++ b/app/views/govuk_component/government_navigation.raw.html.erb
@@ -1,0 +1,17 @@
+<%
+  active ||= nil
+%>
+
+<nav id="proposition-menu" class="no-proposition-name">
+  <ul id="proposition-links">
+    <li><a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">Departments</a></li>
+    <li><a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">Worldwide</a></li>
+    <li><a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">How government works</a></li>
+    <li><a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">Get involved</a></li>
+    <li class="clear-child"><a class="<%= 'active' if active == 'policies' %>" href="/government/policies">Policies</a></li>
+    <li><a class="<%= 'active' if active == 'publications' %>" href="/government/publications">Publications</a></li>
+    <li><a class="<%= 'active' if active == 'consultations' %>" href="/government/publications?publication_filter_option=consultations">Consultations</a></li>
+    <li><a class="<%= 'active' if active == 'statistics' %>" href="/government/statistics">Statistics</a></li>
+    <li><a class="<%= 'active' if active == 'announcements' %>" href="/government/announcements">Announcements</a></li>
+  </ul>
+</nav>


### PR DESCRIPTION
This commit adds a component for the government_navigation which contains only markup. This can be included anywhere on GOV.UK and will be lifted by Slimmer and placed into the header, appropriately styling it.

It can be passed a string assigned to active which will then mark the matching link as active. See the code for which strings are used.

This component is slightly odd as Slimmer will move it from the page the first instance it is included and it doesn't come with it's own CSS so the first example on the component view in the guide contains nothing and the second example contains an unstyled list.

Screenshot:
![screen shot 2015-03-03 at 16 11 24](https://cloud.githubusercontent.com/assets/449004/6466512/f9941afe-c1bf-11e4-901c-3dcac3cf85d5.png)
