### PR TITLE
Add analytics meta tag component

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -1,0 +1,17 @@
+<%
+  links_hash = content_item["links"] || {}
+
+  organisations = []
+  organisations += links_hash["organisations"] || []
+  organisations += links_hash["lead_organisations"] || []
+  organisations += links_hash["supporting_organisations"] || []
+  organisations += links_hash["worldwide_organisations"] || []
+
+  world_locations = links_hash["world_locations"] || []
+%>
+<% if organisations.any? %>
+  <meta name="govuk:analytics:organisations" content="&lt;<%= organisations.map { |link| link["analytics_identifier"] }.join('><') %>&gt;">
+<% end %>
+<% if world_locations.any? %>
+  <meta name="govuk:analytics:world-locations" content="&lt;<%= world_locations.map { |link| link["analytics_identifier"] }.join('><') %>&gt;">
+<% end %>

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -427,3 +427,30 @@
       next_page:
         url: "next-page"
         title: "Next page"
+- id: "analytics_meta_tags"
+  name: "Analytics Meta Tags"
+  description: "Meta tags to provide analytics information about the current page"
+  body: |
+    Currently this just takes a content-store links hash like object which it
+    can then turn into the correct analytics identifier metadata tags.
+
+    The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
+  fixtures:
+    default: {}
+    with_organisations:
+      content_item:
+        links:
+          organisations:
+            - "D1"
+            - "D3"
+          lead_organisations:
+            - "D2"
+          supporting_organisations:
+          - "EO3"
+          worldwide_organisations:
+          - "EO3"
+    with_world_locations:
+      content_item:
+        links:
+          world_locations:
+            - "WL3"


### PR DESCRIPTION
Create a component which takes a links hash object from a content-store
object and turns that into a collection of meta-tags which can then be
read by our analytics JavaScript. This information in then sent to
Google as a custom dimension.

The component doesn't actually render anything visual so doesn't have a
corresponding stylesheet.

Would appreciate @dsingleton's thoughts on this.