### PR TITLE
Fix robots blocking of /apply-for-a-licence

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -8,7 +8,7 @@ Allow: /licence-finder
 # We only allow indexing of the finance finder landing page
 Disallow: /business-finance-support-finder/*
 Allow: /business-finance-support-finder
-Disallow: /apply-for-a-licence
+Disallow: /apply-for-a-licence/
 # Don't allow indexing of user needs pages
 Disallow: /info/*
 Sitemap: https://www.gov.uk/sitemap.xml


### PR DESCRIPTION
Content under /apply-for-a-licence/ should be blocked from robots,
because we want people to access it via the license start pages (eg, via
https://www.gov.uk/temporary-events-notice/westminster/apply for
https://www.gov.uk/apply-for-a-licence/temporary-event-notice/westminster/apply-1)
which have more explanatory content, and rank well in search.

However, robots.txt exclusions are prefixes, so this line was also
banning https://www.gov.uk/apply-for-a-licence-to-use-an-orphan-work
from being indexed.  In turn, this was causing search engines such as
Google and Bing to display a description for this page of "A description
for this result is not available because of this site's robots.txt".
Further, Bing was attempting to guess a title from the URL and other
off-page information, and was picking "How to Apply for a License to Use
an Orphan Work"; note the incorrect spelling of "License".

Adding a trailing / to the exclusion line should avoid it catching such
cases.