### PR TITLE
Add Analytics dimensions for History Mode

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -101,6 +101,8 @@
     this.setFormatDimension(dimensions['format']);
     this.setNeedIDsDimension(dimensions['need-ids']);
     this.setResultCountDimension(dimensions['search-result-count']);
+    this.setPublishingGovernmentDimension(dimensions['publishing-government']);
+    this.setPoliticalStatusDimension(dimensions['political-status']);
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
   };
@@ -139,6 +141,14 @@
 
   StaticTracker.prototype.setResultCountDimension = function(count) {
     this.setDimension(5, count, 'ResultCount');
+  };
+
+  StaticTracker.prototype.setPublishingGovernmentDimension = function(government) {
+    this.setDimension(6, government, 'PublishingGovernment');
+  };
+
+  StaticTracker.prototype.setPoliticalStatusDimension = function(status) {
+    this.setDimension(7, status, 'PoliticalStatus');
   };
 
   StaticTracker.prototype.setOrganisationsDimension = function(orgs) {

--- a/spec/javascripts/analytics/static-tracker-spec.js
+++ b/spec/javascripts/analytics/static-tracker-spec.js
@@ -80,6 +80,8 @@ describe("GOVUK.StaticTracker", function() {
           <meta name="govuk:format" content="format">\
           <meta name="govuk:need-ids" content="1,2,3">\
           <meta name="govuk:search-result-count" content="1000">\
+          <meta name="govuk:publishing-government" content="2005-to-2010-labour-government">\
+          <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
         ');
@@ -99,11 +101,17 @@ describe("GOVUK.StaticTracker", function() {
         expect(window._gaq[9]).toEqual(['_setCustomVar', 5, 'ResultCount', '1000', 3]);
         expect(universalSetupArguments[7]).toEqual(['set', 'dimension5', '1000']);
 
-        expect(window._gaq[10]).toEqual(['_setCustomVar', 9, 'Organisations', '<D10>', 3]);
-        expect(universalSetupArguments[8]).toEqual(['set', 'dimension9', '<D10>']);
+        expect(window._gaq[10]).toEqual(['_setCustomVar', 6, 'PublishingGovernment', '2005-to-2010-labour-government', 3]);
+        expect(universalSetupArguments[8]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
 
-        expect(window._gaq[11]).toEqual(['_setCustomVar', 10, 'WorldLocations', '<W1>', 3]);
-        expect(universalSetupArguments[9]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(window._gaq[11]).toEqual(['_setCustomVar', 7, 'PoliticalStatus', 'historic', 3]);
+        expect(universalSetupArguments[9]).toEqual(['set', 'dimension7', 'historic']);
+
+        expect(window._gaq[12]).toEqual(['_setCustomVar', 9, 'Organisations', '<D10>', 3]);
+        expect(universalSetupArguments[10]).toEqual(['set', 'dimension9', '<D10>']);
+
+        expect(window._gaq[13]).toEqual(['_setCustomVar', 10, 'WorldLocations', '<W1>', 3]);
+        expect(universalSetupArguments[11]).toEqual(['set', 'dimension10', '<W1>']);
       });
 
       it('ignores meta tags not set', function() {


### PR DESCRIPTION
Documents in Whitehall that are political and published
by a previous government will be marked as historical.

This adds two new dimensions that will be used to track
content related to History mode, but they've been kept
a little more general, so they could be applied more
widely in the future.

The new dimensions are:
 - PublishingGovernment, the government a document was
   first published under (which may not be when it was
   first published to GOV.UK)
 - PoliticalStatus, whether a document is historic
   (political and non current), political (political
   and current) or apolitical

https://trello.com/c/fednKEAR/105-add-analytics-for-history-mode

Note: This re-orders the tests slightly, so the argument IDs and dimension IDs are both increasing. This feels a bit brittle, and generates noise in the diff, but is more readable, I think. 

Longer term it would be nicer if the test didn't need to care about the order dimensions are set in, eg a test helper like: 
```
expect(classicDimensionFor(1, 'Section').toEqual(['section', 3]);
expect(universalDimensionFor('dimension1').toEqual('section']);
```
Thoughts?