### PR TITLE
On option select, only set height one time

### DIFF
--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -90,7 +90,9 @@
   OptionSelect.prototype.open = function open(){
     if (this.isClosed()) {
       this.$optionSelect.removeClass('js-closed');
-      this.setupHeight();
+      if (!this.$optionsContainer.prop('style').height) {
+        this.setupHeight();
+      }
     }
   };
 

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -161,9 +161,11 @@ describe('GOVUK.OptionSelect', function() {
       expect(optionSelect.isClosed()).toBe(false);
     });
 
-    it ('calls setupHeight()', function(){
+    it ('calls setupHeight(), once', function(){
       $optionSelectHTML.addClass('closed');
       spyOn(optionSelect, "setupHeight");
+      optionSelect.open();
+      expect(optionSelect.setupHeight.calls.count()).toBe(1);
       optionSelect.open();
       expect(optionSelect.setupHeight.calls.count()).toBe(1);
     });


### PR DESCRIPTION
Browsers maintain the scroll position of an option select even when they are closed. This confuses the code that tries to calculate the height of the container to cut off the last 'visible' item.

For some scroll positions this causes the container to get progressively shorter each time it is opened.

![error-option-select](https://cloud.githubusercontent.com/assets/355079/7179430/a553902c-e42f-11e4-944c-ee14e74f8b70.gif)

To fix this the option select should only have its height set once, the first time it is opened.