### PR TITLE
Make the webchat unable to be interacted with, when closed

### DIFF
--- a/app/assets/stylesheets/helpers/_webchat.scss
+++ b/app/assets/stylesheets/helpers/_webchat.scss
@@ -21,7 +21,7 @@
   opacity: 1;
 }
 
-.webchat-banner h2 {
+.webchat-banner h2:first-child {
   margin-top: 0;
 }
 

--- a/app/assets/stylesheets/helpers/_webchat.scss
+++ b/app/assets/stylesheets/helpers/_webchat.scss
@@ -6,6 +6,7 @@
   padding: 0 $gutter-half;
   opacity: 0;
   margin-bottom: 0;
+  overflow: hidden;
   -webkit-transition: .7s ease-out;
   -webkit-transition-property: max-height, opacity, margin-bottom, padding-top, padding-bottom;
   transition: .7s ease-out;
@@ -14,7 +15,6 @@
 
 .webchat-banner.open {
   max-height: 200px;
-  overflow: hidden;
   padding-top: $gutter-half;
   padding-bottom: $gutter-half;
   margin-bottom: $gutter;


### PR DESCRIPTION
We’d missed a hidden overflow in the original version, which was leaving the white text unnoticed on top of the main content. The links could then be clicked, which would result in a JS error.