### PR TITLE
Fix AnalyticsMetadata component in a better way

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -1,17 +1,18 @@
 <%
-  links_hash = content_item.with_indifferent_access["links"] || {}
+
+  links_hash = content_item.to_h[:links] || {}
 
   organisations = []
-  organisations += links_hash["organisations"] || []
-  organisations += links_hash["lead_organisations"] || []
-  organisations += links_hash["supporting_organisations"] || []
-  organisations += links_hash["worldwide_organisations"] || []
+  organisations += links_hash[:organisations] || []
+  organisations += links_hash[:lead_organisations] || []
+  organisations += links_hash[:supporting_organisations] || []
+  organisations += links_hash[:worldwide_organisations] || []
 
-  world_locations = links_hash["world_locations"] || []
+  world_locations = links_hash[:world_locations] || []
 %>
 <% if organisations.any? %>
-  <meta name="govuk:analytics:organisations" content="&lt;<%= organisations.map { |link| link["analytics_identifier"] }.join('><') %>&gt;">
+  <meta name="govuk:analytics:organisations" content="&lt;<%= organisations.map { |link| link[:analytics_identifier] }.join('><') %>&gt;">
 <% end %>
 <% if world_locations.any? %>
-  <meta name="govuk:analytics:world-locations" content="&lt;<%= world_locations.map { |link| link["analytics_identifier"] }.join('><') %>&gt;">
+  <meta name="govuk:analytics:world-locations" content="&lt;<%= world_locations.map { |link| link[:analytics_identifier] }.join('><') %>&gt;">
 <% end %>


### PR DESCRIPTION
Follow up to https://github.com/alphagov/static/pull/668/

With real Content Items, rather than fixtures, the object will be
a `GdsApi::Response` object, which doesn't support `with_indifferent_access`
and would break for an app passing that in.

Instead of trying to make the fixtures/content item both response to string
keys, which is an exception to the component style guide, ensure the
content item keys are all symbols, by casting to a hash.

For fixtures, this will be a no-op, for the API response it will switch to
a symbol-key'd hash, the rest of the template can then deal only with
symbol key'd hashes.

IMO this is a cleaner fix, as it also further removes the main bit of
component logic from the specific structure/object of a content item