### PR TITLE
Remove link titles

### DIFF
--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -26,7 +26,7 @@
                 </li>
               <% end %>
               <% if section and section["content_with_tag"] and section["content_with_tag"]["web_url"].present? %>
-                <li class="related-topic"><a href="<%= h section["content_with_tag"]["web_url"] %>" title="More in <%= h section["title"] %>"
+                <li class="related-topic"><a href="<%= h section["content_with_tag"]["web_url"] %>"
                   >More <span class="visuallyhidden">in <%= h section["title"] %></span></a></li>
               <% end %>
             </ul>


### PR DESCRIPTION
Having link text the same as the title makes reading the link out really
repetitive for a screen reader user as it will read the same text twice.

Remove the repeated text as you get all the content you need from the
link text.