### PR TITLE
Improve contact information layout for place options

### DIFF
--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -491,8 +491,8 @@ article {
     .additional-information {
       @include core-16;
 
-      a {
-        display: block;
+      p {
+        margin: 0.25em 0;
       }
     }
 


### PR DESCRIPTION
Place information rendered from imminence on frontend
e.g. www.gov.uk/find-atf-dvsa-test-station lists email, website and phone
information for each found place. Labels and values for contact info is rendered
on separate lines (see example below).

With equal spaces between the lines it looks rather messy. I tried finding
design guidelines for cases like this but the only thing I found was mainstream
styleguides for contacts
https://github.com/alphagov/govspeak/wiki/Using-govspeak-on-GOV.UK#contacts.

As far as I can tell the CSS I have changed is only used in that one place I
intend to change. I also intend to remove Email and Website labels from the
frontend app to conform to these guidelines.

The commit that introduced the current style is e6f4153969473a1df870f47df810c3068598c3a6

Before:
<img width="673" alt="screenshot 2015-07-31 16 52 26" src="https://cloud.githubusercontent.com/assets/218239/9011328/8b96b6e6-37a4-11e5-8f49-1bccffc6c15f.png">

After (including planned label removal from frontend):
<img width="676" alt="screenshot 2015-07-31 16 53 26" src="https://cloud.githubusercontent.com/assets/218239/9011349/b0ac9e8c-37a4-11e5-984f-97aba2cfc252.png">

Note there's now some margin between two paragraphs at the bottom too, previously it was impossible to tell these are two paragraphs.