### PR TITLE
Notification banner refactorings and test clean-up

### DIFF
--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -4,7 +4,7 @@ module NotificationHelper
   include ActionView::Helpers::TagHelper
 
   def banner_notification
-    if node = NotificationFileLookup.instance.banner
+    if node = Static.banner
       content_tag(:section, "<div>#{node[:file]}</div>",
         {:id => "banner-notification", :class => node[:colour]}, false)
     else

--- a/config/initializers/notification_banner.rb
+++ b/config/initializers/notification_banner.rb
@@ -1,0 +1,4 @@
+require 'static'
+require 'notification_file_lookup'
+
+Static.banner = NotificationFileLookup.new.banner

--- a/lib/notification_file_lookup.rb
+++ b/lib/notification_file_lookup.rb
@@ -1,4 +1,8 @@
 class NotificationFileLookup
+  def initialize(banner_file_location = "#{Rails.root}/app/views/notifications")
+    @banner_file_location = banner_file_location
+  end
+
   def banner
     @banner_file ||= identify_banner_file
   end
@@ -10,8 +14,8 @@ class NotificationFileLookup
   private
 
   def identify_banner_file
-    red = File.read("#{Rails.root}/app/views/notifications/banner_red.erb").strip
-    green = File.read("#{Rails.root}/app/views/notifications/banner_green.erb").strip
+    red = File.read(File.join(@banner_file_location, "banner_red.erb")).strip
+    green = File.read(File.join(@banner_file_location, "banner_green.erb")).strip
 
     case
     when red.present?

--- a/lib/notification_file_lookup.rb
+++ b/lib/notification_file_lookup.rb
@@ -1,11 +1,8 @@
 class NotificationFileLookup
   include Singleton
 
-  cattr_accessor :banner_file
-
   def banner
     @banner_file ||= identify_banner_file
-    @banner_file[:file].blank? ? nil : @banner_file
   end
 
   def banner=(file)
@@ -16,15 +13,15 @@ class NotificationFileLookup
 
   def identify_banner_file
     red = File.read("#{Rails.root}/app/views/notifications/banner_red.erb").strip
-    unless red.blank?
-      return { :file => red, :colour => :red }
-    end
-
     green = File.read("#{Rails.root}/app/views/notifications/banner_green.erb").strip
-    unless green.blank?
-      return { :file => green, :colour => :green }
-    end
 
-    { :file => nil, :colour => nil }
+    case
+    when red.present?
+      { file: red, colour: :red }
+    when green.present?
+      { file: green, colour: :green }
+    else
+      nil
+    end
   end
 end

--- a/lib/notification_file_lookup.rb
+++ b/lib/notification_file_lookup.rb
@@ -1,6 +1,4 @@
 class NotificationFileLookup
-  include Singleton
-
   def banner
     @banner_file ||= identify_banner_file
   end

--- a/lib/static.rb
+++ b/lib/static.rb
@@ -1,0 +1,3 @@
+module Static
+  mattr_accessor :banner
+end

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -54,13 +54,13 @@ class NotificationsTest < ActionDispatch::IntegrationTest
       context "given view files are present for a red notification" do
         setup do
           File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-            .returns('<p>Everything is fine</p>')
+            .returns('<p>Everything is not fine</p>')
         end
 
         should "show a banner notification on the page" do
           visit "/templates/wrapper.html.erb"
           assert page.has_selector? "#banner-notification.red"
-          assert_match '<p>Everything is fine</p>', page.body
+          assert_match '<p>Everything is not fine</p>', page.body
         end
       end
     end

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -20,14 +20,16 @@ class NotificationsTest < ActionDispatch::IntegrationTest
   end
 
   context "banner notifications" do
+    teardown do
+      clean_up_test_files
+    end
+
     context "given view files are empty" do
       setup do
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-          .returns('')
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-          .returns('')
+        create_test_file(filename: "banner_green.erb", content: '')
+        create_test_file(filename: "banner_red.erb", content: '')
 
-        Static.banner = NotificationFileLookup.new.banner
+        Static.banner = NotificationFileLookup.new(location_of_test_files).banner
       end
 
       should "not show a banner notification on the page" do
@@ -38,12 +40,10 @@ class NotificationsTest < ActionDispatch::IntegrationTest
 
     context "given view files are present for a green notification" do
       setup do
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-          .returns('<p>Everything is fine</p>')
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-          .returns('')
+        create_test_file(filename: "banner_green.erb", content: '<p>Everything is fine</p>')
+        create_test_file(filename: "banner_red.erb", content: '')
 
-        Static.banner = NotificationFileLookup.new.banner
+        Static.banner = NotificationFileLookup.new(location_of_test_files).banner
       end
 
       should "show a banner notification on the page" do
@@ -55,12 +55,10 @@ class NotificationsTest < ActionDispatch::IntegrationTest
 
     context "given view files are present for a red notification" do
       setup do
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-          .returns('')
-        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-          .returns('<p>Everything is not fine</p>')
+        create_test_file(filename: "banner_green.erb", content: '')
+        create_test_file(filename: "banner_red.erb", content: '<p>Everything is not fine</p>')
 
-        Static.banner = NotificationFileLookup.new.banner
+        Static.banner = NotificationFileLookup.new(location_of_test_files).banner
       end
 
       should "show a banner notification on the page" do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -1,6 +1,14 @@
 require 'integration_test_helper'
 
 class NotificationsTest < ActionDispatch::IntegrationTest
+  setup do
+    @original_banner = Static.banner
+  end
+
+  teardown do
+    Static.banner = @original_banner
+  end
+
   context "banner files" do
     should "have a green file" do
       assert File.exist? "#{Rails.root}/app/views/notifications/banner_green.erb"
@@ -12,16 +20,14 @@ class NotificationsTest < ActionDispatch::IntegrationTest
   end
 
   context "banner notifications" do
-    setup do
-      NotificationFileLookup.instance.banner = nil
-    end
-
     context "given view files are empty" do
       setup do
         File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
           .returns('')
         File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
           .returns('')
+
+        Static.banner = NotificationFileLookup.new.banner
       end
 
       should "not show a banner notification on the page" do
@@ -36,6 +42,8 @@ class NotificationsTest < ActionDispatch::IntegrationTest
           .returns('<p>Everything is fine</p>')
         File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
           .returns('')
+
+        Static.banner = NotificationFileLookup.new.banner
       end
 
       should "show a banner notification on the page" do
@@ -51,6 +59,8 @@ class NotificationsTest < ActionDispatch::IntegrationTest
           .returns('')
         File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
           .returns('<p>Everything is not fine</p>')
+
+        Static.banner = NotificationFileLookup.new.banner
       end
 
       should "show a banner notification on the page" do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -38,30 +38,25 @@ class NotificationsTest < ActionDispatch::IntegrationTest
           .returns('')
       end
 
-      context "given view files are present for a green notification" do
-        setup do
-          File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-            .returns('<p>Everything is fine</p>')
-        end
+      should "show a banner notification on the page" do
+        visit "/templates/wrapper.html.erb"
+        assert page.has_selector? "#banner-notification.green"
+        assert_match '<p>Everything is fine</p>', page.body
+      end
+    end
 
-        should "show a banner notification on the page" do
-          visit "/templates/wrapper.html.erb"
-          assert page.has_selector? "#banner-notification.green"
-          assert_match '<p>Everything is fine</p>', page.body
-        end
+    context "given view files are present for a red notification" do
+      setup do
+        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
+          .returns('')
+        File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
+          .returns('<p>Everything is not fine</p>')
       end
 
-      context "given view files are present for a red notification" do
-        setup do
-          File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-            .returns('<p>Everything is not fine</p>')
-        end
-
-        should "show a banner notification on the page" do
-          visit "/templates/wrapper.html.erb"
-          assert page.has_selector? "#banner-notification.red"
-          assert_match '<p>Everything is not fine</p>', page.body
-        end
+      should "show a banner notification on the page" do
+        visit "/templates/wrapper.html.erb"
+        assert page.has_selector? "#banner-notification.red"
+        assert_match '<p>Everything is not fine</p>', page.body
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,3 +6,19 @@ require 'minitest/autorun'
 require 'test/unit'
 require 'rails/test_help'
 require 'mocha/mini_test'
+
+class ActiveSupport::TestCase
+  def create_test_file(filename:, content:)
+    FileUtils.mkdir_p location_of_test_files
+    full_path = File.join(location_of_test_files, filename)
+    File.open(full_path, "w") {|f| f << content }
+  end
+
+  def location_of_test_files
+    Rails.root.join("tmp", "test")
+  end
+
+  def clean_up_test_files
+    FileUtils.rm_r location_of_test_files
+  end
+end

--- a/test/unit/notification_file_lookup_test.rb
+++ b/test/unit/notification_file_lookup_test.rb
@@ -19,6 +19,8 @@ describe NotificationFileLookup do
     it "returns the red banner content if present" do
       File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
         .returns('<p>Keep calm and carry on.</p>')
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
+        .returns('')
 
       expected = {:file => "<p>Keep calm and carry on.</p>", :colour => :red}
       assert_equal expected, NotificationFileLookup.instance.banner

--- a/test/unit/notification_file_lookup_test.rb
+++ b/test/unit/notification_file_lookup_test.rb
@@ -3,17 +3,13 @@ require_relative '../../lib/notification_file_lookup'
 
 describe NotificationFileLookup do
   describe "banner" do
-    before do
-      NotificationFileLookup.instance.banner = nil
-    end
-
     it "returns nil if both banner content files are empty" do
       File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
         .returns('')
       File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
         .returns('')
 
-      assert_nil NotificationFileLookup.instance.banner
+      assert_nil NotificationFileLookup.new.banner
     end
 
     it "returns the red banner content if present" do
@@ -23,10 +19,12 @@ describe NotificationFileLookup do
         .returns('')
 
       expected = {:file => "<p>Keep calm and carry on.</p>", :colour => :red}
-      assert_equal expected, NotificationFileLookup.instance.banner
+      assert_equal expected, NotificationFileLookup.new.banner
     end
 
     it "opens banner content file only once" do
+      lookup = NotificationFileLookup.new
+
       File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
         .returns('Test')
       File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
@@ -34,7 +32,7 @@ describe NotificationFileLookup do
 
       expected = {:file => "Test", :colour => :green}
       3.times do
-        assert_equal expected, NotificationFileLookup.instance.banner
+        assert_equal expected, lookup.banner
       end
     end
 
@@ -44,7 +42,7 @@ describe NotificationFileLookup do
       File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
         .returns('')
 
-      assert_nil NotificationFileLookup.instance.banner
+      assert_nil NotificationFileLookup.new.banner
     end
 
     it "falls back to green if the red file is empty" do
@@ -54,7 +52,7 @@ describe NotificationFileLookup do
         .returns('')
 
       expected = {:file => "<p>Nothing to see here.</p>", :colour => :green}
-      assert_equal expected, NotificationFileLookup.instance.banner
+      assert_equal expected, NotificationFileLookup.new.banner
     end
   end
 end

--- a/test/unit/notification_file_lookup_test.rb
+++ b/test/unit/notification_file_lookup_test.rb
@@ -2,57 +2,57 @@ require 'test_helper'
 require_relative '../../lib/notification_file_lookup'
 
 describe NotificationFileLookup do
-	describe "banner" do
-		before do
-			NotificationFileLookup.instance.banner = nil
-		end
+  describe "banner" do
+    before do
+      NotificationFileLookup.instance.banner = nil
+    end
 
-		it "returns nil if both banner content files are empty" do
-			File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-				.returns('')
-			File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-				.returns('')
+    it "returns nil if both banner content files are empty" do
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
+        .returns('')
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
+        .returns('')
 
-			assert_nil NotificationFileLookup.instance.banner
-		end
+      assert_nil NotificationFileLookup.instance.banner
+    end
 
-		it "returns the red banner content if present" do
-			File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-				.returns('<p>Keep calm and carry on.</p>')
+    it "returns the red banner content if present" do
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
+        .returns('<p>Keep calm and carry on.</p>')
 
       expected = {:file => "<p>Keep calm and carry on.</p>", :colour => :red}
-			assert_equal expected, NotificationFileLookup.instance.banner
-		end
+      assert_equal expected, NotificationFileLookup.instance.banner
+    end
 
-		it "opens banner content file only once" do
-			File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-				.returns('Test')
-			File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-				.returns('')
+    it "opens banner content file only once" do
+      File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
+        .returns('Test')
+      File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
+        .returns('')
 
       expected = {:file => "Test", :colour => :green}
-			3.times do
-				assert_equal expected, NotificationFileLookup.instance.banner
-			end
-		end
+      3.times do
+        assert_equal expected, NotificationFileLookup.instance.banner
+      end
+    end
 
-		it "returns nil if the banner content only contains whitespace" do
-			File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-				.returns("\n\n\r\n\r\n\n\n")
-			File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-				.returns('')
+    it "returns nil if the banner content only contains whitespace" do
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
+        .returns("\n\n\r\n\r\n\n\n")
+      File.stubs(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
+        .returns('')
 
-			assert_nil NotificationFileLookup.instance.banner
-		end
+      assert_nil NotificationFileLookup.instance.banner
+    end
 
-		it "falls back to green if the red file is empty" do
+    it "falls back to green if the red file is empty" do
       File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_green.erb")
-				.returns('<p>Nothing to see here.</p>')
+        .returns('<p>Nothing to see here.</p>')
       File.expects(:read).with("#{Rails.root}/app/views/notifications/banner_red.erb")
-				.returns('')
+        .returns('')
 
       expected = {:file => "<p>Nothing to see here.</p>", :colour => :green}
-			assert_equal expected, NotificationFileLookup.instance.banner
-		end
-	end
+      assert_equal expected, NotificationFileLookup.instance.banner
+    end
+  end
 end

--- a/test/unit/notification_helper_test.rb
+++ b/test/unit/notification_helper_test.rb
@@ -4,29 +4,34 @@ describe "Notification Helper" do
   include NotificationHelper
 
   describe "banner_notification" do
+    before do
+      @original_banner = Static.banner
+    end
+
+    after do
+      Static.banner = @original_banner
+    end
+
     it "should return an empty string if no banner is present" do
-      NotificationFileLookup.any_instance.stubs(:banner).returns(nil)
+      Static.banner = nil
       assert_equal "", banner_notification
     end
 
     describe "when a banner is present" do
       it "should return a banner notification" do
-        banner = {:file => "<p>You've got notifications!</p>", :colour => :green}
-        NotificationFileLookup.any_instance.stubs(:banner).returns(banner)
+        Static.banner = {:file => "<p>You've got notifications!</p>", :colour => :green}
         assert_match "<p>You've got notifications!</p>", banner_notification
       end
 
       it "should have a section wrapper with the banner colour for a green notification" do
-        banner = {:file => "<p>You've got notifications!</p>", :colour => :green}
-        NotificationFileLookup.any_instance.stubs(:banner).returns(banner)
+        Static.banner = {:file => "<p>You've got notifications!</p>", :colour => :green}
 
         assert_equal "<section class=\"green\" id=\"banner-notification\"><div><p>You've got notifications!</p></div></section>",
                      banner_notification
       end
 
       it "should have a section wrapper with the banner colour for a red notification" do
-        banner = {:file => "<p>You've got notifications!</p>", :colour => :red}
-        NotificationFileLookup.any_instance.stubs(:banner).returns(banner)
+        Static.banner = {:file => "<p>You've got notifications!</p>", :colour => :red}
 
         assert_equal "<section class=\"red\" id=\"banner-notification\"><div><p>You've got notifications!</p></div></section>",
                      banner_notification


### PR DESCRIPTION
The original intention of this refactoring was to remove stubbing from the banner integration tests (which has [caused intermittent test failures on CI](https://ci-new.alphagov.co.uk/job/govuk_static_branches/602/console)), but it pays down some tech debt on the way.

The highlights:

- simplification of the `NotificationFileLookup` class
- `NotificationFileLookup` is no longer a singleton (instead, a module attribute `Static.banner` is introduced to store the global state)
- `NotificationFileLookup` can be optionally passed a path where the banner templates can be found
- fix some nesting and duplication issues in `NotificationsTest`
- `NotificationsTest` no longer uses stubbing, creating and deleting real test template files instead

/cc @binaryberry @jamiecobbett @boffbowsh 