### PR TITLE
Fix retina bug for option-select arrows

### DIFF
--- a/app/assets/stylesheets/govuk-component/_option-select.scss
+++ b/app/assets/stylesheets/govuk-component/_option-select.scss
@@ -89,6 +89,7 @@
 
         @include device-pixel-ratio() {
           background-size: 32px 50px;
+          background: image-url('govuk-component/option-select-toggle-sprite.png') no-repeat right 5px;
         }
 
         &:hover {


### PR DESCRIPTION
Although the retina file is included in the project already, for some
reason I never actually added it. So, this commit uses the file.

Pivotal: https://www.pivotaltracker.com/story/show/97293160

Before:
![screen shot 2015-06-23 at 15 40 09](https://cloud.githubusercontent.com/assets/68009/8308706/3f01eee4-19be-11e5-9e2f-22359aad9b3d.png)

After:
![screen shot 2015-06-23 at 15 40 20](https://cloud.githubusercontent.com/assets/68009/8308708/43a4f1b2-19be-11e5-81de-871867818666.png)