### PR TITLE
Remove unnecessary '---' from component YML, and fix generator

### DIFF
--- a/app/views/govuk_component/docs/alpha_label.yml
+++ b/app/views/govuk_component/docs/alpha_label.yml
@@ -1,4 +1,3 @@
----
 name: Alpha Banner
 description: A banner that indicates content is in an alpha phase with an optional
   explanation

--- a/app/views/govuk_component/docs/analytics_meta_tags.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags.yml
@@ -1,4 +1,3 @@
----
 name: Analytics Meta Tags
 description: Meta tags to provide analytics information about the current page
 body: |

--- a/app/views/govuk_component/docs/beta_label.yml
+++ b/app/views/govuk_component/docs/beta_label.yml
@@ -1,4 +1,3 @@
----
 name: Beta Banner
 description: A banner that indicates content is in a beta phase with an optional explanation
 fixtures:

--- a/app/views/govuk_component/docs/document_footer.yml
+++ b/app/views/govuk_component/docs/document_footer.yml
@@ -1,4 +1,3 @@
----
 name: Document footer metadata
 description: A metadata block to be displayed below the document
 fixtures:

--- a/app/views/govuk_component/docs/government_navigation.yml
+++ b/app/views/govuk_component/docs/government_navigation.yml
@@ -1,4 +1,3 @@
----
 name: Government navigation
 description: Navigation placed in the header by Slimmer and used by pages which sit
   under the /government path. This is a markup only component and is not available

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -1,4 +1,3 @@
----
 name: Govspeak content
 description: To display long form text which has been converted from markdown
 fixtures:

--- a/app/views/govuk_component/docs/metadata.yml
+++ b/app/views/govuk_component/docs/metadata.yml
@@ -1,4 +1,3 @@
----
 name: Metadata block
 description: To display relevant metadata about organisations and tags for a document
 fixtures:

--- a/app/views/govuk_component/docs/option_select.yml
+++ b/app/views/govuk_component/docs/option_select.yml
@@ -1,4 +1,3 @@
----
 name: Option select
 description: A scrollable list of checkboxes to be displayed on a form where one might
   otherwise use a multi-select

--- a/app/views/govuk_component/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_component/docs/previous_and_next_navigation.yml
@@ -1,4 +1,3 @@
----
 name: Previous and next navigation
 description: Navigational links that allow users navigate within a series of pages
   or elements.

--- a/app/views/govuk_component/docs/title.yml
+++ b/app/views/govuk_component/docs/title.yml
@@ -1,4 +1,3 @@
----
 name: Page title
 description: A page title with optional context label
 body: |

--- a/lib/generators/govuk_component/templates/component.yml
+++ b/lib/generators/govuk_component/templates/component.yml
@@ -1,10 +1,10 @@
-- name: "<%= human_name %>"
-  description: "A short description of the <%= human_name %> component"
-  body: |
-    A long form description of the <%= human_name %> component, which may
-    include markdown formatting.
+name: "<%= human_name %>"
+description: "A short description of the <%= human_name %> component"
+body: |
+  A long form description of the <%= human_name %> component, which may
+  include markdown formatting.
 
-    It should try and descrive the intent of the component, and document
-    any parameters passed to the component.
-  fixtures:
-    default: {}
+  It should try and descrive the intent of the component, and document
+  any parameters passed to the component.
+fixtures:
+  default: {}


### PR DESCRIPTION
The generator was creating a single item array, rather than a hash, due to the `-` and indentation. I just ran into this while testing a new component, but missed it in the original PR.

Remove unnecessary '---' from component YML docs. Despite Tommy's prodding in the previous PR (#664) I messed this up, the `---` isn't required, and is only inserted if you programatically write the YML files, which I did to convert the single YML file to the many smaller ones.

It's not required, and the generator wasn't creating it anyway, so we can drop it from the doc files, for simplicity's sake.
