### PR TITLE
Update libv8 to fix error on bundle install on OS X Yosemite

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     journey (1.0.4)
     json (1.8.1)
     kgio (2.7.4)
-    libv8 (3.16.14.3)
+    libv8 (3.16.14.7)
     link_header (0.0.7)
     logstash-event (1.1.5)
     logstasher (0.4.8)


### PR DESCRIPTION
I was seeing the following error when running `bundle install`:

    Unable to find a compiler officially supported by v8.
    It is recommended to use GCC v4.4 or higher
    Using compiler: g++

This then seems to have resulted in the following compilation error:

    ../src/cached-powers.cc:136:18: error: unused variable 'kCachedPowersLength' [-Werror,-Wunused-const-variable]
    static const int kCachedPowersLength = ARRAY_SIZE(kCachedPowers);
                     ^
I believe the problem was [fixed][1] between version 3.16.14.3 and version
3.16.14.7 of libv8 and a simple `bundle update libv8` seems to have done the
trick.

[1]: https://github.com/cowboyd/libv8/pull/124