### PR TITLE
Remove robots blocking of /apply-for-a-licence

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,7 +8,6 @@ Allow: /licence-finder
 # We only allow indexing of the finance finder landing page
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
-Disallow: /apply-for-a-licence
 # Don't allow indexing of user needs pages
 Disallow: /info/*
 Sitemap: https://www.gov.uk/sitemap.xml


### PR DESCRIPTION
This was added in 2012, and /apply-for-a-licence doesn't now exist
(or rather, it's a redirect to /licence-finder).

Also, robots.txt exclusions are prefixes, so this line was also banning
https://www.gov.uk/apply-for-a-licence-to-use-an-orphan-work from being
indexed.  In turn, this was causing search engines such as Google and
Bing to display a description for this page of "A description for this
result is not available because of this site's robots.txt".  Further,
Bing was attempting to guess a title from the URL and other off-page
information, and was picking "How to Apply for a License to Use an
Orphan Work"; note the incorrect spelling of "License".