### PR TITLE
Upgrade govuk_frontend_toolkit gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ end
 
 gem 'plek', '1.7.0'
 
-gem 'govuk_frontend_toolkit', '4.0.0'
+gem 'govuk_frontend_toolkit', '4.0.1'
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"
 else

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -55,7 +55,7 @@ GEM
       null_logger
       plek
       rest-client (~> 1.6.3)
-    govuk_frontend_toolkit (4.0.0)
+    govuk_frontend_toolkit (4.0.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.13.0)
@@ -175,7 +175,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 7.18.0)
-  govuk_frontend_toolkit (= 4.0.0)
+  govuk_frontend_toolkit (= 4.0.1)
   govuk_template (= 0.13.0)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.10.6)


### PR DESCRIPTION
4.0.1 fixes the beta label to be multiline.

Related: https://github.com/alphagov/govuk_frontend_toolkit/pull/197

Trello: https://trello.com/c/H9UMp051/139-allow-topic-subtopics-to-be-labelled-as-beta