### PR TITLE
Stop tracking Need IDs as custom dimensions

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -83,7 +83,6 @@
 
     this.setSectionDimension(dimensions['section']);
     this.setFormatDimension(dimensions['format']);
-    this.setNeedIDsDimension(dimensions['need-ids']);
     this.setResultCountDimension(dimensions['search-result-count']);
     this.setPublishingGovernmentDimension(dimensions['publishing-government']);
     this.setPoliticalStatusDimension(dimensions['political-status']);
@@ -122,10 +121,6 @@
 
   StaticAnalytics.prototype.setFormatDimension = function(format) {
     this.setDimension(2, format);
-  };
-
-  StaticAnalytics.prototype.setNeedIDsDimension = function(ids) {
-    this.setDimension(3, ids);
   };
 
   StaticAnalytics.prototype.setResultCountDimension = function(count) {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -57,7 +57,6 @@ describe("GOVUK.StaticAnalytics", function() {
         $('head').append('\
           <meta name="govuk:section" content="section">\
           <meta name="govuk:format" content="format">\
-          <meta name="govuk:need-ids" content="1,2,3">\
           <meta name="govuk:search-result-count" content="1000">\
           <meta name="govuk:publishing-government" content="2005-to-2010-labour-government">\
           <meta name="govuk:political-status" content="historic">\
@@ -70,12 +69,11 @@ describe("GOVUK.StaticAnalytics", function() {
 
         expect(universalSetupArguments[4]).toEqual(['set', 'dimension1', 'section']);
         expect(universalSetupArguments[5]).toEqual(['set', 'dimension2', 'format']);
-        expect(universalSetupArguments[6]).toEqual(['set', 'dimension3', '1,2,3']);
-        expect(universalSetupArguments[7]).toEqual(['set', 'dimension5', '1000']);
-        expect(universalSetupArguments[8]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
-        expect(universalSetupArguments[9]).toEqual(['set', 'dimension7', 'historic']);
-        expect(universalSetupArguments[10]).toEqual(['set', 'dimension9', '<D10>']);
-        expect(universalSetupArguments[11]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(universalSetupArguments[6]).toEqual(['set', 'dimension5', '1000']);
+        expect(universalSetupArguments[7]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
+        expect(universalSetupArguments[8]).toEqual(['set', 'dimension7', 'historic']);
+        expect(universalSetupArguments[9]).toEqual(['set', 'dimension9', '<D10>']);
+        expect(universalSetupArguments[10]).toEqual(['set', 'dimension10', '<W1>']);
       });
 
       it('ignores meta tags not set', function() {


### PR DESCRIPTION
Need ID data isn’t being used. Allow dimension slot to be re-used for other data.
(The Need ID dimension was missed when we were deprecating unused dimensions back in February)