### PR TITLE
Post-upgrade fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rack_strip_client_ip', '0.0.1'
 gem 'actionpack-page_caching', '1.0.2'
 
 gem "therubyracer", "0.12.0"
-gem 'uglifier', "1.3.0"
+gem 'uglifier', ">= 1.3.0"
 gem 'sass-rails', "5.0.4"
 gem 'airbrake', '~> 4.3.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,8 +59,7 @@ GEM
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
-    execjs (1.4.0)
-      multi_json (~> 1.0)
+    execjs (2.6.0)
     exifr (1.2.0)
     fspath (2.1.0)
     gds-api-adapters (23.2.2)
@@ -208,9 +207,9 @@ GEM
     tilt (2.0.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
-    uglifier (1.3.0)
+    uglifier (2.7.2)
       execjs (>= 0.3.0)
-      multi_json (~> 1.0, >= 1.0.2)
+      json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.1)
@@ -249,7 +248,7 @@ DEPENDENCIES
   shoulda
   test-unit
   therubyracer (= 0.12.0)
-  uglifier (= 1.3.0)
+  uglifier (>= 1.3.0)
   unicorn (= 4.3.1)
   webmock
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,7 @@ Static::Application.configure do
   config.serve_static_files = false
 
   # Compress JavaScripts and CSS
-  config.assets.compress = true
+  config.assets.js_compressor = :uglifier
 
   # Don't fallback to assets pipeline if a precompiled asset is missed
   config.assets.compile = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -30,8 +30,8 @@ Static::Application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # See everything in the log (default is :info)
-  # config.log_level = :debug
+  # See everything in the log
+  config.log_level = :info
 
   # Use a different logger for distributed setups
   # config.logger = SyslogLogger.new

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -24,4 +24,4 @@ fi
 
 RAILS_ENV=test bundle exec rake test
 RAILS_ENV=test bundle exec rake spec:javascript
-bundle exec rake assets:precompile
+RAILS_ENV=production bundle exec rake assets:precompile


### PR DESCRIPTION
This is to fix a couple of issues introduced during the recent Rails 4.X upgrades:

- JS asset compression stopped working
- silence an overlooked deprecation warning

/cc @boffbowsh 