### PR TITLE
Nokogiri 1.6.6.5 pre release

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'uglifier', ">= 1.3.0"
 gem 'sass-rails', "5.0.4"
 gem 'airbrake', '~> 4.3.1'
 
+gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
+
 group :development do
   gem 'image_optim', '0.17.1'
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: git://github.com/alphagov/nokogiri.git
+  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
+  branch: v1.6.6.5.rc
+  specs:
+    nokogiri (1.6.6.5.20151124112525)
+      mini_portile (~> 0.6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -128,8 +136,6 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
@@ -251,6 +257,7 @@ DEPENDENCIES
   minitest
   minitest-capybara (~> 0.7.2)
   mocha (~> 1.1.0)
+  nokogiri!
   plek (= 1.11.0)
   pry
   quiet_assets (= 1.1.0)


### PR DESCRIPTION
This builds against an unofficial hacked-together release branch of nokogiri: https://github.com/sparklemotion/nokogiri/compare/v1.6.6.4...alphagov:v1.6.6.5.rc#diff-6ec7138703b74a4663177519781472b6

Addresses the security vulnerabilities in libxml2 by vendoring v2.9.3. Release announcement: http://www.xmlsoft.org/bugs.html

A similar PR exists in alphagov/whitehall#2389