### PR TITLE
Rich Govspeak with bold

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -8,6 +8,12 @@
     text-align: start;
   }
 
+  &.rich-govspeak {
+    strong {
+      font-weight: bold;
+    }
+  }
+
   h2:first-child,
   h3:first-child,
   h4:first-child,

--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -201,6 +201,10 @@
           <li>تابعنا باللغة العربية عبر</li>
           <li>تابعنا باللغة العربية عبر تويتر </li>
         </ul>
+    with_rich_govspeak:
+      rich_govspeak: true
+      content: |
+        <p>This content has some <strong>rich govspeak</strong></p>
 - id: "title"
   name: "Page title"
   description: "A page title with optional context label"

--- a/app/views/govuk_component/govspeak.raw.html.erb
+++ b/app/views/govuk_component/govspeak.raw.html.erb
@@ -2,6 +2,10 @@
   direction_class = ""
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
-<div class="govuk-govspeak<%= direction_class %>">
+<%
+  rich_govspeak = false
+  rich_govspeak = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+%>
+<div class="govuk-govspeak<%= direction_class %><%= ' rich-govspeak' if rich_govspeak %>">
   <%= raw content %>
 </div>


### PR DESCRIPTION
As we need to have bold on certain pages of GOV.UK (the Highway Code)
this commit updates the Govspeak component to have extra CSS set by a
flag of `rich_govspeak`. This can be set by the rendering App.
Additional CSS could be added to this rich mode if we wish.

This has been discussed with both Product Managers, Content and
Designers and the approach I've followed was agreed upon.

[Ticket](https://trello.com/c/eYyOkNRR/131-highway-code-manual-has-styled-strong-tags).