### PR TITLE
Remove registration of /fonts route.

### DIFF
--- a/lib/tasks/router.rake
+++ b/lib/tasks/router.rake
@@ -18,7 +18,6 @@ namespace :router do
       %w(/favicon.ico exact),
       %w(/humans.txt exact),
       %w(/robots.txt exact),
-      %w(/fonts prefix),
       %w(/google6db9c061ce178960.html exact), # DWP YouTube annotations
       %w(/google991dec8b62e37cfb.html exact),
       %w(/googlef35857dca8b812e7.html exact),
@@ -37,6 +36,10 @@ namespace :router do
         raise
       end
     end
+
+    # FIXME: Remove when this has run everywhere.
+    @router_api.delete_route("/fonts")
+
     @router_api.commit_routes
   end
 


### PR DESCRIPTION
Nothing uses this route. The fonts are actually embedded in the
stylesheets using data-uri's. The fonts for IE8 are served through the
assets vhost under the /static/fonts path. There's nothing in this
application that serves anything from the /fonts path.

Another note, some of the handling for this route was removed in
https://github.gds/gds/puppet/pull/1153