### PR TITLE
Add fixture for statistic headlines

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -106,6 +106,11 @@
           <li>two</li>
           <li>three</li>
         </ol>
+    statistic_headlines:
+      content: |
+        <aside>
+          <p><em>13.8bn</em> years since the big bang</p>
+        </aside>
     blockquote:
       content: |
         <blockquote>


### PR DESCRIPTION
Statistic headlines are in govspeak since 3.5.0.
They are only styled as big numbers in HTML publications.

See https://github.com/alphagov/whitehall/pull/2356 and https://github.com/alphagov/govspeak/pull/60