### PR TITLE
Use stable version of Nokogiri

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'uglifier', ">= 1.3.0"
 gem 'sass-rails', "5.0.4"
 gem 'airbrake', '~> 4.3.1'
 
-gem 'nokogiri', github: "alphagov/nokogiri", branch: "v1.6.6.5.rc"
+gem 'nokogiri', "~> 1.6.6.4"
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/nokogiri.git
-  revision: 597dd3bb86df337b310bf22c8224884c9fc5161a
-  branch: v1.6.6.5.rc
-  specs:
-    nokogiri (1.6.6.5.20151124112525)
-      mini_portile (~> 0.6.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -136,6 +128,8 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.11.2)
     netrc (0.10.3)
+    nokogiri (1.6.6.4)
+      mini_portile (~> 0.6.0)
     null_logger (0.0.1)
     parser (2.2.2.6)
       ast (>= 1.1, < 3.0)
@@ -257,7 +251,7 @@ DEPENDENCIES
   minitest
   minitest-capybara (~> 0.7.2)
   mocha (~> 1.1.0)
-  nokogiri!
+  nokogiri (~> 1.6.6.4)
   plek (= 1.11.0)
   pry
   quiet_assets (= 1.1.0)
@@ -269,3 +263,6 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (= 4.9.0)
   webmock
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Nokogiri will be cutting an official release soon after more testing. This
hacked together release is causing some developers issues with building
Nokogiri, and the security vulnerabilities are no longer thought to be too
severe. Whilst we wait for an official release, we should revert as far as the
most recent stable release, 1.6.6.4, as this does address some security
vulnerabilites.