### PR TITLE
Wrap the related sidebar in an aside

### DIFF
--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -3,7 +3,7 @@
   <!-- related -->
   <div class="related-container">
 
-    <div class="related" id="related">
+    <aside class="related" id="related">
       <% artefact.related_artefacts.group_by(&:group).each do |group, related_artefacts| %>
         <%
           section = case group
@@ -53,7 +53,7 @@
       <div class="inner group">
         <a class="return-to-top" href="#content">Return to top &uarr;</a>
       </div>
-    </div>
+    </aside>
 
   </div>
 <!-- end related -->


### PR DESCRIPTION
The aside element lets you mark content on the page which is
complementary to the page. This lets screen readers and other assistive
technology announce to the user that the content isn't part of the main
body of the page.

In user research we have seen users accidentally enter the related
sidebar without realising and assuming that they are still in the main
body of the page. This should help those users.