### PR TITLE
Remove broken analytics component fixture

### DIFF
--- a/app/views/govuk_component/docs/analytics_meta_tags.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags.yml
@@ -7,7 +7,6 @@ body: |
 
   The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
 fixtures:
-  default: {}
   with_organisations:
     content_item:
       links:


### PR DESCRIPTION
The component expects a content item, and a fixture with no arguments
will A) isn't meaningful, and B) causes an error in the component guide