### PR TITLE
Replace exception_notification integration with Errbit/Airbrake

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ source 'https://rubygems.org'
 gem 'rails', '4.1.13'
 gem 'unicorn', '4.3.1'
 
-gem 'aws-ses', :require => 'aws/ses' # Needed by exception_notification
-gem 'exception_notification'
 gem 'logstasher', '0.4.8'
 gem 'rack_strip_client_ip', '0.0.1'
 gem 'actionpack-page_caching', '1.0.2'

--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'actionpack-page_caching', '1.0.2'
 gem "therubyracer", "0.12.0"
 gem 'uglifier', "1.3.0"
 gem 'sass-rails', "5.0.4"
+gem 'airbrake', '~> 4.3.1'
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,11 +35,6 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    aws-ses (0.4.4)
-      builder
-      mail (> 2.2.5)
-      mime-types
-      xml-simple
     builder (3.2.2)
     capybara (2.1.0)
       mime-types (>= 1.16)
@@ -52,8 +47,6 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    exception_notification (2.6.1)
-      actionmailer (>= 3.0.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
     exifr (1.2.0)
@@ -203,7 +196,6 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-    xml-simple (1.1.1)
     xpath (2.0.0)
       nokogiri (~> 1.3)
 
@@ -212,9 +204,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-page_caching (= 1.0.2)
-  aws-ses
   capybara (= 2.1.0)
-  exception_notification
   gds-api-adapters (= 23.2.2)
   govuk-lint (~> 0.3.0)
   govuk_frontend_toolkit (~> 4.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,6 +31,9 @@ GEM
       thread_safe (~> 0.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
+    airbrake (4.3.1)
+      builder
+      multi_json
     arel (5.0.1.20140414130214)
     ast (2.1.0)
     astrolabe (1.3.1)
@@ -204,6 +207,7 @@ PLATFORMS
 
 DEPENDENCIES
   actionpack-page_caching (= 1.0.2)
+  airbrake (~> 4.3.1)
   capybara (= 2.1.0)
   gds-api-adapters (= 23.2.2)
   govuk-lint (~> 0.3.0)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -1,0 +1,10 @@
+if ENV['ERRBIT_API_KEY'].present?
+  errbit_uri = Plek.find_uri('errbit')
+
+  Airbrake.configure do |config|
+    config.api_key = ENV['ERRBIT_API_KEY']
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == 'https'
+    config.environment_name = ENV['ERRBIT_ENVIRONMENT_NAME']
+  end
+end

--- a/config/initializers/exception_notification.rb
+++ b/config/initializers/exception_notification.rb
@@ -1,6 +1,0 @@
-unless Rails.env.development? or Rails.env.test?
-  Rails.application.config.middleware.use ExceptionNotifier,
-    :email_prefix => "[#{Rails.application.class.to_s.split('::').first}] ",
-    :sender_address => %{"Winston Smith-Churchill" <winston@alphagov.co.uk>},
-    :exception_recipients => %w{govuk-exceptions@digital.cabinet-office.gov.uk}
-end


### PR DESCRIPTION
Errbit is the current approach in our stack for tracking errors.

Related PRs:

- https://github.gds/gds/puppet/pull/3390
- https://github.gds/gds/deployment/pull/706
- https://github.gds/gds/alphagov-deployment/pull/1053