### PR TITLE
Up the size of the checkbox on option selects

### DIFF
--- a/app/assets/stylesheets/govuk-component/_option-select.scss
+++ b/app/assets/stylesheets/govuk-component/_option-select.scss
@@ -42,7 +42,7 @@
 
     label {
       @include inline-block;
-      padding: 7px 0 7px 30px;
+      padding: 7px 0 7px 35px;
       border-bottom: 1px solid $border-colour;
       width: 100%;
       cursor:pointer;
@@ -57,8 +57,15 @@
     }
 
     input {
-      margin-left: -23px;
-      vertical-align: top;
+      float: left;
+      margin: 2px 0 0 -27px;
+      width: 20px;
+      height: 20px;
+      @include ie(8) {
+        width: auto;
+        height: auto;
+        margin-top: 0;
+      }
     }
   }
 


### PR DESCRIPTION
We’re upping the size of checkboxes generally across the site. Originally this code just used  a negative margin-left to pull the checkbox to the left, but this also pulls the following text regardless of padding. By floating it left the following text will respect the padding boundary set against the label.

Most browsers look good, IE9 is the odd one out. It looks OK but is slightly out of position and cramped. I’m assuming we’ll go down the same route as on https://github.com/alphagov/govuk_elements/pull/98 though.

Screenshots:

*Chrome (Android)*

![android_chrome](https://cloud.githubusercontent.com/assets/7414/9679533/450528e4-52e7-11e5-8187-81d8bc166368.png)

*Safari (iOS)*

![ios_safari](https://cloud.githubusercontent.com/assets/7414/9679537/450be4fe-52e7-11e5-9e40-42da9d45b68d.png)

*Chrome (OS X)*

![osx_chrome](https://cloud.githubusercontent.com/assets/7414/9679535/4508dcfa-52e7-11e5-8b45-3bccc75679e3.png)

*Firefox (OS X)*

![osx_firefox](https://cloud.githubusercontent.com/assets/7414/9679534/450848c6-52e7-11e5-8433-3ac10d77b6ca.png)

*Safari (OS X)*

![osx_safari](https://cloud.githubusercontent.com/assets/7414/9679538/450c9656-52e7-11e5-9cbe-9b372ef244f6.png)

*IE8 (Windows 7)*

![win7_ie8](https://cloud.githubusercontent.com/assets/7414/9679536/450969ae-52e7-11e5-86b3-dfe0dc09842a.png)

*IE9 (Windows 7)*

![win7_ie9](https://cloud.githubusercontent.com/assets/7414/9679539/45188e48-52e7-11e5-96c7-88602f91cfed.png)

*Chrome (Windows 10)*

![win10_chrome](https://cloud.githubusercontent.com/assets/7414/9679540/451c1842-52e7-11e5-9f19-8d90839591f5.png)

*Edge (Windows 10)*

![win10_edge](https://cloud.githubusercontent.com/assets/7414/9679541/451d3646-52e7-11e5-9a11-1fdc3bb74d0a.png)

*Firefox (Windows 10)*

![win10_firefox](https://cloud.githubusercontent.com/assets/7414/9679543/451e7db2-52e7-11e5-8d90-b78fdb4f04eb.png)

*IE11 (Windows 10)*

![win10_ie11](https://cloud.githubusercontent.com/assets/7414/9679542/451de0c8-52e7-11e5-8002-6f214bb7495b.png)

*Opera (Windows 10)*

![win10_opera](https://cloud.githubusercontent.com/assets/7414/9679544/452008da-52e7-11e5-94b6-61e2832ada9f.png)
