### PR TITLE
Track downloads with events not pageviews

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ group :development, :test do
 end
 
 gem 'plek', '1.11.0'
-gem 'govuk_frontend_toolkit', '~> 4.2.0'
+gem 'govuk_frontend_toolkit', '~> 4.2.1'
 
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', :path => "../govuk_template"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,7 +58,7 @@ GEM
       plek
       rack-cache
       rest-client (~> 1.8.0)
-    govuk_frontend_toolkit (4.2.0)
+    govuk_frontend_toolkit (4.2.1)
       rails (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_template (0.13.0)
@@ -186,7 +186,7 @@ DEPENDENCIES
   capybara (= 2.1.0)
   exception_notification
   gds-api-adapters (= 20.1.1)
-  govuk_frontend_toolkit (~> 4.2.0)
+  govuk_frontend_toolkit (~> 4.2.1)
   govuk_template (= 0.13.0)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.10.6)


### PR DESCRIPTION
Pick up changes to download link tracker from https://github.com/alphagov/govuk_frontend_toolkit/pull/214

> Events show a user intent, but are less likely to be interpreted incorrectly – it shows that a user clicked a link on a page, rather than the file was successfully downloaded and viewed.
>
> It should avoid inflating our pageview numbers, prevent an increase in our cardinality and leave open a more complete pageview tracking solution from logs (eg for direct downloads).