### PR TITLE
Provide additional visual cue that option-select is scrollable

### DIFF
--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -102,13 +102,39 @@
   OptionSelect.prototype.setupHeight = function setupHeight(){
     var optionsContainer = this.$optionSelect.find('.options-container');
     var optionList = optionsContainer.children('.js-auto-height-inner');
+    var options = optionList.children('label');
     var initialOptionContainerHeight = optionsContainer.height();
     var height = optionList.height();
+    var lastVisibleOption;
 
     if (height < initialOptionContainerHeight + 50) {
       // Resize if the list is only slightly bigger than its container
-      optionsContainer.height(optionList.height());
+      optionsContainer.css({
+        'max-height': 'none',
+        'height': optionList.height()
+      });
+      return;
     }
+
+    // Resize to cut last item cleanly in half
+    lastVisibleOption = options.filter(function(index, option) {
+      var distanceFromTopOfContainer = $(option).offset().top - optionList.offset().top;
+      var containerHeight = optionsContainer.height();
+      return distanceFromTopOfContainer < containerHeight
+    }).last();
+
+    var middleOfLastVisibleOption = (
+      lastVisibleOption.position().top +
+      parseInt(lastVisibleOption.css('border-top-width'), 10) +
+      parseInt(lastVisibleOption.css('padding-top'), 10) +
+      (parseInt(lastVisibleOption.css('line-height'), 10) / 2)
+    );
+
+    optionsContainer.css({
+      'max-height': 'none', // Have to clear the max-height set by the CSS
+      'height': middleOfLastVisibleOption
+    });
+
   };
 
   OptionSelect.prototype.listenForKeys = function listenForKeys(){

--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -106,34 +106,36 @@
     var initialOptionContainerHeight = optionsContainer.height();
     var height = optionList.height();
     var lastVisibleOption;
+    var setContainerHeight = function(height) {
+      // Have to clear the 'max-height' set by the CSS in order for 'height' to be applied
+      optionsContainer.css({
+        'max-height': 'none',
+        'height': height
+      });
+    };
 
     if (height < initialOptionContainerHeight + 50) {
       // Resize if the list is only slightly bigger than its container
-      optionsContainer.css({
-        'max-height': 'none',
-        'height': optionList.height()
-      });
+      setContainerHeight(optionList.height());
       return;
     }
 
     // Resize to cut last item cleanly in half
     lastVisibleOption = options.filter(function(index, option) {
       var distanceFromTopOfContainer = $(option).offset().top - optionList.offset().top;
-      var containerHeight = optionsContainer.height();
-      return distanceFromTopOfContainer < containerHeight
+      return distanceFromTopOfContainer < initialOptionContainerHeight
     }).last();
 
-    var middleOfLastVisibleOption = (
+    setContainerHeight(
       lastVisibleOption.position().top +
       parseInt(lastVisibleOption.css('border-top-width'), 10) +
       parseInt(lastVisibleOption.css('padding-top'), 10) +
-      (parseInt(lastVisibleOption.css('line-height'), 10) / 2)
+      (parseInt(
+        "normal" == lastVisibleOption.css('line-height') ?
+          lastVisibleOption.css('font-size') : lastVisibleOption.css('line-height'),
+        10
+      ) / 2)
     );
-
-    optionsContainer.css({
-      'max-height': 'none', // Have to clear the max-height set by the CSS
-      'height': middleOfLastVisibleOption
-    });
 
   };
 

--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -124,7 +124,7 @@
   OptionSelect.prototype.setupHeight = function setupHeight(){
     var initialOptionContainerHeight = this.$optionsContainer.height();
     var height = this.$optionList.height();
-    var lastVisibleLabel;
+    var lastVisibleLabel, position, topBorder, topPadding, lineHeight;
 
     if (height < initialOptionContainerHeight + 50) {
       // Resize if the list is only slightly bigger than its container
@@ -134,17 +134,16 @@
 
     // Resize to cut last item cleanly in half
     lastVisibleLabel = this.getVisibleLabels().last();
+    position = lastVisibleLabel.position().top;
+    topBorder = parseInt(lastVisibleLabel.css('border-top-width'), 10);
+    topPadding = parseInt(lastVisibleLabel.css('padding-top'), 10);
+    if ("normal" == lastVisibleLabel.css('line-height')) {
+      lineHeight = parseInt(lastVisibleLabel.css('font-size'), 10);
+    } else {
+      lineHeight = parseInt(lastVisibleLabel.css('line-height'), 10);
+    }
 
-    this.setContainerHeight(
-      lastVisibleLabel.position().top +
-      parseInt(lastVisibleLabel.css('border-top-width'), 10) +
-      parseInt(lastVisibleLabel.css('padding-top'), 10) +
-      (parseInt(
-        "normal" == lastVisibleLabel.css('line-height') ?
-          lastVisibleLabel.css('font-size') : lastVisibleLabel.css('line-height'),
-        10
-      ) / 2)
-    );
+    this.setContainerHeight(position + topBorder + topPadding + (lineHeight / 2));
 
   };
 

--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -109,13 +109,16 @@
     });
   };
 
-  OptionSelect.prototype.getVisibleLabels = function getVisibleLabels(){
+  OptionSelect.prototype.isLabelVisible = function isLabelVisible(index, option){
+    var $label = $(option);
     var initialOptionContainerHeight = this.$optionsContainer.height();
     var optionListOffsetTop = this.$optionList.offset().top;
-    return this.$labels.filter(function() {
-      var distanceFromTopOfContainer = $(this).offset().top - optionListOffsetTop;
-      return distanceFromTopOfContainer < initialOptionContainerHeight;
-    });
+    var distanceFromTopOfContainer = $label.offset().top - optionListOffsetTop;
+    return distanceFromTopOfContainer < initialOptionContainerHeight;
+  };
+
+  OptionSelect.prototype.getVisibleLabels = function getVisibleLabels(){
+    return this.$labels.filter(this.isLabelVisible.bind(this));
   };
 
   OptionSelect.prototype.setupHeight = function setupHeight(){

--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -10,6 +10,9 @@
 
     this.$optionSelect = options.$el;
     this.$options = this.$optionSelect.find("input[type='checkbox']");
+    this.$labels = this.$optionSelect.find("label");
+    this.$optionsContainer = this.$optionSelect.find('.options-container');
+    this.$optionList = this.$optionsContainer.children('.js-auto-height-inner');
 
     // Build clearing link
     this.$clearingLink = this.attachClearingLink();
@@ -99,40 +102,43 @@
     return this.$optionSelect.hasClass('js-closed');
   };
 
+  OptionSelect.prototype.setContainerHeight = function setContainerHeight(height){
+    this.$optionsContainer.css({
+      'max-height': 'none', // Have to clear the 'max-height' set by the CSS in order for 'height' to be applied
+      'height': height
+    });
+  };
+
+  OptionSelect.prototype.getVisibleLabels = function getVisibleLabels(){
+    var initialOptionContainerHeight = this.$optionsContainer.height();
+    var optionListOffsetTop = this.$optionList.offset().top;
+    return this.$labels.filter(function() {
+      var distanceFromTopOfContainer = $(this).offset().top - optionListOffsetTop;
+      return distanceFromTopOfContainer < initialOptionContainerHeight;
+    });
+  };
+
   OptionSelect.prototype.setupHeight = function setupHeight(){
-    var optionsContainer = this.$optionSelect.find('.options-container');
-    var optionList = optionsContainer.children('.js-auto-height-inner');
-    var options = optionList.children('label');
-    var initialOptionContainerHeight = optionsContainer.height();
-    var height = optionList.height();
-    var lastVisibleOption;
-    var setContainerHeight = function(height) {
-      // Have to clear the 'max-height' set by the CSS in order for 'height' to be applied
-      optionsContainer.css({
-        'max-height': 'none',
-        'height': height
-      });
-    };
+    var initialOptionContainerHeight = this.$optionsContainer.height();
+    var height = this.$optionList.height();
+    var lastVisibleLabel;
 
     if (height < initialOptionContainerHeight + 50) {
       // Resize if the list is only slightly bigger than its container
-      setContainerHeight(optionList.height());
+      this.setContainerHeight(height);
       return;
     }
 
     // Resize to cut last item cleanly in half
-    lastVisibleOption = options.filter(function(index, option) {
-      var distanceFromTopOfContainer = $(option).offset().top - optionList.offset().top;
-      return distanceFromTopOfContainer < initialOptionContainerHeight
-    }).last();
+    lastVisibleLabel = this.getVisibleLabels().last();
 
-    setContainerHeight(
-      lastVisibleOption.position().top +
-      parseInt(lastVisibleOption.css('border-top-width'), 10) +
-      parseInt(lastVisibleOption.css('padding-top'), 10) +
+    this.setContainerHeight(
+      lastVisibleLabel.position().top +
+      parseInt(lastVisibleLabel.css('border-top-width'), 10) +
+      parseInt(lastVisibleLabel.css('padding-top'), 10) +
       (parseInt(
-        "normal" == lastVisibleOption.css('line-height') ?
-          lastVisibleOption.css('font-size') : lastVisibleOption.css('line-height'),
+        "normal" == lastVisibleLabel.css('line-height') ?
+          lastVisibleLabel.css('font-size') : lastVisibleLabel.css('line-height'),
         10
       ) / 2)
     );

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -16,7 +16,7 @@ describe('GOVUK.OptionSelect', function() {
             '</label>'+
           '<label for="agriculture-environment-and-natural-resources">'+
             '<input name="market_sector[]" value="agriculture-environment-and-natural-resources" id="agriculture-environment-and-natural-resources" type="checkbox">'+
-            'Agriculture, environment and natural resources'+
+            'Agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment, natural resources, agriculture, environment and natural resources.'+
             '</label>'+
           '<label for="building-and-construction">'+
             '<input name="market_sector[]" value="building-and-construction" id="building-and-construction" type="checkbox">'+

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -197,10 +197,9 @@ describe('GOVUK.OptionSelect', function() {
     beforeEach(function(){
 
       // Set some visual properties which are done in the CSS IRL
-      optionSelectHeight = 200;
       $checkboxList = $optionSelectHTML.find('.options-container');
       $checkboxList.css({
-        'height': optionSelectHeight,
+        'height': 200,
         'position': 'relative',
         'overflow': 'scroll'
       });
@@ -222,12 +221,12 @@ describe('GOVUK.OptionSelect', function() {
       expect($checkboxList.height()).toBe($checkboxListInner.height());
     });
 
-    it('does nothing if the height of the checkbox list is longer than the height of the container by more than 50px', function(){
+    it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
       $checkboxListInner.height(251);
       optionSelect.setupHeight();
 
       // Wrapping HTML should not stretch as 251px is too big.
-      expect($checkboxList.height()).toBe(optionSelectHeight);
+      expect($checkboxList.height()).toBeGreaterThan(199);
     });
 
   });

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -191,6 +191,62 @@ describe('GOVUK.OptionSelect', function() {
     });
   });
 
+  describe ('setContainerHeight', function(){
+
+    it('can have its height set', function(){
+      optionSelect.setContainerHeight(200);
+      expect(optionSelect.$optionsContainer.height()).toBe(200);
+    });
+
+    it('still works even if the container has a max-height', function(){
+      optionSelect.$optionsContainer.css("max-height", 100);
+      expect(optionSelect.$optionsContainer.height()).toBeLessThan(101);
+      optionSelect.setContainerHeight(200);
+      expect(optionSelect.$optionsContainer.height()).toBe(200);
+    });
+  });
+
+  describe ('isLabelVisible', function(){
+    var firstLabel, lastLabel;
+
+    beforeEach(function(){
+      optionSelect.setContainerHeight(100);
+      optionSelect.$optionsContainer.width(100);
+      firstLabel = optionSelect.$labels[0];
+      lastLabel = optionSelect.$labels[optionSelect.$labels.length -1];
+    });
+
+    it('returns true if a label is visible', function(){
+      expect(optionSelect.isLabelVisible.call(optionSelect, 0, firstLabel)).toBe(true);
+    });
+
+    it('returns true if a label is outside its container', function(){
+      expect(optionSelect.isLabelVisible.call(optionSelect, 0, lastLabel)).toBe(false);
+    });
+
+  });
+
+  describe ('getVisibleLabels', function(){
+    var visibleLabels, lastLabelForAttribute, lastVisibleLabelForAttribute;
+
+    it('returns all the labels if the container doesn\'t overflow', function(){
+      expect(optionSelect.$labels.length).toBe(optionSelect.getVisibleLabels().length);
+    });
+
+    it('only returns some of the first labels if the container\'s dimensions are constricted', function(){
+      optionSelect.setContainerHeight(100);
+      optionSelect.$optionsContainer.width(100);
+
+      visibleLabels = optionSelect.getVisibleLabels();
+      expect(visibleLabels.length).toBeLessThan(optionSelect.$labels.length);
+
+      lastLabelForAttribute = optionSelect.$labels[optionSelect.$labels.length - 1].getAttribute("for");
+      lastVisibleLabelForAttribute = visibleLabels[visibleLabels.length - 1].getAttribute("for");
+      expect(lastLabelForAttribute).not.toBe(lastVisibleLabelForAttribute);
+    });
+
+  });
+
   describe ('setupHeight', function(){
     var checkboxContainerHeight, stretchMargin;
 
@@ -222,7 +278,7 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
-      $checkboxList.css({height: 101});
+      $checkboxList.css({"max-height": 101});
       optionSelect.setupHeight();
 
       // Wrapping HTML should not stretch as 251px is too big.

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -222,11 +222,11 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
-      $checkboxListInner.height(251);
+      $checkboxList.css({height: 101});
       optionSelect.setupHeight();
 
       // Wrapping HTML should not stretch as 251px is too big.
-      expect($checkboxList.height()).toBeGreaterThan(199);
+      expect($checkboxList.height()).toBeGreaterThan(100);
     });
 
   });

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -196,10 +196,18 @@ describe('GOVUK.OptionSelect', function() {
 
     beforeEach(function(){
 
-      // Set the height of option-select-container to 200 (this is done in the CSS IRL)
+      // Set some visual properties which are done in the CSS IRL
       optionSelectHeight = 200;
       $checkboxList = $optionSelectHTML.find('.options-container');
-      $checkboxList.height(optionSelectHeight);
+      $checkboxList.css({
+        'height': optionSelectHeight,
+        'position': 'relative',
+        'overflow': 'scroll'
+      });
+      $listItems = $checkboxList.find('label');
+      $listItems.css({
+        'display': 'block'
+      });
 
       $checkboxListInner = $checkboxList.find(' > .js-auto-height-inner');
       listItem = "<input type='checkbox' name='ca98'id='ca89'><label for='ca89'>CA89</label>";
@@ -221,6 +229,7 @@ describe('GOVUK.OptionSelect', function() {
       // Wrapping HTML should not stretch as 251px is too big.
       expect($checkboxList.height()).toBe(optionSelectHeight);
     });
+
   });
 
   describe('listenForKeys', function(){


### PR DESCRIPTION
## The problem

In research on the Digital Marketplace we have seen users not realise that the option-select has more options than those visible.

On certain combinations of browsers/operating system/number-of-lines-per-option it isn't clear that the component is scrollable. This is because the `max-height` of the container lines up with the bottom edge of the last visible option.

## The solution

This pull request adds Javascript to adjust the height of the container so that the first line of the last visible option is always cut exactly in half horizontally.

Before | After
--- | ---
![before](https://cloud.githubusercontent.com/assets/355079/6524399/ed718832-c3f0-11e4-87b0-8eb0f9ffe262.png) | ![after](https://cloud.githubusercontent.com/assets/355079/6524405/f8b2a438-c3f0-11e4-9f1d-b11f4851e318.png)


It also works when the options wrap to multiple lines:
![multiline](https://cloud.githubusercontent.com/assets/355079/6524397/e7eda288-c3f0-11e4-85e0-dc9abeddd598.png)

## Feedback

I'd especially like to know:
- If there's a more thorough way to test this, without going as far as re-writing the logic from the component in the tests
- If you can understand what the code is doing from reading it—the logic is somewhat complex so if it could be written in a more explicit way I'd welcome that