### PR TITLE
Fix Analytics Metadata component use with fixtures

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -1,5 +1,5 @@
 <%
-  links_hash = content_item["links"] || {}
+  links_hash = content_item.with_indifferent_access["links"] || {}
 
   organisations = []
   organisations += links_hash["organisations"] || []

--- a/app/views/govuk_component/docs/analytics_meta_tags.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags.yml
@@ -10,16 +10,16 @@ fixtures:
     content_item:
       links:
         organisations:
-        - D1
-        - D3
+        - analytics_identifier: D1
+        - analytics_identifier: D3
         lead_organisations:
-        - D2
+        - analytics_identifier: D2
         supporting_organisations:
-        - EO3
+        - analytics_identifier: EO3
         worldwide_organisations:
-        - EO3
+        - analytics_identifier: EO3
   with_world_locations:
     content_item:
       links:
         world_locations:
-        - WL3
+        - analytics_identifier: WL3


### PR DESCRIPTION
Fixtures/the component guide generate an object with symbol keys,
as this is the convention of GOV.UK components, as we had confusion
between symbol and string keys, see:

  https://github.com/alphagov/static/pull/602

Analytics Metadata is an exception, because it's passed ContentItem
object directly from the `content_store` API, which will always
have string keys.

This also changes the structure of link sub-hashes to match the
structure expected by the component template, specifically, it
expects a field called `analytics_identifier` for a link, not the
link to have that as it's value.