### PR TITLE
Set analytics custom dimensions from `govuk:` meta tags

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -19,7 +19,7 @@
     setHTTPStatusCodeDimension();
     shimNextPageParams();
     shimClassicAnalyticsQueue(classicQueue);
-    setDimensionsFromMetaTags.apply(this);
+    this.setDimensionsFromMetaTags();
 
     // Track initial pageview
     tracker.trackPageview();
@@ -79,35 +79,35 @@
       tracker.setDimension(customVar[1], customVar[3], customVar[2], customVar[4]);
     }
 
-    function setDimensionsFromMetaTags() {
-      var $metas = $('meta[name^="govuk:"]'),
-          dimensions = {};
-
-      $metas.each(function() {
-        var $meta = $(this),
-            key = $meta.attr('name').split('govuk:')[1],
-            value = $meta.attr('content');
-
-        dimensions[key] = value;
-      });
-
-      this.setSectionDimension(dimensions['section']);
-      this.setFormatDimension(dimensions['format']);
-      this.setNeedIDsDimension(dimensions['need-ids']);
-      this.setResultCountDimension(dimensions['search-result-count']);
-      this.setOrganisationsDimension(dimensions['analytics:organisations']);
-      this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
-    }
-
   };
 
   StaticTracker.load = function() {
     GOVUK.Tracker.load();
   };
 
+  StaticTracker.prototype.setDimensionsFromMetaTags = function() {
+    var $metas = $('meta[name^="govuk:"]'),
+        dimensions = {};
+
+    $metas.each(function() {
+      var $meta = $(this),
+          key = $meta.attr('name').split('govuk:')[1],
+          value = $meta.attr('content');
+
+      dimensions[key] = value;
+    });
+
+    this.setSectionDimension(dimensions['section']);
+    this.setFormatDimension(dimensions['format']);
+    this.setNeedIDsDimension(dimensions['need-ids']);
+    this.setResultCountDimension(dimensions['search-result-count']);
+    this.setOrganisationsDimension(dimensions['analytics:organisations']);
+    this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
+  };
+
   StaticTracker.prototype.trackPageview = function(path, title) {
     this.tracker.trackPageview(path, title);
-  }
+  };
 
   StaticTracker.prototype.trackEvent = function(category, action, options) {
     this.tracker.trackEvent(category, action, options);

--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -19,6 +19,7 @@
     setHTTPStatusCodeDimension();
     shimNextPageParams();
     shimClassicAnalyticsQueue(classicQueue);
+    setDimensionsFromMetaTags.apply(this);
 
     // Track initial pageview
     tracker.trackPageview();
@@ -78,6 +79,26 @@
       tracker.setDimension(customVar[1], customVar[3], customVar[2], customVar[4]);
     }
 
+    function setDimensionsFromMetaTags() {
+      var $metas = $('meta[name^="govuk:"]'),
+          dimensions = {};
+
+      $metas.each(function() {
+        var $meta = $(this),
+            key = $meta.attr('name').split('govuk:')[1],
+            value = $meta.attr('content');
+
+        dimensions[key] = value;
+      });
+
+      this.setSectionDimension(dimensions['section']);
+      this.setFormatDimension(dimensions['format']);
+      this.setNeedIDsDimension(dimensions['need-ids']);
+      this.setResultCountDimension(dimensions['search-result-count']);
+      this.setOrganisationsDimension(dimensions['analytics:organisations']);
+      this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
+    }
+
   };
 
   StaticTracker.load = function() {
@@ -93,6 +114,10 @@
   };
 
   StaticTracker.prototype.setDimension = function(index, value, name, scope) {
+    if (typeof value === "undefined") {
+      return;
+    }
+
     this.tracker.setDimension(index, value, name, scope);
   };
 
@@ -100,16 +125,32 @@
     this.tracker.trackShare(network);
   };
 
-  StaticTracker.prototype.setSearchPositionDimension = function(position) {
-    this.tracker.setDimension(21, position, 'searchPosition');
+  StaticTracker.prototype.setSectionDimension = function(section) {
+    this.setDimension(1, section, 'Section');
+  };
+
+  StaticTracker.prototype.setFormatDimension = function(format) {
+    this.setDimension(2, format, 'Format');
+  };
+
+  StaticTracker.prototype.setNeedIDsDimension = function(ids) {
+    this.setDimension(3, ids, 'NeedID');
   };
 
   StaticTracker.prototype.setResultCountDimension = function(count) {
-    this.tracker.setDimension(5, count, 'ResultCount');
+    this.setDimension(5, count, 'ResultCount');
   };
 
-  StaticTracker.prototype.setSectionDimension = function(section) {
-    this.tracker.setDimension(1, section, 'Section');
+  StaticTracker.prototype.setOrganisationsDimension = function(orgs) {
+    this.setDimension(9, orgs, 'Organisations');
+  };
+
+  StaticTracker.prototype.setWorldLocationsDimension = function(locations) {
+    this.setDimension(10, locations, 'WorldLocations');
+  };
+
+  StaticTracker.prototype.setSearchPositionDimension = function(position) {
+    this.setDimension(21, position, 'searchPosition');
   };
 
   GOVUK.StaticTracker = StaticTracker;

--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -3,7 +3,7 @@
   window._gaq = window._gaq || [];
   GOVUK.Analytics = GOVUK.Analytics || {};
   <%#
-    Slimmer inserts custom variables here
-    https://github.com/alphagov/slimmer/blob/master/lib/slimmer/processors/google_analytics_configurator.rb
+    Slimmer < 8.0.0 inserts custom variables here
+    Once all apps have been updated beyond this version, this can be removed
   %>
 </script>

--- a/spec/javascripts/analytics/static-tracker-spec.js
+++ b/spec/javascripts/analytics/static-tracker-spec.js
@@ -63,6 +63,64 @@ describe("GOVUK.StaticTracker", function() {
       });
     });
 
+    describe('when there are govuk: meta tags', function() {
+      beforeEach(function() {
+        window.ga.calls.reset();
+        window._gaq = [];
+      });
+
+      afterEach(function() {
+        $('head').find('meta[name^="govuk:"]').remove();
+      });
+
+      it('sets them as dimensions', function() {
+
+        $('head').append('\
+          <meta name="govuk:section" content="section">\
+          <meta name="govuk:format" content="format">\
+          <meta name="govuk:need-ids" content="1,2,3">\
+          <meta name="govuk:search-result-count" content="1000">\
+          <meta name="govuk:analytics:organisations" content="<D10>">\
+          <meta name="govuk:analytics:world-locations" content="<W1>">\
+        ');
+
+        tracker = new GOVUK.StaticTracker({universalId: 'universal-id', classicId: 'classic-id'});
+        universalSetupArguments = window.ga.calls.allArgs();
+
+        expect(window._gaq[6]).toEqual(['_setCustomVar', 1, 'Section', 'section', 3]);
+        expect(universalSetupArguments[4]).toEqual(['set', 'dimension1', 'section']);
+
+        expect(window._gaq[7]).toEqual(['_setCustomVar', 2, 'Format', 'format', 3]);
+        expect(universalSetupArguments[5]).toEqual(['set', 'dimension2', 'format']);
+
+        expect(window._gaq[8]).toEqual(['_setCustomVar', 3, 'NeedID', '1,2,3', 3]);
+        expect(universalSetupArguments[6]).toEqual(['set', 'dimension3', '1,2,3']);
+
+        expect(window._gaq[9]).toEqual(['_setCustomVar', 5, 'ResultCount', '1000', 3]);
+        expect(universalSetupArguments[7]).toEqual(['set', 'dimension5', '1000']);
+
+        expect(window._gaq[10]).toEqual(['_setCustomVar', 9, 'Organisations', '<D10>', 3]);
+        expect(universalSetupArguments[8]).toEqual(['set', 'dimension9', '<D10>']);
+
+        expect(window._gaq[11]).toEqual(['_setCustomVar', 10, 'WorldLocations', '<W1>', 3]);
+        expect(universalSetupArguments[9]).toEqual(['set', 'dimension10', '<W1>']);
+      });
+
+      it('ignores meta tags not set', function() {
+
+        $('head').append('<meta name="govuk:section" content="section">');
+
+        tracker = new GOVUK.StaticTracker({universalId: 'universal-id', classicId: 'classic-id'});
+        universalSetupArguments = window.ga.calls.allArgs();
+
+        expect(window._gaq[6]).toEqual(['_setCustomVar', 1, 'Section', 'section', 3]);
+        expect(universalSetupArguments[4]).toEqual(['set', 'dimension1', 'section']);
+
+        expect(window._gaq[7]).toEqual(['_trackPageview']);
+        expect(universalSetupArguments[5]).toEqual(['send', 'pageview']);
+      });
+    });
+
     describe('when there is an existing queue of custom variables', function() {
       beforeEach(function() {
         window.ga.calls.reset();


### PR DESCRIPTION
Related to https://github.com/alphagov/slimmer/pull/119

* Find `govuk:` namespaced meta tags and use the content of these tags to set dimensions
* Be explicit about what's being read and set
* Works with both old and new slimmer versions but can be simplified once apps are all on version 8.0.0 or greater