### PR TITLE
Update webchat URL to point at HMRC

### DIFF
--- a/app/assets/javascripts/webchat-iframe.html.erb
+++ b/app/assets/javascripts/webchat-iframe.html.erb
@@ -24,7 +24,7 @@
     }
 
     function loadIFrame(pageURL, pageTitle) {
-      var src = 'https://mcb.kcom.com/system/Offers.egain?command=GetRulesJS&egofferpageurl=' + pageURL + '&egofferpagetitle=' + pageTitle + '&egofferpatternchecksum=';
+      var src = 'https://online.hmrc.gov.uk/webchat/Offers.egain?command=GetRulesJS&egofferpageurl=' + pageURL + '&egofferpagetitle=' + pageTitle + '&egofferpatternchecksum=';
 
       var script = $('<script/>');
       script.on('load', function(){


### PR DESCRIPTION
Jonathan Charlton at kcom provided this new URL to load the script from. Checking in the network panel in-browser shows this URL returning a 200 and what looks like the necessary script.

![screen shot 2015-12-01 at 12 58 16](https://cloud.githubusercontent.com/assets/7414/11501334/423125e4-982b-11e5-8b26-cd3bf33002c2.png)

I’m yet to see an offer appear, but this is likely due to lack of operators.