### PR TITLE
Change the text of the "Cymraeg" link in the footer

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -3,6 +3,6 @@
   <li><a href="/help">Help</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
-  <li><a href="/cymraeg">Cymraeg</a></li>
+  <li><a href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
 </ul>


### PR DESCRIPTION
- Research shows users think clicking the "Cymraeg" link will take
  them to a translated version of the page they are on, rather than a
  specific list of services GOV.UK has translated into Welsh. The
  phrase "Rhestr o Wasanaethau Cymraeg" better describes the nature of
  the page users are taken to.

Before:

![screen shot 2015-04-16 at 15 39 34](https://cloud.githubusercontent.com/assets/355033/7183348/d062f22a-e44e-11e4-9efd-1a5d07fb9174.png)

After:

![screen shot 2015-04-16 at 15 38 20](https://cloud.githubusercontent.com/assets/355033/7183329/b47d6cca-e44e-11e4-89f9-261667f7c864.png)

(The link text wraps "Built by the Government Digital Service" onto a new line, but according to the designers on our team, this is fine.)