### PR TITLE
Revert "Nokogiri 1.6.6.5 pre release"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,8 +11,6 @@ gem 'uglifier', ">= 1.3.0"
 gem 'sass-rails', "5.0.4"
 gem 'airbrake', '~> 4.3.1'
 
-gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
-
 group :development do
   gem 'image_optim', '0.17.1'
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/nokogiri.git
-  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
-  branch: v1.6.6.5.rc
-  specs:
-    nokogiri (1.6.6.5.20151124112525)
-      mini_portile (~> 0.6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,6 +128,8 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
     netrc (0.10.3)
+    nokogiri (1.6.6.2)
+      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
@@ -257,7 +251,6 @@ DEPENDENCIES
   minitest
   minitest-capybara (~> 0.7.2)
   mocha (~> 1.1.0)
-  nokogiri!
   plek (= 1.11.0)
   pry
   quiet_assets (= 1.1.0)


### PR DESCRIPTION
Reverts alphagov/static#679

Nokogiri will be cutting an [official release soon](https://github.com/sparklemotion/nokogiri/pull/1378#issuecomment-159447729) after more testing. This hacked together release is causing some developers issues with building Nokogiri, and the security vulnerabilities are no longer thought to be too severe.

Reverting all PRs that use this temporary release.

/cc @bradwright 