### PR TITLE
Remove trailing comma from JS

### DIFF
--- a/app/assets/javascripts/report-a-problem-form.js
+++ b/app/assets/javascripts/report-a-problem-form.js
@@ -57,7 +57,7 @@
       success: this.triggerSuccess.bind(this),
       error: this.handleError.bind(this),
       statusCode: {
-        500: this.triggerError.bind(this),
+        500: this.triggerError.bind(this)
       }
     });
   };


### PR DESCRIPTION
This trailing comma is throwing errors in ie7 and 6 causing none of the
JavaScript to work in dev for those browsers. Luckily the minification
used on the live site strips the commas out anyway so this is only an
issue in development.