### PR TITLE
Add unit tests for all existing components

### DIFF
--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -1,3 +1,4 @@
+<% if local_assigns.include?(:next_page) || local_assigns.include?(:previous_page) %>
 <nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>
@@ -18,3 +19,4 @@
     <% end %>
   </ul>
 </nav>
+<% end %>

--- a/test/govuk_component/beta_label_test.rb
+++ b/test/govuk_component/beta_label_test.rb
@@ -1,0 +1,24 @@
+require 'govuk_component_test_helper'
+
+class BetaLabelTestCase < ComponentTestCase
+  def component_name
+    "beta_label"
+  end
+
+  test "no error if no message" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".govuk-beta-label"
+    end
+  end
+
+  test "custom message appears" do
+    render_component(message: "custom message")
+    assert_select ".govuk-beta-label span", text: "custom message"
+  end
+
+  test "custom message HTML works" do
+    render_component(message: "custom <strong>message</strong>")
+    assert_select ".govuk-beta-label strong", text: "message"
+  end
+end

--- a/test/govuk_component/document_footer_test.rb
+++ b/test/govuk_component/document_footer_test.rb
@@ -1,0 +1,109 @@
+require 'govuk_component_test_helper'
+
+class DocumentFooterTestCase < ComponentTestCase
+  def component_name
+    "document_footer"
+  end
+
+  test "renders document metadata in a footer based on data provided" do
+    render_component({})
+    assert_select ".govuk-document-footer h2", text: "Document information"
+
+    assert_select ".published", false
+    assert_select ".updated", false
+    assert_select ".other-date", false
+    assert_select ".change-notes", false
+    assert_select ".from", false
+    assert_select ".part-of", false
+    assert_select ".other", false
+  end
+
+  test "renders the deparments a document is from" do
+    render_component({
+      from: [
+        "<a href='/space-travel'>Department for Space Travel</a>",
+        "<a href='/extra-solar-exploration'>Extra Solar Exploration Office</a>"
+      ]
+    })
+
+    assert_link_with_text_in(".from .definition", "/space-travel", "Department for Space Travel")
+    assert_link_with_text_in(".from .definition", "/extra-solar-exploration", "Extra Solar Exploration Office")
+  end
+
+  test "renders things the document is part of" do
+    render_component({
+      part_of: [
+        "<a href='/space'>Space</a>",
+        "<a href='/astro-engineering'>Astro Engineering</a>"
+      ]
+    })
+
+    assert_link_with_text_in(".part-of .definition", "/space", "Space")
+    assert_link_with_text_in(".part-of .definition", "/astro-engineering", "Astro Engineering")
+  end
+
+  test "renders custom metadata" do
+    render_component({
+      other: {
+        "Space travel type": "<a href='/faster-than-light'>Faster than light</a>"
+      }
+    })
+
+    assert_select 'p', text: /Space travel type/
+    assert_link_with_text_in(".other .definition", "/faster-than-light", "Faster than light")
+  end
+
+  test "renders custom document dates" do
+    render_component({
+      published: "20 January 2092",
+      updated: "22 January 2092",
+      other_dates: {
+        "Date opened": "1 February 2092",
+        "Date closed": "1 March 2093"
+      }
+    })
+
+    assert_select 'p', text: 'Published: 20 January 2092'
+    assert_select 'p', text: 'Updated: 22 January 2092'
+    assert_select 'p', text: 'Date opened: 1 February 2092'
+    assert_select 'p', text: 'Date closed: 1 March 2093'
+  end
+
+  test "renders document history" do
+    render_component({
+      history: [
+        {
+          display_time: "22 January 2012",
+          timestamp: "22-01-2012Z14:19:00T",
+          note: "We updated the document"
+        },
+        {
+          display_time: "24 January 2012",
+          timestamp: "24-01-2012Z14:19:00T",
+          note: "We updated the document again"
+        }
+      ]
+    })
+
+    assert_timestamp_in('.change-notes', '22-01-2012Z14:19:00T', '22 January 2012')
+    assert_select 'li', text: /We updated the document$/
+
+    assert_timestamp_in('.change-notes', '24-01-2012Z14:19:00T', '24 January 2012')
+    assert_select 'li', text: /We updated the document again/
+
+    assert_select '.change-notes li', count: 2
+  end
+
+  test "supports right to left content" do
+    render_component({direction: "rtl"})
+    assert_select '.govuk-document-footer.direction-rtl'
+  end
+
+  def assert_link_with_text_in(selector, link, text)
+    assert_select "#{selector} a[href=\"#{link}\"]", text: text
+  end
+
+  def assert_timestamp_in(selector, timestamp, text)
+    assert_select "#{selector} time[datetime=\"#{timestamp}\"]", text: text
+  end
+end

--- a/test/govuk_component/document_footer_test.rb
+++ b/test/govuk_component/document_footer_test.rb
@@ -98,12 +98,4 @@ class DocumentFooterTestCase < ComponentTestCase
     render_component({direction: "rtl"})
     assert_select '.govuk-document-footer.direction-rtl'
   end
-
-  def assert_link_with_text_in(selector, link, text)
-    assert_select "#{selector} a[href=\"#{link}\"]", text: text
-  end
-
-  def assert_timestamp_in(selector, timestamp, text)
-    assert_select "#{selector} time[datetime=\"#{timestamp}\"]", text: text
-  end
 end

--- a/test/govuk_component/government_navigation_test.rb
+++ b/test/govuk_component/government_navigation_test.rb
@@ -22,8 +22,4 @@ class GovernmentNavigationTestCase < ComponentTestCase
     render_component({active: 'departments'})
     assert_select "a.active", text: "Departments"
   end
-
-  def assert_link_with_text(link, text)
-    assert_select "a[href=\"#{link}\"]", text: text
-  end
 end

--- a/test/govuk_component/government_navigation_test.rb
+++ b/test/govuk_component/government_navigation_test.rb
@@ -1,0 +1,29 @@
+require 'govuk_component_test_helper'
+
+class GovernmentNavigationTestCase < ComponentTestCase
+  def component_name
+    "government_navigation"
+  end
+
+  test "renders a list of government links" do
+    render_component({})
+    assert_select "\#proposition-links li a", text: "Departments"
+    assert_link_with_text("/government/organisations", "Departments")
+    assert_link_with_text("/government/announcements", "Announcements")
+    # etc.
+  end
+
+  test "no links are active by default" do
+    render_component({})
+    assert_select "a.active", false
+  end
+
+  test "can mark a link as active" do
+    render_component({active: 'departments'})
+    assert_select "a.active", text: "Departments"
+  end
+
+  def assert_link_with_text(link, text)
+    assert_select "a[href=\"#{link}\"]", text: text
+  end
+end

--- a/test/govuk_component/govspeak_test.rb
+++ b/test/govuk_component/govspeak_test.rb
@@ -1,0 +1,28 @@
+require 'govuk_component_test_helper'
+
+class GovspeakTestCase < ComponentTestCase
+  def component_name
+    "govspeak"
+  end
+
+  test "renders content in a govspeak wrapper" do
+    render_component({content: '<h1>content</h1>'})
+    assert_select ".govuk-govspeak h1", text: 'content'
+  end
+
+  test "renders right to left content correctly" do
+    render_component({
+      direction: "rtl",
+      content: "<h2>right to left</h2>"})
+
+    assert_select ".direction-rtl h2", text: 'right to left'
+  end
+
+  test "can enable rich govspeak" do
+    render_component({
+      rich_govspeak: true,
+      content: "<strong>boldly go</strong>"})
+
+    assert_select ".rich-govspeak strong", text: 'boldly go'
+  end
+end

--- a/test/govuk_component/metadata_test.rb
+++ b/test/govuk_component/metadata_test.rb
@@ -1,0 +1,72 @@
+require 'govuk_component_test_helper'
+
+class MetadataTestCase < ComponentTestCase
+  def component_name
+    "metadata"
+  end
+
+  test "renders metadata in a definition list" do
+    render_component({})
+    assert_select ".govuk-metadata dl"
+
+    assert_select "dd", false
+    assert_select "dt", false
+  end
+
+  test "renders from metadata" do
+    render_component({
+      from: "<a href='/link'>Department</a>"
+    })
+
+    assert_definition('From:', 'Department')
+    assert_link_with_text_in('dd', '/link', 'Department')
+  end
+
+  test "renders part of metadata" do
+    render_component({
+      part_of: "<a href='/link'>Department</a>"
+    })
+
+    assert_definition('Part of:', 'Department')
+    assert_link_with_text_in('dd', '/link', 'Department')
+  end
+
+  test "renders history metadata" do
+    render_component({
+      history: "Updated 2 weeks ago"
+    })
+
+    assert_definition('History:', 'Updated 2 weeks ago')
+  end
+
+  test "renders custom metadata" do
+    render_component({
+      other: {
+        "Related topics": [
+          "<a href='/government/topics/arts-and-culture'>Arts and culture</a>",
+          "<a href='/government/topics/sports-and-leisure'>Sports and leisure</a>"
+        ],
+        "Applies to": "England"
+      }
+    })
+
+    assert_definition('Related topics:', 'Arts and culture and Sports and leisure')
+    assert_definition('Applies to:', 'England')
+    assert_link_with_text_in('dd', '/government/topics/arts-and-culture', 'Arts and culture')
+    assert_link_with_text_in('dd', '/government/topics/sports-and-leisure', 'Sports and leisure')
+  end
+
+  test "renders multiples as a single sentence (except history)" do
+    render_component({
+      from: %w( one another ),
+      part_of: %w( this that ),
+      other: {
+        "Related topics": %w( a b c )
+      }
+    })
+
+    assert_definition('From:', 'one and another')
+    assert_definition('Part of:', 'this and that')
+    assert_definition('Related topics:', 'a, b, and c')
+  end
+end

--- a/test/govuk_component/option_select_test.rb
+++ b/test/govuk_component/option_select_test.rb
@@ -1,0 +1,92 @@
+require 'govuk_component_test_helper'
+
+class OptionSelectTestCase < ComponentTestCase
+  def component_name
+    "option_select"
+  end
+
+  def option_key
+    "key"
+  end
+
+  def option_select_arguments
+    {
+      key: option_key,
+      title: "Market sector",
+      options_container_id: "list-of-sectors",
+      options: [
+        {
+          value: "aerospace",
+          label: "Aerospace",
+          id: "aerospace"
+        },
+        {
+          value: "value",
+          label: "Label",
+          id: "ID"
+        }
+      ]
+    }
+  end
+
+  test "renders a heading for the option select box containing the title" do
+    render_component(option_select_arguments)
+    assert_select ".option-select-label", text: "Market sector"
+  end
+
+  test "renders a container with the id passed in" do
+    render_component(option_select_arguments)
+    assert_select "\#list-of-sectors.options-container"
+  end
+
+  test "renders a list of checkboxes" do
+    render_component(option_select_arguments)
+
+    assert_label_and_checkbox("Aerospace", "aerospace", "aerospace")
+    assert_label_and_checkbox("Label", "ID", "value")
+  end
+
+  test "can set checkboxes to be pre-selected" do
+    arguments = option_select_arguments
+    arguments[:options][0][:checked] = true
+    arguments[:options][1][:checked] = true
+    render_component(arguments)
+
+    assert_label_and_checked_checkbox("Aerospace", "aerospace", "aerospace")
+    assert_label_and_checked_checkbox("Label", "ID", "value")
+  end
+
+  test "can indicate that the checkboxes control content displayed via aria-controls-id" do
+    arguments = option_select_arguments
+    arguments[:aria_controls_id] = "aria-controls-id"
+    render_component(arguments)
+
+    assert_select 'input[aria-controls="aria-controls-id"]', count: 2
+  end
+
+  test "can begin with the options box closed on load" do
+    arguments = option_select_arguments
+    arguments[:closed_on_load] = true
+    render_component(arguments)
+
+    assert_select '.govuk-option-select[data-closed-on-load="true"]'
+  end
+
+  def assert_label_and_checked_checkbox(label, id, value)
+    assert_label_and_checkbox(label, id, value, true)
+  end
+
+  def assert_label_and_checkbox(label, id, value, checked = false)
+    expected_name = "[name='#{option_key}[]']"
+    expected_id = "[id='#{option_key}-#{id}']"
+    expected_value = "[value='#{value}']"
+    expected_checked = checked ? "[checked='checked']" : ""
+
+    assert_select expected_name
+    assert_select expected_id
+    assert_select expected_value
+
+    assert_select "label[for='#{option_key}-#{id}']", text: label
+    assert_select "input[type='checkbox']#{expected_name}#{expected_id}#{expected_value}#{expected_checked}"
+  end
+end

--- a/test/govuk_component/preview_and_next_navigation_test.rb
+++ b/test/govuk_component/preview_and_next_navigation_test.rb
@@ -32,8 +32,4 @@ class PreviousAndNextNavigationTestCase < ComponentTestCase
     assert_select ".pagination-label", text: "2 of 3"
     assert_link("next-page")
   end
-
-  def assert_link(link)
-    assert_select "a[href=\"#{link}\"]"
-  end
 end

--- a/test/govuk_component/preview_and_next_navigation_test.rb
+++ b/test/govuk_component/preview_and_next_navigation_test.rb
@@ -1,0 +1,39 @@
+require 'govuk_component_test_helper'
+
+class PreviousAndNextNavigationTestCase < ComponentTestCase
+  def component_name
+    "previous_and_next_navigation"
+  end
+
+  test "nothing renders if no parameters" do
+    assert_empty render_component({})
+  end
+
+  test "previous pagination appears" do
+    render_component(previous_page: {
+      url: "previous-page",
+      title: "Previous page",
+      label: "1 of 3"
+    })
+
+    assert_select ".pagination-part-title", text: "Previous page"
+    assert_select ".pagination-label", text: "1 of 3"
+    assert_link("previous-page")
+  end
+
+  test "next pagination appears" do
+    render_component(next_page: {
+      url: "next-page",
+      title: "Next page",
+      label: "2 of 3"
+    })
+
+    assert_select ".pagination-part-title", text: "Next page"
+    assert_select ".pagination-label", text: "2 of 3"
+    assert_link("next-page")
+  end
+
+  def assert_link(link)
+    assert_select "a[href=\"#{link}\"]"
+  end
+end

--- a/test/govuk_component_test_helper.rb
+++ b/test/govuk_component_test_helper.rb
@@ -8,4 +8,25 @@ class ComponentTestCase < ActionView::TestCase
   def render_component(locals)
     render file: "govuk_component/#{component_name}.raw", locals: locals
   end
+
+  def assert_definition(term, definition)
+    assert_select "dt", text: term
+    assert_select "dd", text: definition
+  end
+
+  def assert_link(link)
+    assert_select "a[href=\"#{link}\"]"
+  end
+
+  def assert_link_with_text(link, text)
+    assert_select "a[href=\"#{link}\"]", text: text
+  end
+
+  def assert_link_with_text_in(selector, link, text)
+    assert_select "#{selector} a[href=\"#{link}\"]", text: text
+  end
+
+  def assert_timestamp_in(selector, timestamp, text)
+    assert_select "#{selector} time[datetime=\"#{timestamp}\"]", text: text
+  end
 end


### PR DESCRIPTION
https://trello.com/c/NLkm3EDy/17-unit-test-components

Includes:
* Beta label
* Govspeak
* Pagination
* Government navigation
* Document footer
* Option select
* Metadata

Also adds some test helpers for making future component unit tests easier, eg
```ruby
def assert_link_with_text(link, text)
   assert_select "a[href=\"#{link}\"]", text: text
end
```

cc @dsingleton @jamiecobbett 