### PR TITLE
Make report a problem link always underlined and grey

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -58,12 +58,16 @@
   }
 }
 
-.report-a-problem-toggle{
+.report-a-problem-toggle {
   @include core-16;
   margin-bottom: 30px;
 
-  a{
-    color: $secondary-text-colour;
+  a {
+    /* Use !important to override highly specific link styles
+       that appear in apps. eg `#whitehall-wrapper a`
+       Guarantees correct appearance. */
+    color: $secondary-text-colour !important;
+    text-decoration: underline !important;
   }
 
   @include ie-lte(7) {


### PR DESCRIPTION
In Whitehall, link styles are wrapped in a #whitehall-wrapper class, so they have a higher specificity, meaning they are purple (there's no href, so the link is deemed visited) and not underlined (Whitehall link styles are currently inconsistent with the rest of GOV.UK – see https://github.com/alphagov/whitehall/pull/712)

* Make sure the link is always grey and always underlined, `!important` ensures this

## Before
![screen shot 2015-07-27 at 13 59 11](https://cloud.githubusercontent.com/assets/319055/8906632/16f7a53c-3468-11e5-9a3e-2cff6df39949.png)

## After
![screen shot 2015-07-27 at 13 59 43](https://cloud.githubusercontent.com/assets/319055/8906633/1b48be46-3468-11e5-8580-5ad8b898bf02.png)
