### PR TITLE
Revert "Merge pull request #660 from alphagov/fix-report-a-problem-alignment"

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -3,6 +3,7 @@
 }
 
 .report-a-problem-container{
+  @extend %site-width-container;
   clear: both;
 
   .report-a-problem-inner {
@@ -81,5 +82,6 @@
 }
 
 .report-a-problem-toggle-wrapper {
+  @extend %site-width-container;
   clear:both;
 }


### PR DESCRIPTION
We're seeing problems with the position of the report a problem link on various pages including the homepage and on Whitehall.

![screen shot 2015-10-12 at 16 04 07](https://cloud.githubusercontent.com/assets/319055/10431077/e93007aa-70fa-11e5-846e-5495e6ea6beb.png)

Reverts commit 6fa1eb582bcd75737b8277f0efa751c953f355e9, reversing
changes made to 52a5f91cfd9194393f37c8a234a85385481118bd.

Reverts #660 

cc @dsingleton @benilovj 