### PR TITLE
AB test “Report a problem” design

### DIFF
--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -21,6 +21,8 @@
           variant_1: {variantId: 1, callback: renderVariant}
         }
       });
+
+      $form.on("reportAProblemForm.success", this.trackSuccessfulFeedback.bind(this));
     } else {
       renderOriginal();
     }
@@ -112,6 +114,13 @@
 
     if (ReportAProblem.isBeingTestedOnThisPage() && typeof GOVUK.analytics === "object") {
       GOVUK.analytics.trackEvent('ab-test-report-a-problem', 'was-page-useful', {label: wasUseful.toLowerCase()});
+    }
+  };
+
+  ReportAProblem.prototype.trackSuccessfulFeedback = function(evt) {
+    var variant = this.multivariateTest.getCohort();
+    if (typeof GOVUK.analytics === "object") {
+      GOVUK.analytics.trackEvent('ab-test-report-a-problem', 'feedback-submitted', {label: variant});
     }
   };
 

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -44,7 +44,14 @@
         ],
         slug = ReportAProblem.getCurrentSlug();
 
-    return slugsBeingTested.indexOf(slug) > -1;
+    for (var i = 0, l = slugsBeingTested.length; i < l; i++) {
+      // starts with
+      if (slug.indexOf(slugsBeingTested[i]) === 0) {
+        return true;
+      }
+    }
+
+    return false;
   };
 
   ReportAProblem.getCurrentSlug = function() {

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -28,7 +28,26 @@
   };
 
   ReportAProblem.isBeingTestedOnThisPage = function() {
-    return true;
+    var slugsBeingTested = [
+          '/bank-holidays',
+          '/vehicle-tax-rate-tables',
+          '/contact-the-dvla',
+          '/check-uk-visa',
+          '/life-in-the-uk-test',
+          '/government/publications/application-to-transfer-or-retain-a-vehicle-registration-number',
+          '/government/publications/income-tax-tax-relief-for-expenses-of-employment-p87',
+          '/calculate-state-pension',
+          '/calculate-your-holiday-entitlement',
+          '/am-i-getting-minimum-wage'
+        ],
+        slug = ReportAProblem.getCurrentSlug();
+
+    return slugsBeingTested.indexOf(slug) > -1;
+  };
+
+  ReportAProblem.getCurrentSlug = function() {
+    // no parameters or fragments
+    return window.location.pathname;
   };
 
   ReportAProblem.prototype.renderOriginal = function() {

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -11,7 +11,6 @@
 
     $form.on('reportAProblemForm.success', this.showConfirmation.bind(this));
     $form.on('reportAProblemForm.error', this.showError.bind(this));
-    $container.parent().on("click", ".js-report-a-problem-toggle", this.toggleForm.bind(this));
 
     if (ReportAProblem.isBeingTestedOnThisPage()) {
       this.multivariateTest = new GOVUK.MultivariateTest({
@@ -34,27 +33,85 @@
 
   ReportAProblem.prototype.renderOriginal = function() {
     this.addToggleLink();
-  };
-
-  ReportAProblem.prototype.renderVariant = function() {
-    this.addToggleLink();
+    this.$toggle.on("click", ".js-report-a-problem-toggle", this.toggleForm.bind(this));
   };
 
   ReportAProblem.prototype.addToggleLink = function() {
-    this.$container.before('\
+    this.$toggle = $('\
       <div class="report-a-problem-toggle-wrapper js-footer">\
         <p class="report-a-problem-toggle">\
           <a href="" class="js-report-a-problem-toggle">Is there anything wrong with this page?</a>\
         </p>\
       </div>');
+
+    this.$container.before(this.$toggle);
+  };
+
+  ReportAProblem.prototype.renderVariant = function() {
+    this.removeOriginalFormParts();
+    this.addVariantFormParts();
+    this.addYesNoLinks();
+
+    this.$toggle.on("click", ".js-report-a-problem-toggle", this.showFormAndHideOption.bind(this));
+    this.$toggle.on("click", ".js-report-a-problem-toggle", this.trackIfPageIsUseful.bind(this));
+  };
+
+  ReportAProblem.prototype.addYesNoLinks = function() {
+    this.$toggle = $('\
+      <div class="report-a-problem-toggle-wrapper was-this-useful js-footer">\
+        <div class="report-a-problem-toggle">\
+          <p>\
+            Was this page useful?\
+            <a href="#" data-useful="Yes" class="js-report-a-problem-toggle">Yes</a>\
+            <a href="#" data-useful="No" class="js-report-a-problem-toggle">No</a>\
+          <p>\
+        </div>\
+      </div>');
+
+    this.$container.before(this.$toggle);
+  };
+
+  ReportAProblem.prototype.removeOriginalFormParts = function() {
+    this.$container.find('.js-original-variant').remove();
+  };
+
+  ReportAProblem.prototype.addVariantFormParts = function() {
+    this.$container.find('form').prepend('\
+      <h2>Thanks. Your feedback has been recorded.</h2>\
+      <input type="hidden" name="what_doing" value="" />\
+      <label for="how-could-we-improve">How could we improve this page?</label>\
+      <textarea id="how-could-we-improve" name="what_wrong"></textarea>\
+      <p>This is anonymous feedback. Don’t include personal or financial information.</p>\
+      <p>We can’t reply to this form. If you want a reply, use the <a href="/contact">contact form</a> to send your questions or comments about the website.</p>\
+    ');
+  };
+
+  ReportAProblem.prototype.trackIfPageIsUseful = function(evt) {
+    var wasUseful = $(evt.target).data('useful');
+
+    this.$container.find('[name="what_doing"]').val('Was this page useful? ' + wasUseful)
+
+    if (ReportAProblem.isBeingTestedOnThisPage() && typeof GOVUK.analytics === "object") {
+      GOVUK.analytics.trackEvent('report-a-problem', 'was-page-useful', {label: wasUseful.toLowerCase()});
+    }
   };
 
   ReportAProblem.prototype.toggleForm = function(evt) {
     this.$container.toggle();
 
+    if (ReportAProblem.isBeingTestedOnThisPage() && typeof GOVUK.analytics === "object") {
+      GOVUK.analytics.trackEvent('report-a-problem', 'link-toggled');
+    }
+
     if ($(evt.target).is('a')) {
       evt.preventDefault();
     }
+  };
+
+  ReportAProblem.prototype.showFormAndHideOption = function(evt) {
+    this.$container.show();
+    this.$toggle.hide();
+    evt.preventDefault();
   };
 
   ReportAProblem.prototype.showConfirmation = function(evt, data) {

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -111,7 +111,7 @@
     this.$container.find('[name="what_doing"]').val('Was this page useful? ' + wasUseful)
 
     if (ReportAProblem.isBeingTestedOnThisPage() && typeof GOVUK.analytics === "object") {
-      GOVUK.analytics.trackEvent('report-a-problem', 'was-page-useful', {label: wasUseful.toLowerCase()});
+      GOVUK.analytics.trackEvent('ab-test-report-a-problem', 'was-page-useful', {label: wasUseful.toLowerCase()});
     }
   };
 
@@ -119,7 +119,7 @@
     this.$container.toggle();
 
     if (ReportAProblem.isBeingTestedOnThisPage() && typeof GOVUK.analytics === "object") {
-      GOVUK.analytics.trackEvent('report-a-problem', 'link-toggled');
+      GOVUK.analytics.trackEvent('ab-test-report-a-problem', 'link-toggled');
     }
 
     if ($(evt.target).is('a')) {

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -5,12 +5,38 @@
   var ReportAProblem = function ($container) {
     this.$container = $container;
     var $form = $container.find('form'),
-        form = new GOVUK.ReportAProblemForm($form);
+        form = new GOVUK.ReportAProblemForm($form),
+        renderOriginal = this.renderOriginal.bind(this),
+        renderVariant = this.renderVariant.bind(this);
 
-    $form.on("reportAProblemForm.success", this.showConfirmation.bind(this));
-    $form.on("reportAProblemForm.error", this.showError.bind(this));
+    $form.on('reportAProblemForm.success', this.showConfirmation.bind(this));
+    $form.on('reportAProblemForm.error', this.showError.bind(this));
     $container.parent().on("click", ".js-report-a-problem-toggle", this.toggleForm.bind(this));
 
+    if (ReportAProblem.isBeingTestedOnThisPage()) {
+      this.multivariateTest = new GOVUK.MultivariateTest({
+        name: 'report-a-problem-redesign-ab-test',
+        contentExperimentId: "SnpcHld1SJuQig-_SsaN_Q",
+        cohorts: {
+          variant_0: {variantId: 0, callback: renderOriginal},
+          variant_1: {variantId: 1, callback: renderVariant}
+        }
+      });
+    } else {
+      renderOriginal();
+    }
+
+  };
+
+  ReportAProblem.isBeingTestedOnThisPage = function() {
+    return true;
+  };
+
+  ReportAProblem.prototype.renderOriginal = function() {
+    this.addToggleLink();
+  };
+
+  ReportAProblem.prototype.renderVariant = function() {
     this.addToggleLink();
   };
 

--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -1,13 +1,14 @@
-.js-enabled .report-a-problem-container{
+.js-enabled .report-a-problem-container {
   display: none;
 }
 
-.report-a-problem-container{
+.report-a-problem-container {
   @extend %site-width-container;
   clear: both;
 
   .report-a-problem-inner {
     margin-bottom: 60px;
+
     .report-a-problem-content {
       max-width: 35em;
     }
@@ -60,12 +61,17 @@
   }
 }
 
-.report-a-problem-toggle{
+.report-a-problem-toggle {
   @include core-16;
   margin-bottom: 30px;
+  color: $secondary-text-colour;
 
-  a{
+  a {
     color: $secondary-text-colour;
+  }
+
+  p {
+    @include core-16;
   }
 
   @include ie-lte(7) {

--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -30,7 +30,6 @@
 
   p {
     @include core-19;
-    padding-bottom: 1em;
   }
 
   label {
@@ -41,20 +40,23 @@
     font-weight: bold;
   }
 
-  input {
-    &[type="text"] {
-      display: block;
-      @include core-19;
-      margin: 0 0 1em 0;
-      background-color: #f8f8f8;
-      border: 1px inset #bfc1c3;
-      padding: 0.3em 0 0.1em 0.4em;
-      width: 95%;
+  input[type="text"],
+  textarea {
+    display: block;
+    @include core-19;
+    margin: 0 0 1em 0;
+    background-color: #f8f8f8;
+    border: 1px inset #bfc1c3;
+    padding: 0.3em 0 0.1em 0.4em;
+    width: 95%;
 
-      @include ie-lte(7) {
-        width: 550px;
-      }
+    @include ie-lte(7) {
+      width: 550px;
     }
+  }
+
+  textarea {
+    height: 5em;
   }
 }
 
@@ -80,4 +82,8 @@
 .report-a-problem-toggle-wrapper {
   @extend %site-width-container;
   clear:both;
+}
+
+.was-this-useful a {
+  margin-left: 0.5em;
 }

--- a/app/views/root/report_a_problem.raw.html.erb
+++ b/app/views/root/report_a_problem.raw.html.erb
@@ -1,7 +1,7 @@
 <div class="report-a-problem-container">
   <div class="report-a-problem-inner">
     <div class="report-a-problem-content">
-      <h2>Help us improve GOV.UK</h2>
+      <h2 class="js-original-variant">Help us improve GOV.UK</h2>
       <form accept-charset="UTF-8" action="/contact/govuk/problem_reports" method="post">
         <div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="✓"></div>
         <input id="url" name="url" type="hidden" value="<%= h request_url %>">
@@ -12,14 +12,15 @@
           <input id="page_owner" name="page_owner" type="hidden" value="<%= page_owner %>">
         <% end %>
 
-        <p>Don’t include personal or financial information, eg your National Insurance number or credit card details.</p>
+        <div class="js-original-variant">
+          <p>Don’t include personal or financial information, eg your National Insurance number or credit card details.</p>
 
-        <label for="what_doing">What you were doing</label>
-        <input id="what_doing" name="what_doing" type="text" />
+          <label for="what_doing">What you were doing</label>
+          <input id="what_doing" name="what_doing" type="text" />
 
-        <label for="what_wrong">What went wrong</label>
-        <input id="what_wrong" name="what_wrong" type="text" />
-
+          <label for="what_wrong">What went wrong</label>
+          <input id="what_wrong" name="what_wrong" type="text" />
+        </div>
         <div class="button-wrapper">
           <button name="commit" type="submit" class="button">Send</button>
         </div>

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -1,44 +1,100 @@
 describe("form submission for reporting a problem", function () {
-  var FORM_TEXT = '<div class="report-a-problem-container">' +
-                    '<div class="report-a-problem-content">' +
-                      '<form><button class="button" name="button" type="submit">Send</button></form>' +
-                    '</div>' +
-                  '</div>';
-  var form;
+  var $form, reportAProblem;
 
   beforeEach(function() {
-    setFixtures(FORM_TEXT);
+    setFixtures('<div class="report-a-problem-container">\
+                      <div class="report-a-problem-content">\
+                          <form><button class="button" name="button" type="submit">Send</button></form>\
+                      </div>\
+                 </div>');
     $form = $('form');
-    new GOVUK.ReportAProblem($('.report-a-problem-container'));
   });
 
-  describe("clicking on the toggle", function(){
-    it("should toggle the visibility of the form", function() {
-      expect($form).toBeVisible();
-      $('.js-report-a-problem-toggle').click();
-      expect($form).toBeHidden();
-      $('.js-report-a-problem-toggle').click();
-      expect($form).toBeVisible();
+  describe("when not included in redesign test", function() {
+
+    beforeEach(function() {
+        spyOn(GOVUK.ReportAProblem, 'isBeingTestedOnThisPage').and.returnValue(false);
+        spyOn(GOVUK, 'MultivariateTest');
+        reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+    });
+
+    it("does not create a multivariate test", function(){
+        expect(GOVUK.MultivariateTest).not.toHaveBeenCalled();
+        expect(reportAProblem.multivariateTest).toBe(undefined);
+    });
+
+    testBehaviour();
+  });
+
+  describe("when included in redesign test", function() {
+
+    beforeEach(function() {
+      spyOn(GOVUK.ReportAProblem, 'isBeingTestedOnThisPage').and.returnValue(true);
+    });
+
+    it('creates a multivariate test', function() {
+      reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      expect(reportAProblem.multivariateTest.name).toBe('report-a-problem-redesign-ab-test');
+    });
+
+    describe("when showing original variant", function(){
+      beforeEach(function() {
+        spyOn(GOVUK, 'cookie').and.returnValue('variant_0');
+        reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      });
+
+      it('uses variant_0', function() {
+        expect(reportAProblem.multivariateTest.getCohort()).toBe('variant_0');
+      });
+
+      testBehaviour();
+    });
+
+    describe("when showing new variant", function(){
+      beforeEach(function() {
+        spyOn(GOVUK, 'cookie').and.returnValue('variant_1');
+        reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      });
+
+      it('uses variant_1', function() {
+        expect(reportAProblem.multivariateTest.getCohort()).toBe('variant_1');
+      });
+
+      testBehaviour();
     });
   });
 
-  describe("if the request succeeds", function() {
-    it("should replace the form with the response from the AJAX call", function() {
 
-      $form.trigger('reportAProblemForm.success', {message: 'great success!'});
+  function testBehaviour() {
 
-      expect($form).toBeHidden();
-      expect($('.report-a-problem-content').html()).toEqual('great success!');
+    describe("clicking on the toggle", function(){
+      it("should toggle the visibility of the form", function() {
+        expect($form).toBeVisible();
+        $('.js-report-a-problem-toggle').click();
+        expect($form).toBeHidden();
+        $('.js-report-a-problem-toggle').click();
+        expect($form).toBeVisible();
+      });
     });
-  });
 
-  describe("if the request has failed", function() {
-    it("should display an error message", function() {
+    describe("if the request succeeds", function() {
+      it("should replace the form with the response from the AJAX call", function() {
 
-      $form.trigger('reportAProblemForm.error');
+        $form.trigger('reportAProblemForm.success', {message: 'great success!'});
 
-      expect($form).not.toBeVisible();
-      expect($('.report-a-problem-content').html()).toContain("Sorry, we’re unable to receive your message");
+        expect($form).toBeHidden();
+        expect($('.report-a-problem-content').html()).toEqual('great success!');
+      });
     });
-  });
+
+    describe("if the request has failed", function() {
+      it("should display an error message", function() {
+
+        $form.trigger('reportAProblemForm.error');
+
+        expect($form).not.toBeVisible();
+        expect($('.report-a-problem-content').html()).toContain("Sorry, we’re unable to receive your message");
+      });
+    });
+  }
 });

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -16,6 +16,14 @@ describe("form submission for reporting a problem", function () {
     $('.report-a-problem-container').hide();
   });
 
+  describe("when on a page that's part of an ab test", function() {
+    it("creates a multivariate test", function() {
+      spyOn(GOVUK.ReportAProblem, 'getCurrentSlug').and.returnValue('/life-in-the-uk-test');
+      reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      expect(reportAProblem.multivariateTest.name).toBe('report-a-problem-redesign-ab-test');
+    });
+  });
+
   describe("when not included in redesign test", function() {
 
     beforeEach(function() {

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -16,11 +16,23 @@ describe("form submission for reporting a problem", function () {
     $('.report-a-problem-container').hide();
   });
 
-  describe("when on a page that's part of an ab test", function() {
-    it("creates a multivariate test", function() {
+  describe("when on a page that might be part of an ab test", function() {
+    it("creates a multivariate test if the slug matches", function() {
       spyOn(GOVUK.ReportAProblem, 'getCurrentSlug').and.returnValue('/life-in-the-uk-test');
       reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
       expect(reportAProblem.multivariateTest.name).toBe('report-a-problem-redesign-ab-test');
+    });
+
+    it("creates a multivariate test if the start of the slug matches", function() {
+      spyOn(GOVUK.ReportAProblem, 'getCurrentSlug').and.returnValue('/life-in-the-uk-test/sub/page/y/answer?page');
+      reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      expect(reportAProblem.multivariateTest.name).toBe('report-a-problem-redesign-ab-test');
+    });
+
+    it("does not create a multivariate test if the slug isn’t being tested", function() {
+      spyOn(GOVUK.ReportAProblem, 'getCurrentSlug').and.returnValue('/not-tested');
+      reportAProblem = new GOVUK.ReportAProblem($('.report-a-problem-container'));
+      expect(reportAProblem.multivariateTest).toBe(undefined);
     });
   });
 

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -65,7 +65,7 @@ describe("form submission for reporting a problem", function () {
       it('tracks an event when the form is toggled', function() {
         spyOn(GOVUK.analytics, 'trackEvent');
         $('.js-report-a-problem-toggle').first().click();
-        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('report-a-problem', 'link-toggled');
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'link-toggled');
       });
 
       testToggleBehaviour();
@@ -92,10 +92,10 @@ describe("form submission for reporting a problem", function () {
         spyOn(GOVUK.analytics, 'trackEvent');
 
         $('[data-useful=No]').click();
-        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('report-a-problem', 'was-page-useful', {label: 'no'});
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'was-page-useful', {label: 'no'});
 
         $('[data-useful=Yes]').click();
-        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('report-a-problem', 'was-page-useful', {label: 'yes'});
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'was-page-useful', {label: 'yes'});
       });
 
       it('records yes or no in a hidden input', function() {

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -68,6 +68,12 @@ describe("form submission for reporting a problem", function () {
         expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'link-toggled');
       });
 
+      it("tracks successfully submitted feedback", function() {
+        spyOn(GOVUK.analytics, 'trackEvent');
+        $form.trigger('reportAProblemForm.success', {message: 'great success!'});
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'feedback-submitted', {label: 'variant_0'});
+      });
+
       testToggleBehaviour();
       testRequestHandlingBehaviour();
     });
@@ -104,6 +110,12 @@ describe("form submission for reporting a problem", function () {
 
         $('[data-useful=Yes]').click();
         expect($form.find('[name=what_doing]').val()).toBe('Was this page useful? Yes');
+      });
+
+      it("tracks successfully submitted feedback", function() {
+        spyOn(GOVUK.analytics, 'trackEvent');
+        $form.trigger('reportAProblemForm.success', {message: 'great success!'});
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('ab-test-report-a-problem', 'feedback-submitted', {label: 'variant_1'});
       });
 
       testRequestHandlingBehaviour();


### PR DESCRIPTION
On specified pages, create a multivariate test showing a new report a problem design.

The design:
* collects quantitative data about the page's usefulness which gets sent to Google Analytics
* analytics also tracks opening and closing of original form on test pages, and successfully submitted feedback for both variants
* hides the yes/no links and asks for more details about problems
* forms are still submitted to the same endpoint, but the "what doing" field is pre-filled and hidden

![screen shot 2015-04-28 at 11 18 43](https://cloud.githubusercontent.com/assets/319055/7367642/dbece706-ed98-11e4-90dc-39939ba694e6.png)

![screen shot 2015-04-28 at 11 18 51](https://cloud.githubusercontent.com/assets/319055/7367643/dbee75b2-ed98-11e4-9a76-9a256822cb73.png)

cc @binaryberry @benilovj