### PR TITLE
Remove analytics slimmer shims

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -3,21 +3,15 @@
   window.GOVUK = window.GOVUK || {};
 
   var StaticTracker = function(config) {
-    var classicQueue,
-        tracker;
-
-    classicQueue = getClassicAnalyticsQueue();
-    resetClassicAnalyticsQueue();
 
     // Create universal and classic analytics tracker
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/tracker.js
-    tracker = new GOVUK.Tracker(config);
+    var tracker = new GOVUK.Tracker(config);
     this.tracker = tracker;
 
     setPixelDensityDimension();
     setHTTPStatusCodeDimension();
-    shimClassicAnalyticsQueue(classicQueue);
     this.setDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
 
@@ -28,17 +22,6 @@
     GOVUK.analyticsPlugins.error();
     GOVUK.analyticsPlugins.printIntent();
 
-    function getClassicAnalyticsQueue() {
-      // Slimmer inserts custom variables into the ga-params script tag
-      // https://github.com/alphagov/slimmer/blob/master/lib/slimmer/processors/google_analytics_configurator.rb
-      // Pickout these variables before continuing
-      return (window._gaq && window._gaq.length) > 0 ? window._gaq.slice() : [];
-    }
-
-    function resetClassicAnalyticsQueue() {
-      window._gaq = [];
-    }
-
     function setPixelDensityDimension() {
       if (window.devicePixelRatio) {
         tracker.setDimension(11, window.devicePixelRatio, 'Pixel Ratio', 2);
@@ -47,19 +30,6 @@
 
     function setHTTPStatusCodeDimension() {
       tracker.setDimension(15, window.httpStatusCode || 200, 'httpStatusCode');
-    }
-
-    function shimClassicAnalyticsQueue(queue) {
-      $.each(queue, function(index, classicParams) {
-        if (classicParams[0] == "_setCustomVar") {
-          setDimensionFromCustomVariable(classicParams);
-        }
-      });
-    }
-
-    function setDimensionFromCustomVariable(customVar) {
-      // index, value, name, scope
-      tracker.setDimension(customVar[1], customVar[3], customVar[2], customVar[4]);
     }
 
   };

--- a/app/views/root/_google_analytics.html.erb
+++ b/app/views/root/_google_analytics.html.erb
@@ -1,9 +1,0 @@
-<script id="ga-params">
-  window.GOVUK = window.GOVUK || {};
-  window._gaq = window._gaq || [];
-  GOVUK.Analytics = GOVUK.Analytics || {};
-  <%#
-    Slimmer < 8.0.0 inserts custom variables here
-    Once all apps have been updated beyond this version, this can be removed
-  %>
-</script>

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,3 +1,2 @@
 <%= javascript_include_tag 'libs/jquery/jquery-1.7.2.js' %>
-<%= render partial: "google_analytics" %>
 <%= javascript_include_tag local_assigns[:js_file] || 'application' %>

--- a/spec/javascripts/analytics/static-tracker-spec.js
+++ b/spec/javascripts/analytics/static-tracker-spec.js
@@ -115,30 +115,6 @@ describe("GOVUK.StaticTracker", function() {
         expect(universalSetupArguments[5]).toEqual(['send', 'pageview']);
       });
     });
-
-    describe('when there is an existing queue of custom variables', function() {
-      beforeEach(function() {
-        window.ga.calls.reset();
-        window._gaq = [
-          ['_setCustomVar', 21, 'name', 'value', 3],
-          ['_setCustomVar', 10, 'name-2', 'value-2', 2]
-        ];
-        tracker = new GOVUK.StaticTracker({universalId: 'universal-id', classicId: 'classic-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
-      });
-
-      it('resets the queue before setup', function() {
-        expect(window._gaq[0]).toEqual(['_setAccount', 'classic-id']);
-      });
-
-      it('sets the custom variables as dimensions', function() {
-        expect(window._gaq[6]).toEqual(['_setCustomVar', 21, 'name', 'value', 3]);
-        expect(window._gaq[7]).toEqual(['_setCustomVar', 10, 'name-2', 'value-2', 2]);
-        expect(universalSetupArguments[4]).toEqual(['set', 'dimension21', 'value']);
-        expect(universalSetupArguments[5]).toEqual(['set', 'dimension10', 'value-2']);
-      });
-    });
-
   });
 
   describe('when tracking pageviews, events and custom dimensions', function() {


### PR DESCRIPTION
Now slimmer uses meta tags to convey page metadata and all apps have been updated to the latest slimmer (and deployed), the inline `<script>` tag and shims for resetting the original `_gaq` queue can
be removed.

This also removes the last uses of the `GOVUK.Analytics` namespace.

cc @benilovj 