### PR TITLE
Add download and external link tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,8 +31,7 @@ group :development, :test do
 end
 
 gem 'plek', '1.11.0'
-
-gem 'govuk_frontend_toolkit', '~> 4.1.1'
+gem 'govuk_frontend_toolkit', '~> 4.2.0'
 
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
-    govuk_frontend_toolkit (4.1.1)
+    govuk_frontend_toolkit (4.2.0)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.13.0)
@@ -186,7 +186,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 20.1.1)
-  govuk_frontend_toolkit (~> 4.1.1)
+  govuk_frontend_toolkit (~> 4.2.0)
   govuk_template (= 0.13.0)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.10.6)

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -2,6 +2,8 @@
 //= require govuk/analytics/analytics
 //= require govuk/analytics/print-intent
 //= require govuk/analytics/error-tracking
+//= require govuk/analytics/external-link-tracker
+//= require govuk/analytics/download-link-tracker
 
 //= require analytics/static-analytics
 //= require analytics/init

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -21,6 +21,10 @@
     // Begin error and print tracking
     GOVUK.analyticsPlugins.error();
     GOVUK.analyticsPlugins.printIntent();
+    GOVUK.analyticsPlugins.externalLinkTracker();
+    GOVUK.analyticsPlugins.downloadLinkTracker({
+      selector: 'a[href*="/government/uploads"], a[href*="assets.digital.cabinet-office.gov.uk"]'
+    });
 
     function setPixelDensityDimension() {
       if (window.devicePixelRatio) {
@@ -91,8 +95,8 @@
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
   };
 
-  StaticAnalytics.prototype.trackPageview = function(path, title) {
-    this.analytics.trackPageview(path, title);
+  StaticAnalytics.prototype.trackPageview = function(path, title, options) {
+    this.analytics.trackPageview(path, title, options);
   };
 
   StaticAnalytics.prototype.trackEvent = function(category, action, options) {


### PR DESCRIPTION
Following on from https://github.com/alphagov/govuk_frontend_toolkit/pull/208
https://trello.com/c/ihxFfLWH/70-create-simplest-external-link-and-download-tracker-medium

> This is a minimum viable tracker. It will work as expected in Chrome and Firefox – browsers that support navigator.sendBeacon, about 30% of all users. On older browsers we will still send analytics events, and we'll receive some data, but not all events will make it to GA and the dataset will be incomplete. We will however be able to estimate what proportion of events we're missing based on the complete Chrome and Firefox datasets – those estimates can be used to prioritise and influence a more complex solutions.
>
>A fully-formed tracker would include, in older browsers, a means of preventing the page from loading until an event has been successfully tracked. This degrades the user experience and the complexities introduce a greater risk of links not working. The data collected from this tracker will provide much needed context and visibility.