### PR TITLE
Track rendering application

### DIFF
--- a/app/assets/javascripts/analytics/static-tracker.js
+++ b/app/assets/javascripts/analytics/static-tracker.js
@@ -89,6 +89,7 @@
     this.setPoliticalStatusDimension(dimensions['political-status']);
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
+    this.setRenderingApplicationDimension(dimensions['rendering-application']);
   };
 
   StaticTracker.prototype.trackPageview = function(path, title) {
@@ -145,6 +146,10 @@
 
   StaticTracker.prototype.setWorldLocationsDimension = function(locations) {
     this.setDimension(10, locations, 'WorldLocations');
+  };
+
+  StaticTracker.prototype.setRenderingApplicationDimension = function(app) {
+    this.setDimension(20, app, 'RenderingApps');
   };
 
   StaticTracker.prototype.setSearchPositionDimension = function(position) {


### PR DESCRIPTION
The rendering application is being set in a meta-tag. Send this
information to Google so we can start segmenting data by it.

This makes use of this slimmer change: https://github.com/alphagov/slimmer/pull/126