### PR TITLE
Fix failing test around option select

### DIFF
--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -278,7 +278,10 @@ describe('GOVUK.OptionSelect', function() {
     });
 
     it('expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items', function(){
-      $checkboxList.css({"max-height": 101});
+      $checkboxList.css({
+        "max-height": 200,
+        "width": 600
+      });
       optionSelect.setupHeight();
 
       // Wrapping HTML should not stretch as 251px is too big.


### PR DESCRIPTION
The Jasmine tests were failing on the command line with the following error:
```
GOVUK.OptionSelect setupHeight expands the checkbox-container just enough to cut the last visible item in half horizontally, if there are many items
  Expected 29 to be greater than 100.
    Error: Expected 29 to be greater than 100.
```

This test was, however, passing in the browser test runner.

The inconsistency is because of a difference between viewport sizes in the browser and command line test runners, which caused text to break onto a new line at different points. This pull request addresses this inconsistency by explicitly setting the height and width of the checkbox container in the failing test.