### PR TITLE
Only support symbol keys in component arguments

### DIFF
--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -5,7 +5,6 @@
   <div class='options-container' id='<%= options_container_id %>'>
     <div class='js-auto-height-inner'>
       <% options.each do | option |%>
-      <% option = option.with_indifferent_access %>
       <label for='<%= option[:id] %>'>
         <input
         name="<%= key %>[]"

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -1,7 +1,6 @@
 <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>
-      <% previous_page = previous_page.with_indifferent_access %>
       <li class="previous-page">
         <a href="<%= previous_page[:url] %>" rel="previous" >
           <span class="pagination-part-title"><%= previous_page[:title] %></span>
@@ -10,7 +9,6 @@
       </li>
     <% end %>
     <% if local_assigns.include?(:next_page) %>
-      <% next_page = next_page.with_indifferent_access %>
       <li class="next-page">
         <a href="<%= next_page[:url] %>" rel="next">
           <span class="pagination-part-title"><%= next_page[:title] %></span>


### PR DESCRIPTION
This removes transitional change that supported accessing by string
or symbol key.

Once clients calling components with string keys have been updated
to use symbol keys this can be merged.

Related:
 - https://github.com/alphagov/finder-frontend/pull/217
 - https://github.com/alphagov/manuals-frontend/pull/147

It's worth reading the discussion on the PR that added the transitional support for either kind of key, it outlines the reasoning there: https://github.com/alphagov/static/pull/601