### PR TITLE
Add cross domain tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk_frontend_toolkit', '3.4.2'
+gem 'govuk_frontend_toolkit', '3.5.0'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (3.4.2)
+    govuk_frontend_toolkit (3.5.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.10.1)
@@ -175,7 +175,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 7.18.0)
-  govuk_frontend_toolkit (= 3.4.2)
+  govuk_frontend_toolkit (= 3.5.0)
   govuk_template (= 0.10.1)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.10.6)

--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -111,6 +111,10 @@
     this.tracker.trackShare(network);
   };
 
+  StaticTracker.prototype.addLinkedTrackerDomain = function(trackerId, name, domain) {
+    this.tracker.addLinkedTrackerDomain(trackerId, name, domain);
+  };
+
   StaticTracker.prototype.setSectionDimension = function(section) {
     this.setDimension(1, section, 'Section');
   };


### PR DESCRIPTION
This adds the cross domain tracking functionality from https://github.com/alphagov/govuk_frontend_toolkit/pull/185 to static, making it globally available.