### PR TITLE
Remove custom variable in a cookie shim

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -17,7 +17,6 @@
 
     setPixelDensityDimension();
     setHTTPStatusCodeDimension();
-    shimNextPageParams();
     shimClassicAnalyticsQueue(classicQueue);
     this.setDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
@@ -48,23 +47,6 @@
 
     function setHTTPStatusCodeDimension() {
       tracker.setDimension(15, window.httpStatusCode || 200, 'httpStatusCode');
-    }
-
-    function shimNextPageParams() {
-      // A cookie is sometimes set by apps to declare the GA parameters that
-      // should run on the subsequent page. These declare the actual methods
-      // to call in classic analytics. This is a temporary shim to ensure these
-      // are applied to both classic and universal before updating apps.
-      if (GOVUK.cookie && GOVUK.cookie('ga_nextpage_params') !== null){
-        var classicParams = GOVUK.cookie('ga_nextpage_params').split(',');
-
-        if (classicParams[0] == "_setCustomVar") {
-          setDimensionFromCustomVariable(classicParams);
-        }
-
-        // Delete cookie
-        GOVUK.cookie('ga_nextpage_params', null);
-      }
     }
 
     function shimClassicAnalyticsQueue(queue) {

--- a/spec/javascripts/analytics/static-tracker-spec.js
+++ b/spec/javascripts/analytics/static-tracker-spec.js
@@ -50,25 +50,6 @@ describe("GOVUK.StaticTracker", function() {
       expect(GOVUK.analyticsPlugins.error).toHaveBeenCalled();
     });
 
-    describe('when there is an old GA cookie with next page parameters set', function() {
-      it('sets them as a dimension', function() {
-        window.ga.calls.reset();
-        window._gaq = [];
-        spyOn(GOVUK, 'cookie').and.callFake(function(name) {
-          if (name === "ga_nextpage_params") {
-            return "_setCustomVar,21,name,value,3";
-          }
-
-          return null;
-        });
-        tracker = new GOVUK.StaticTracker({universalId: 'universal-id', classicId: 'classic-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
-
-        expect(window._gaq[6]).toEqual(['_setCustomVar', 21, 'name', 'value', 3]);
-        expect(universalSetupArguments[4]).toEqual(['set', 'dimension21', 'value']);
-      });
-    });
-
     describe('when there are govuk: meta tags', function() {
       beforeEach(function() {
         window.ga.calls.reset();
@@ -230,26 +211,13 @@ describe("GOVUK.StaticTracker", function() {
     });
 
     it('calls the method', function() {
-      spyOn(GOVUK, 'cookie').and.callFake(function(name) {
-        if (name === "analytics_next_page_call") {
-          return '["trackPageview"]';
-        }
-
-        return null;
-      });
+      spyOn(GOVUK, 'cookie').and.returnValue('["trackPageview"]');
       tracker.callMethodRequestedByPreviousPage();
       expect(tracker.trackPageview).toHaveBeenCalledWith();
     });
 
     it('calls the method with given parameters', function() {
-      spyOn(GOVUK, 'cookie').and.callFake(function(name) {
-        if (name === "analytics_next_page_call") {
-          return '["trackPageview","/path","Title"]';
-        }
-
-        return null;
-      });
-
+      spyOn(GOVUK, 'cookie').and.returnValue('["trackPageview","/path","Title"]');
       tracker.callMethodRequestedByPreviousPage();
       expect(tracker.trackPageview).toHaveBeenCalledWith('/path', 'Title');
     });


### PR DESCRIPTION
__Do not merge until https://github.com/alphagov/frontend/pull/777 is deployed__

The technique for setting analytics calls for a following page was updated in https://github.com/alphagov/static/pull/560 and uses of the old technique updated in https://github.com/alphagov/frontend/pull/777.

* Remove shim
* Simplify tests