### PR TITLE
Remove abbr underlines in Firefox

### DIFF
--- a/app/assets/stylesheets/helpers/_reset.scss
+++ b/app/assets/stylesheets/helpers/_reset.scss
@@ -33,3 +33,7 @@ table, caption, tbody, tfoot, thead, tr, th, td {
 strong {
   font-weight: bold;
 }
+
+abbr[title], acronym[title] {
+  text-decoration: none;
+}


### PR DESCRIPTION
Firefox now supports text-decoration with a dotted underline; consequently (and inline with W3’s recommended default stylesheet) Mozilla [updated Firefox’s default stylesheet](https://bugzilla.mozilla.org/show_bug.cgi?id=1157083) to style abbrs and acronyms with a dotted text-decoration instead of a dotted border. Our reset stylesheet removes borders from abbr and acronym elements, but doesn’t reset text decoration. The upshot of all this is that every abbr on gov.uk now has dots underneath it.

This patch simply adds a rule to remove text-decoration from abbr and acronym elements. If text-decoration is being deliberately set anywhere it’ll override this base rule.