### PR TITLE
Show closing quote on govspeak blockquotes

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -156,7 +156,7 @@
         padding-left: $gutter;
       }
 
-     &:before {
+      &:before {
         content: "\201C";
         float: left;
         clear: both;
@@ -183,7 +183,7 @@
         padding-left: 0;
       }
 
-     &:before {
+      &:before {
         content: "\201D";
         float: right;
         margin-right: -$gutter-half;

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -163,7 +163,7 @@
         margin-left: -$gutter-half;
       }
 
-      &.last-child:after {
+      &:last-child:after {
         content: "\201D";
       }
     }
@@ -190,7 +190,7 @@
         margin-left: 0;
       }
 
-      &.last-child:after {
+      &:last-child:after {
         content: "\201C";
       }
     }


### PR DESCRIPTION
When writing content and converting to govspeak, the `.last-child` class isn’t automatically added to the last `<p>` tag in a `<blockquote>`. Only Whitehall currently does this

* Use the last-child pseudo selector to enable end quotes on all apps

A closing quote will not show on IE8 (no `:last-child` support), which currently represents 3.5% of pageviews.

https://trello.com/c/tTYHNfWt/7-closing-quotations-marks-should-show-in-manuals-small

cc @edds 