### PR TITLE
Remove absolute positioning from option-select

### DIFF
--- a/app/assets/stylesheets/govuk-component/_option-select.scss
+++ b/app/assets/stylesheets/govuk-component/_option-select.scss
@@ -60,7 +60,6 @@
     input {
       margin-left: -23px;
       vertical-align: top;
-      position: absolute;
     }
   }
 


### PR DESCRIPTION
The positioning isn't needed and it's very broken in ie6. I know we don't technically support ie6 anymore, but this is an easy fix that removes something that was added in error and takes the component from being unusable in ie6 to working.

Before
![screen shot 2015-05-13 at 13 59 11](https://cloud.githubusercontent.com/assets/68009/7610918/731678d2-f978-11e4-94e3-8ad93a770514.png)

After
![screen shot 2015-05-13 at 13 58 33](https://cloud.githubusercontent.com/assets/68009/7610919/74540aac-f978-11e4-8652-67dd678d3c06.png)
