### PR TITLE
Fix style names for the previous/next component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
@@ -33,7 +33,7 @@
         background-color: $canvas-colour;
       }
 
-      .pagination-label {
+      .pagination-part-title {
         @include core-27($line-height: (33.75 / 27));
         margin-bottom: 0.1em;
         display: block;
@@ -74,7 +74,7 @@
     &.previous-page a {
       padding: 0.75em 0 0.75em 3em;
     }
-    
+
     &.next-page a {
       padding: 0.75em 3em 0.75em 0;
     }

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -3,17 +3,17 @@
     <% if local_assigns.include?(:previous_page) %>
       <li class="previous-page">
         <a href="<%= previous_page['url'] %>" rel="previous" >
-          <span class="pagination-label"><%= previous_page['title'] %></span> 
-          <span class="pagination-part-title"><%= previous_page['label'] %></span>
-        </a>           
+          <span class="pagination-part-title"><%= previous_page['title'] %></span>
+          <span class="pagination-label"><%= previous_page['label'] %></span>
+        </a>
       </li>
     <% end %>
     <% if local_assigns.include?(:next_page) %>
       <li class="next-page">
         <a href="<%= next_page['url'] %>" rel="next">
-          <span class="pagination-label"><%= next_page['title'] %></span> 
-          <span class="pagination-part-title"><%= next_page['label'] %></span>
-        </a>           
+          <span class="pagination-part-title"><%= next_page['title'] %></span>
+          <span class="pagination-label"><%= next_page['label'] %></span>
+        </a>
       </li>
     <% end %>
   </ul>


### PR DESCRIPTION
This fixes the mismatch between the 'title' and 'label' classes
and the interface of the component. The component interface stays
as before.