### PR TITLE
Add doc note on keys vs string for objects

### DIFF
--- a/doc/govuk-components.md
+++ b/doc/govuk-components.md
@@ -35,6 +35,8 @@ To match rails view convention the partial itself should use an underscore, rath
 </div>
 ```
 
+_Note_: For consistency with other components, and Rails convention, you should only use `:symbols`, rather than `"strings"`, for object keys.
+
 2) There is a SCSS module at `app/stylesheets/govuk-component/_your-component-name.scss` - there should be a single root class, the same class on the root of the partial. For example:
 ```
 .govuk-your-component-name {
@@ -55,3 +57,5 @@ To match rails view convention the partial itself should use an underscore, rath
 
 Adding it to the documentation will allow you to preview it in the `govuk_component_guide`, which can be pointed to any
 version of static, including your local one running a branch. Which you should probably do.
+
+


### PR DESCRIPTION
Some components templates in static were using symbol keys and 
others strings, which was inconsistent and confusing, by only using
symbols we avoid confusion.

Tools like the component guide have been updated so they will
obviously error when strings are used - previously it silently
corrected any string/key mismatch.

More here: https://github.com/alphagov/govuk-component-guide/pull/20

I just took some time cleaning things up to only use symbols, so it
seemed worth doc'ing somewhere. That said, i'm not sure this is a 
well phrased bit of documentation, would appreciate thoughts, 
especially from those who've made component changes, like 
@jackscotti or @alicebartlett.

