### PR TITLE
Mechanism for making analytics calls on next page

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -20,6 +20,7 @@
     shimNextPageParams();
     shimClassicAnalyticsQueue(classicQueue);
     this.setDimensionsFromMetaTags();
+    this.callMethodRequestedByPreviousPage();
 
     // Track initial pageview
     tracker.trackPageview();
@@ -79,6 +80,33 @@
       tracker.setDimension(customVar[1], customVar[3], customVar[2], customVar[4]);
     }
 
+  };
+
+  StaticTracker.prototype.callOnNextPage = function(method, params) {
+    params = params || [];
+
+    if (!$.isArray(params)) {
+      params = [params];
+    }
+
+    if (GOVUK.cookie && typeof this[method] === "function") {
+      params.unshift(method);
+      GOVUK.cookie('analytics_next_page_call', params.join('|'));
+    }
+  };
+
+  StaticTracker.prototype.callMethodRequestedByPreviousPage = function() {
+    if (GOVUK.cookie && GOVUK.cookie('analytics_next_page_call') !== null) {
+      var params = GOVUK.cookie('analytics_next_page_call').split('|'),
+          method = params.shift();
+
+      if (typeof this[method] === "function") {
+        this[method].apply(this, params);
+      }
+
+      // Delete cookie
+      GOVUK.cookie('analytics_next_page_call', null);
+    }
   };
 
   StaticTracker.load = function() {

--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -91,16 +91,20 @@
 
     if (GOVUK.cookie && typeof this[method] === "function") {
       params.unshift(method);
-      GOVUK.cookie('analytics_next_page_call', params.join('|'));
+      GOVUK.cookie('analytics_next_page_call', JSON.stringify(params));
     }
   };
 
   StaticTracker.prototype.callMethodRequestedByPreviousPage = function() {
     if (GOVUK.cookie && GOVUK.cookie('analytics_next_page_call') !== null) {
-      var params = GOVUK.cookie('analytics_next_page_call').split('|'),
-          method = params.shift();
+      var params, method;
 
-      if (typeof this[method] === "function") {
+      try {
+        params = JSON.parse(GOVUK.cookie('analytics_next_page_call'));
+        method = params.shift();
+      } catch(e) {}
+
+      if (method && typeof this[method] === "function") {
         this[method].apply(this, params);
       }
 

--- a/spec/javascripts/helpers/SpecHelper.js
+++ b/spec/javascripts/helpers/SpecHelper.js
@@ -21,15 +21,3 @@ beforeEach(function () {
     }
   });
 });
-
-// When using phantomJS JSON.parse seems bugged, returning a string instead of a built object.
-// I'm unsure as to why, since when testing this behaviour directly in phantom it behaves
-// as expected. This monkey patches the issue, but It'd be good to find out what's going on here.
-var _JSON_parse = JSON.parse;
-JSON.parse = function(json_string) {
-  var result = _JSON_parse(json_string);
-  if (typeof result == "string") {
-    result = eval(result);
-  }
-  return result;
-}


### PR DESCRIPTION
* Based on an existing technique that sets a GOVUK cookie but which needed classic GA parameters to work
* Instead use `callOnNextPage` which sets a method to call on the `analytics` object with an array of parameters to pass to it
* Use JSON stringify and parse to save method name and parameters
* Call the requested method before the initial pageview, allowing for custom variables to be set from a prior page (as is the current use case)

Example of usage replacing old approach in frontend:
https://github.com/alphagov/frontend/compare/next-page-analytics

(Once the frontend change is merged and deployed, the remaining shims within static can be deleted)