### PR TITLE
Update visa-immigration link

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -61,7 +61,7 @@
         <li><a href="/browse/housing-local-services">Housing and local services</a></li>
         <li><a href="/browse/tax">Money and tax</a></li>
         <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
-        <li><a href="/visas-immigration">Visas and immigration</a></li>
+        <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
         <li><a href="/browse/working">Working, jobs and pensions</a></li>
       </ul>
     </div>


### PR DESCRIPTION
The link in the footer on still goes to /visas-immigration
which redirects to /browse/visas-immigration.

This breaks the In-Page Analytics view in Google Analytics,
because the next page tracked doesn't match the link.

Updated to go directly to /browse/visas-immigration.