### PR TITLE
Don't wire up ActionMailer

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../boot', __FILE__)
 
 require "action_controller/railtie"
-require "action_mailer/railtie"
 require "rails/test_unit/railtie"
 require "sprockets/railtie"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Static::Application.configure do
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
   # Print deprecation notices to the Rails logger
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -44,7 +44,7 @@ Static::Application.configure do
 
   # Disable delivery errors, bad email addresses will be ignored
   # config.action_mailer.raise_delivery_errors = false
-  config.action_mailer.delivery_method = :ses
+  # config.action_mailer.delivery_method = :ses
 
   # Enable threaded mode
   # config.threadsafe!

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -24,7 +24,7 @@ Static::Application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
 
   # Use SQL instead of Active Record's schema dumper when creating the test database.
   # This is necessary if your schema can't be completely dumped by the schema dumper,


### PR DESCRIPTION
ActionMailer is no longer required since [`exception_notification` was replaced
by Airbrake integration](https://github.com/alphagov/static/pull/652).

H/T to @tijmenb for [picking this up](https://github.com/alphagov/static/pull/652#issuecomment-140791194) on https://github.com/alphagov/static/pull/652.