### PR TITLE
Fix alignment of report-a-problem at certain widths

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -3,7 +3,6 @@
 }
 
 .report-a-problem-container{
-  @extend %site-width-container;
   clear: both;
 
   .report-a-problem-inner {
@@ -82,6 +81,5 @@
 }
 
 .report-a-problem-toggle-wrapper {
-  @extend %site-width-container;
   clear:both;
 }


### PR DESCRIPTION
At a breakpoint below 1020 the report a problem link, and form, weren't aligned to the grid of the rest of the page, and were indented by an additional 30px on each side.

This was caused by `%site-width-container` being used on the report a problem containers, within `#wrapper`, which already extends `%site-width-container`, causing double margins.

As the report a problem elements already inside a page width container it's same to remove the use of `%site-width-container` for them.

| 🌟  | Before | After |
| --- | --- | --- |
| Closed | ![report-before](https://cloud.githubusercontent.com/assets/63201/10373870/fc2bca12-6de7-11e5-9b23-8b870641a378.png) | ![report-after](https://cloud.githubusercontent.com/assets/63201/10373873/fc2d4c0c-6de7-11e5-8a8f-1c03bd60daeb.png) |
| Open | ![report2-before](https://cloud.githubusercontent.com/assets/63201/10373869/fc2a0a42-6de7-11e5-85d6-50df8931f509.png) | ![report2-after](https://cloud.githubusercontent.com/assets/63201/10373872/fc2ca64e-6de7-11e5-8686-1d33274137bc.png) |
| Mobile | ![report3-before](https://cloud.githubusercontent.com/assets/63201/10373871/fc2bf0c8-6de7-11e5-9513-faaa259498a3.png) | ![report3-after](https://cloud.githubusercontent.com/assets/63201/10373935/4f2d42a4-6de8-11e5-8d1b-6aa96da1c724.png)  |