### PR TITLE
Add close on load to govuk-option-select

### DIFF
--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -40,7 +40,9 @@
       // Add a listener to the checkboxes so if you navigate to them with the keyboard you can definitely see them
       this.$options.on('focus', this.open.bind(this));
 
-      this.close();
+      if (this.$optionSelect.data('closed-on-load') == true) {
+        this.close();
+      }
     }
   }
 

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -372,12 +372,27 @@
         - value: "spain"
           label: "Spain"
           id: "spain"
+    closed_on_load:
+      key: "closed_on_load"
+      title: "List of hats"
+      closed_on_load: true
+      options_container_id: "list_of_hats"
+      options:
+        - value: "bobble_hat"
+          label: "Bobble hat"
+          id: "bobble_hat"
+        - value: "fez"
+          label: "Fez"
+          id: "fez"
+        - value: "sombrero"
+          label: "Sombrero"
+          id: "sombrero"
 - id: "previous_and_next_navigation"
   name: "Previous and next navigation"
   description: "Navigational links that allow users navigate within a series of pages or elements."
   body: |
     This component accepts 2 optional parameters, previous and next.
-    
+
     Each optional parameter accepts:
 
     - an URL for the link

--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-option-select">
+<div class="govuk-option-select" <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>>
   <div class="container-head js-container-head">
     <div class='option-select-label'><%= title %></div>
   </div>

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -64,6 +64,28 @@ describe('GOVUK.OptionSelect', function() {
     $optionSelectHTML.remove();
   });
 
+
+  it('instantiates a closed option-select if data-closed-on-load is true', function(){
+    $closedOnLoadFixture = $('<div class="govuk-option-select" data-closed-on-load=true></div>');
+    $('body').append($closedOnLoadFixture);
+    optionSelect = new GOVUK.OptionSelect({$el:$closedOnLoadFixture});
+    expect(optionSelect.isClosed()).toBe(true);
+  });
+
+  it('instantiates an open option-select if data-closed-on-load is false', function(){
+    $openOnLoadFixture = $('<div class="govuk-option-select" data-closed-on-load="false"></div>');
+    $('body').append($openOnLoadFixture);
+    optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
+    expect(optionSelect.isClosed()).toBe(false);
+  });
+
+  it('instantiates an open option-select if data-closed-on-load is not present', function(){
+    $openOnLoadFixture = $('<div class="govuk-option-select"></div>');
+    $('body').append($openOnLoadFixture);
+    optionSelect = new GOVUK.OptionSelect({$el:$openOnLoadFixture});
+    expect(optionSelect.isClosed()).toBe(false);
+  });
+
   describe('replaceHeadWithButton', function(){
     it ("replaces the `div.container-head` with a button", function(){
       expect($optionSelectHTML.find('button')).toBeDefined();
@@ -87,30 +109,28 @@ describe('GOVUK.OptionSelect', function() {
   });
 
   describe('open', function(){
+    beforeEach(function(){
+      spyOn(optionSelect, "isClosed").and.returnValue(true);
+    });
 
     it ('calls isClosed() and opens if isClosed is true', function(){
-      spyOn(optionSelect, "isClosed").and.returnValue(true);
       optionSelect.open();
       expect(optionSelect.isClosed.calls.count()).toBe(1);
       expect($optionSelectHTML.hasClass('js-closed')).toBe(false);
     });
 
     it('opens the option-select', function(){
-      optionSelect.close();
-      expect(optionSelect.isClosed()).toBe(true);
       optionSelect.open();
-      expect(optionSelect.isClosed()).toBe(false);
+      expect($optionSelectHTML.hasClass('js-closed')).toBe(false);
     });
 
     it ('calls setupHeight()', function(){
-      $optionSelectHTML.addClass('closed');
       spyOn(optionSelect, "setupHeight");
       optionSelect.open();
       expect(optionSelect.setupHeight.calls.count()).toBe(1);
     });
 
     it ('doesn\'t call setupHeight() if a height has already been set', function(){
-      $optionSelectHTML.addClass('closed');
       optionSelect.setContainerHeight(100);
       spyOn(optionSelect, "setupHeight");
       optionSelect.open();


### PR DESCRIPTION
So that clients of this component can specify if the option-select is
open or closed on load. This PR makes the default open, requiring
a parameter (`closed_on_load`) to be set to true if the component 
should be loaded as closed instead.

In http://github.com/alphagov/finder-frontend / http://gov.uk/cma-cases 
(which is the first client of this component) the first option-select on the 
page load is open with has the rest closed.


This PR:
- Adds a new optional parameter: `closed_on_load`.
- Adds a fixture to the docs for `closed_on_load`
- Changes the view to append a data-attribute `data-closed-on-load`
which is then read by the JavaScript and used to determine if the
option-select should call `.close()` on itself at the end of
initialisation
- Refactors the specs for `.open()` to handle the new initialisation
which is open by default not closed
- Adds a test for the reading of `data-closed-on-load`