### PR TITLE
Update offer selector to match new eGain version

### DIFF
--- a/app/assets/javascripts/webchat-iframe.html.erb
+++ b/app/assets/javascripts/webchat-iframe.html.erb
@@ -11,7 +11,7 @@
     'use strict';
 
     function isOfferOpen() {
-      var ribbonContainer = document.querySelector('#egofr-hmrc5-container');
+      var ribbonContainer = document.querySelector('#egofr-hmrc-container');
       return ribbonContainer && ribbonContainer.parentNode.style.visibility !== 'hidden';
     }
 


### PR DESCRIPTION
When the version of eGain changed it altered the selector that we need
to look for to see if the offer has been opened. This brings it in line
to what is in production.