### PR TITLE
Only apply the web chat banner to pages it’s required on

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -38,14 +38,17 @@
     },
 
     init: function (){
-      var insertionPoint = $('.beta-wrapper').length ? $('.beta-wrapper') : $('.heading-block');
-      insertionPoint.after('<div class="webchat-banner" aria-hidden="true"><h2>Talk to an HMRC adviser online</h2><p>You can use web chat instead of calling HMRC’s helpline.</p><a href="#" class="accept">Start web chat</a> <a href="#" class="reject">I’m not interested</a></div>');
+      var insertionPoint;
 
       // IE7 can’t access webchat
       if (window.sessionStorage && window.postMessage) {
 
         // only initialise on the self assessment help page for the time being
         if (webchat.shouldOpen()) {
+
+          insertionPoint = $('.beta-wrapper').length ? $('.beta-wrapper') : $('.heading-block');
+          insertionPoint.after('<div class="webchat-banner" aria-hidden="true"><h2>Talk to an HMRC adviser online</h2><p>You can use web chat instead of calling HMRC’s helpline.</p><a href="#" class="accept">Start web chat</a> <a href="#" class="reject">I’m not interested</a></div>');
+
           webchat.$chatFrame = $('<iframe class="hidden" />');
           webchat.$banner = $('.webchat-banner');
 


### PR DESCRIPTION
The banner was being appended before the shouldOpen() check. This moves the insertion point calculation and banner appending to after that.