### PR TITLE
Support symbol and string keys for some components

### DIFF
--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -5,24 +5,24 @@
   <div class='options-container' id='<%= options_container_id %>'>
     <div class='js-auto-height-inner'>
       <% options.each do | option |%>
-
-      <label for='<%= option['id'] %>'>
+      <% option = option.with_indifferent_access %>
+      <label for='<%= option[:id] %>'>
         <input
         name="<%= key %>[]"
-        value="<%= option['value']%>"
-        id="<%= option['id']%>"
+        value="<%= option[:value]%>"
+        id="<%= option[:id]%>"
         type="checkbox"
 
         <% if local_assigns.include?(:aria_controls_id) %>
           aria-controls="<%= aria_controls_id %>"
         <% end %>
 
-        <% if option['checked'].present? %>
+        <% if option[:checked].present? %>
           checked="checked"
         <% end %>
 
         >
-        <%= option['label']%>
+        <%= option[:label] %>
         </label>
       <% end %>
     </div>

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -1,18 +1,20 @@
 <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>
+      <% previous_page = previous_page.with_indifferent_access %>
       <li class="previous-page">
-        <a href="<%= previous_page['url'] %>" rel="previous" >
-          <span class="pagination-part-title"><%= previous_page['title'] %></span>
-          <span class="pagination-label"><%= previous_page['label'] %></span>
+        <a href="<%= previous_page[:url] %>" rel="previous" >
+          <span class="pagination-part-title"><%= previous_page[:title] %></span>
+          <span class="pagination-label"><%= previous_page[:label] %></span>
         </a>
       </li>
     <% end %>
     <% if local_assigns.include?(:next_page) %>
+      <% next_page = next_page.with_indifferent_access %>
       <li class="next-page">
-        <a href="<%= next_page['url'] %>" rel="next">
-          <span class="pagination-part-title"><%= next_page['title'] %></span>
-          <span class="pagination-label"><%= next_page['label'] %></span>
+        <a href="<%= next_page[:url] %>" rel="next">
+          <span class="pagination-part-title"><%= next_page[:title] %></span>
+          <span class="pagination-label"><%= next_page[:label] %></span>
         </a>
       </li>
     <% end %>


### PR DESCRIPTION
This is a transitional change to switch components that expect
string key'd objects to handle symbol key'd objects only.

We should only use one style of keys for objects used in components,
to avoid reduce confusion when using components (I spent a while
trying to work out why the arguments I was passing to prev/next
weren't rendering). Consistency is good.

After discussion with @edds we agreed to use symbols consistently,
as this makes more sense in a ruby/rails environment.

The first step is to support both, as clients of those components
will still be sending string key;d objects and can't be updated
at the time as this app, so we have to;

1. Support both kinds of keys on components that expect strings
2. Update [clients sending string keys](https://github.com/search?utf8=%E2%9C%93&q=govuk_component%2Foption_select+OR+govuk_component%2Fprevious_and_next_navigation+repo%3Aalphagov%2Fcalendars+repo%3Aalphagov%2Fcollections+repo%3Aalphagov%2Fdesign-principles+repo%3Aalphagov%2Ffeedback+repo%3Aalphagov%2Fcourts-frontend+repo%3Aalphagov%2Fcalculators+repo%3Aalphagov%2Flicence-finder+repo%3Aalphagov%2Ffrontend+repo%3Aalphagov%2Fgovernment-frontend+repo%3Aalphagov%2Fsmart-answers+repo%3Aalphagov%2Finfo-frontend+repo%3Aalphagov%2Fcontacts-frontend+repo%3Aalphagov%2Fmanuals-frontend+repo%3Aalphagov%2Fspecialist-frontend+repo%3Aalphagov%2Ffinder-frontend+repo%3Aalphagov%2Fbusiness-support-finder+repo%3Aalphagov%2Fwhitehall+repo%3Aalphagov%2Fstatic&type=Code&ref=searchresults) to use symbols instead
3. Remove support for string keys from these components

This PR is step 1., and using `with_indifferent_access` is a quick
hack to support both, which we can remove at step 3.