### PR TITLE
Switch away from deprecated jQuery methods

### DIFF
--- a/app/assets/javascripts/report-a-problem-form.js
+++ b/app/assets/javascripts/report-a-problem-form.js
@@ -21,11 +21,11 @@
   };
 
   ReportAProblemForm.prototype.disableSubmitButton = function() {
-    this.$form.find('.button').attr("disabled", true);
+    this.$form.find('.button').prop("disabled", true);
   };
 
   ReportAProblemForm.prototype.enableSubmitButton = function() {
-    this.$form.find('.button').attr("disabled", false);
+    this.$form.find('.button').prop("disabled", false);
   };
 
   ReportAProblemForm.prototype.promptUserToEnterValidData = function() {

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -32,10 +32,9 @@ describe("User Satisfaction Survey", function () {
       document.body.insertAdjacentHTML("afterbegin", block);
 
       $("#user-satisfaction-survey").remove();
-      $("#user-satisfaction-survey-container").data('survey-url', 'javascript:void();');
 
       // Don't actually try and take a survey in test.
-      $('#take-survey').live('click', function(e) {
+      $('#take-survey').on('click', function(e) {
         e.preventDefault();
       });
 


### PR DESCRIPTION
* Switch from `.live` to `.on` 
* Use `prop` over `attr` for disabling/enabling buttons

Identified in https://trello.com/c/wVQ2q3Mr/22-spike-how-can-we-upgrade-jquery-on-static-2-days

cc @edds