### PR TITLE
Add Childcare and parenting link in footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -52,13 +52,14 @@
         <li><a href="/browse/benefits">Benefits</a></li>
         <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
         <li><a href="/browse/business">Business and self-employed</a></li>
+        <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
         <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
         <li><a href="/browse/justice">Crime, justice and the law</a></li>
         <li><a href="/browse/disabilities">Disabled people</a></li>
         <li><a href="/browse/driving">Driving and transport</a></li>
-        <li><a href="/browse/education">Education and learning</a></li>
       </ul>
       <ul>
+        <li><a href="/browse/education">Education and learning</a></li>
         <li><a href="/browse/employing-people">Employing people</a></li>
         <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
         <li><a href="/browse/housing-local-services">Housing and local services</a></li>


### PR DESCRIPTION
Adds the link to the new "Childcare and parenting" browse page in the footer.

## Before

![screen shot 2015-07-15 at 12 25 20](https://cloud.githubusercontent.com/assets/233676/8697413/aaf307e8-2aec-11e5-90d3-7f30b649731c.png)

## After


![screen shot 2015-07-15 at 12 25 14](https://cloud.githubusercontent.com/assets/233676/8697406/a694e6da-2aec-11e5-8b5b-6263a012185a.png)

Trello: https://trello.com/c/KRe96Tvd/236-add-links-to-childcare-and-parenting-to-homepage-and-footers

:no_entry_sign: Don't merge until this new page has been published (scheduled for today).