### PR TITLE
Fix analytics component fixtures

### DIFF
--- a/app/views/govuk_component/docs.yml
+++ b/app/views/govuk_component/docs.yml
@@ -445,8 +445,7 @@
 
     The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
   fixtures:
-    default: {}
-    with_organisations:
+    default:
       content_item:
         links:
           organisations:


### PR DESCRIPTION
The component doc page was erroring as the default fixture doesn't
have enough data to actually render the component, and was [erroring](http://govuk-component-guide.herokuapp.com/components/analytics_meta_tags)
on `content_item["links"] || {}`.

Replace the empty default with the first, that has the required
data.

Note; this component is unusual, in that it's highly coupled to the
structure of Content Items, and uses non-mustache compataible ERB
features, both of which kind of go against the principles of
components, and i'm not sure it's quite right. Or at least, if we're
going to do it, we should do it everywhere and save some pain.