### PR TITLE
Add format and need-ids to analytics component

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -2,8 +2,14 @@
   # We have to call deep_symbolize_keys because we're often dealing with a
   # parsed JSON document which will have string keys by default, but our
   # components use symbol keys and we want consistency.
-  links_hash = content_item.to_h.deep_symbolize_keys[:links] || {}
+  content_item_hash = content_item.to_h.deep_symbolize_keys
+  links_hash = content_item_hash[:links] || {}
   meta_tags = {}
+
+  meta_tags["govuk:format"] = content_item_hash[:format] if content_item_hash[:format]
+
+  need_ids = content_item_hash[:need_ids] || []
+  meta_tags["govuk:need-ids"] = need_ids.join(',') if need_ids.any?
 
   organisations = []
   organisations += links_hash[:organisations] || []

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -16,12 +16,12 @@
   organisations += links_hash[:lead_organisations] || []
   organisations += links_hash[:supporting_organisations] || []
   organisations += links_hash[:worldwide_organisations] || []
-  organisations_content = organisations.map{ |link| "<#{link[:analytics_identifier]}>" }.join
-  meta_tags["govuk:analytics:organisations"] = organisations_content if organisations_content
+  organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.join
+  meta_tags["govuk:analytics:organisations"] = organisations_content if organisations.any?
 
   world_locations = links_hash[:world_locations] || []
-  world_locations_content = world_locations.map{ |link| "<#{link[:analytics_identifier]}>" }.join
-  meta_tags["govuk:analytics:world-locations"] = world_locations_content if world_locations_content
+  world_locations_content = world_locations.map { |link| "<#{link[:analytics_identifier]}>" }.join
+  meta_tags["govuk:analytics:world-locations"] = world_locations_content if world_locations.any?
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -3,18 +3,20 @@
   # parsed JSON document which will have string keys by default, but our
   # components use symbol keys and we want consistency.
   links_hash = content_item.to_h.deep_symbolize_keys[:links] || {}
+  meta_tags = {}
 
   organisations = []
   organisations += links_hash[:organisations] || []
   organisations += links_hash[:lead_organisations] || []
   organisations += links_hash[:supporting_organisations] || []
   organisations += links_hash[:worldwide_organisations] || []
+  organisations_content = organisations.map{ |link| "<#{link[:analytics_identifier]}>" }.join
+  meta_tags["govuk:analytics:organisations"] = organisations_content if organisations_content
 
   world_locations = links_hash[:world_locations] || []
+  world_locations_content = world_locations.map{ |link| "<#{link[:analytics_identifier]}>" }.join
+  meta_tags["govuk:analytics:world-locations"] = world_locations_content if world_locations_content
 %>
-<% if organisations.any? %>
-  <meta name="govuk:analytics:organisations" content="&lt;<%= organisations.map { |link| link[:analytics_identifier] }.join('><') %>&gt;">
-<% end %>
-<% if world_locations.any? %>
-  <meta name="govuk:analytics:world-locations" content="&lt;<%= world_locations.map { |link| link[:analytics_identifier] }.join('><') %>&gt;">
+<% meta_tags.each do |name, content| %>
+  <meta name="<%= name %>" content="<%= content %>">
 <% end %>

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -6,6 +6,16 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     "analytics_meta_tags"
   end
 
+  test "renders format in a meta tag" do
+    render_component(content_item: { format: "case_study" })
+    assert_meta_tag('govuk:format', 'case_study')
+  end
+
+  test "renders need IDs as a comma separated list" do
+    render_component(content_item: { need_ids: [100001, 100002] })
+    assert_meta_tag('govuk:need-ids', '100001,100002')
+  end
+
   test "renders organisations in a meta tag with angle brackets" do
     content_item = {
       links: {
@@ -17,8 +27,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     }
 
     render_component(content_item: content_item)
-
-    assert_select "meta[name='govuk:analytics:organisations'][content='<O1><L2><S3><W4>']"
+    assert_meta_tag('govuk:analytics:organisations', '<O1><L2><S3><W4>')
   end
 
   test "renders world locations in a meta tag with angle brackets" do
@@ -36,8 +45,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     }
 
     render_component(content_item: content_item)
-
-    assert_select "meta[name='govuk:analytics:world-locations'][content='<WL3><WL123>']"
+    assert_meta_tag('govuk:analytics:world-locations', '<WL3><WL123>')
   end
 
   test "handling of string keys and/or GdsApi::Response objects" do
@@ -54,7 +62,10 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     api_response = GdsApi::Response.new(net_http_response)
 
     render_component(content_item: api_response)
+    assert_meta_tag('govuk:analytics:world-locations', '<WL3>')
+  end
 
-    assert_select "meta[name='govuk:analytics:world-locations'][content='<WL3>']"
+  def assert_meta_tag(name, content)
+    assert_select "meta[name='#{name}'][content='#{content}']"
   end
 end

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -6,6 +6,10 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     "analytics_meta_tags"
   end
 
+  test "no meta tags are rendered when there's no trackable data" do
+    assert_empty render_component(content_item: {})
+  end
+
   test "renders format in a meta tag" do
     render_component(content_item: { format: "case_study" })
     assert_meta_tag('govuk:format', 'case_study')


### PR DESCRIPTION
https://trello.com/c/2LJAtceC/156-new-world-analytics-component-medium
Allow format and Need IDs to be tracked to Google Analytics through the existing component.

Matches the format that "old world" frontends are using via Slimmer:
https://github.com/alphagov/slimmer/blob/master/lib/slimmer/processors/metadata_inserter.rb

cc @jamiecobbett @dsingleton 