### PR TITLE
Prefix option select option id attr with key

### DIFF
--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -5,11 +5,11 @@
   <div class='options-container' id='<%= options_container_id %>'>
     <div class='js-auto-height-inner'>
       <% options.each do | option |%>
-      <label for='<%= option[:id] %>'>
+      <label for='<%= key %>-<%= option[:id] %>'>
         <input
         name="<%= key %>[]"
         value="<%= option[:value]%>"
-        id="<%= option[:id]%>"
+        id="<%= key %>-<%= option[:id]%>"
         type="checkbox"
 
         <% if local_assigns.include?(:aria_controls_id) %>


### PR DESCRIPTION
If we have 2 option select components rendered on a page which have an
option in each with the same slug, these will be used as the id on the
input. This will then cause Nokogiri to throw an error in Slimmer and
not render the page.

This commit changes the option select component to prefix the option
value with the key (`key-slugified-value`).