### PR TITLE
Allow option-selects to send their 'closed state' with their form data

### DIFF
--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -43,6 +43,11 @@
       if (this.$optionSelect.data('closed-on-load') == true) {
         this.close();
       }
+
+      var closedStateName = this.$optionSelect.data('closed-state-name');
+      if (closedStateName !== undefined) {
+        this.$closedStateField = this.attachStateField(closedStateName);
+      }
     }
   }
 
@@ -69,8 +74,20 @@
     this.$optionSelect.find('.js-container-head').append('<div class="js-selected-counter">'+this.checkedString()+'</div>');
   };
 
+  OptionSelect.prototype.attachStateField = function attachStateField(name){
+    var $closedStateField = $('<input type="hidden" name="'+name+'" value="'+this.isClosed()+'" />');
+    this.$optionList.append($closedStateField);
+    return $closedStateField;
+  }
+
   OptionSelect.prototype.updateCheckedCount = function updateCheckedCount(){
     this.$optionSelect.find('.js-selected-counter').text(this.checkedString());
+  };
+
+  OptionSelect.prototype.updateClosedStateField = function updateClosedStateField(){
+    if (typeof this.$closedStateField !== 'undefined'){
+      this.$closedStateField.val(this.isClosed().toString());
+    }
   };
 
   OptionSelect.prototype.checkedString = function checkedString(){
@@ -101,11 +118,13 @@
         this.setupHeight();
       }
     }
+    this.updateClosedStateField();
   };
 
   OptionSelect.prototype.close = function close(){
     this.$optionSelect.addClass('js-closed');
     this.$optionSelect.find('.js-container-head').attr('aria-expanded', false);
+    this.updateClosedStateField();
   };
 
   OptionSelect.prototype.isClosed = function isClosed(){

--- a/app/views/govuk_component/docs/option_select.yml
+++ b/app/views/govuk_component/docs/option_select.yml
@@ -94,3 +94,18 @@ fixtures:
     - value: sombrero
       label: Sombrero
       id: sombrero
+  with_closed_state_field:
+    key: closed_state_field
+    title: Famous women in tech
+    closed_state_name: famous_women_in_tech_closed
+    options_container_id: famous_women_in_tech
+    options:
+    - value: fran_allen
+      label: Fran Allen
+      id: fran_allen
+    - value: grace_hopper
+      label: Grace Hopper
+      id: grace_hopper
+    - value: dame_steve_shirley
+      label: Dame Steve Shirley
+      id: dame_steve_shirley

--- a/app/views/govuk_component/option_select.raw.html.erb
+++ b/app/views/govuk_component/option_select.raw.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-option-select" <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %>>
+<div class="govuk-option-select" <% if local_assigns.include?(:closed_on_load) && closed_on_load %>data-closed-on-load="true"<% end %><% if local_assigns.include?(:closed_state_name) && closed_state_name %>data-closed-state-name="<%= closed_state_name %>"<% end %>>
   <div class="container-head js-container-head">
     <div class='option-select-label'><%= title %></div>
   </div>

--- a/spec/javascripts/govuk-component/option-select-spec.js
+++ b/spec/javascripts/govuk-component/option-select-spec.js
@@ -108,6 +108,55 @@ describe('GOVUK.OptionSelect', function() {
     });
   });
 
+  describe('closed state field', function(){
+    var $hasClosedStateFixture;
+
+    beforeEach(function() {
+      $hasClosedStateFixture = $(
+        '<div class="govuk-option-select" data-closed-state-name="market-sector-closed">' +
+          '<div class="options-container">' +
+            '<div class="js-auto-height-inner"></div>' +
+          '</div>' +
+        '</div>'
+      );
+    });
+
+    afterEach(function(){
+      $hasClosedStateFixture.remove();
+    });
+
+    it("creates a closed state field if the 'data-closed-state-name' attribute is set", function(){
+      var $closedStateField;
+
+      $('body').append($hasClosedStateFixture);
+      optionSelect = new GOVUK.OptionSelect({$el:$hasClosedStateFixture});
+      $closedStateField = $hasClosedStateFixture.find('input[name="market-sector-closed"]');
+      expect($closedStateField.length).toEqual(1);
+      expect($closedStateField.val()).toBe('false');
+    });
+
+    it("sets the closed state field to 'closed' when it exists and optionSelect.close() is called", function(){
+      var $closedStateField;
+
+      $('body').append($hasClosedStateFixture);
+      optionSelect = new GOVUK.OptionSelect({$el:$hasClosedStateFixture});
+      $closedStateField = $hasClosedStateFixture.find('input[name="market-sector-closed"]');
+      optionSelect.close();
+      expect($closedStateField.val()).toBe('true');
+    });
+
+    it("sets the closed state field to 'open' when it exists and optionSelect.open() is called", function(){
+      var $closedStateField;
+
+      $hasClosedStateFixture.data('closed-on-load', 'true');
+      $('body').append($hasClosedStateFixture);
+      optionSelect = new GOVUK.OptionSelect({$el:$hasClosedStateFixture});
+      $closedStateField = $hasClosedStateFixture.find('input[name="market-sector-closed"]');
+      optionSelect.open();
+      expect($closedStateField.val()).toBe('false');
+    });
+  });
+
   describe('open', function(){
     beforeEach(function(){
       spyOn(optionSelect, "isClosed").and.returnValue(true);


### PR DESCRIPTION
This pull request is aimed at solving an issue found when using option-selects without AJAX.

### The problem

1. the option-select is in a form which posts to its parent page without the use of JavaScript (ie a search results page with option-selects used for filtering)
2. every time the form is submitted the option-selects do not remember whether they were closed or open when a new version of the page is returned

### Why it's only come up now

Option-selects are used on www.gov.uk in pages where, if the JavaScript sent runs, all form submissions use AJAX meaning the option-select HTML is not reloaded so this is not a problem.

### How this pull request attempts to solve it

These changes allow option-selects that do not use JavaScript for form submissions to preserve their 'closed state' by sending it in the form data.

A `closed_state_name` parameter can be added to the component data which is used by the option-select JavaScript to create a hidden `<input>` tag with that name. This is used to send the 'closed state' of the option-select in the form data.

![image](https://cloud.githubusercontent.com/assets/87140/11953690/08ef09ac-a89a-11e5-8959-4f48985b895a.png)

![image](https://cloud.githubusercontent.com/assets/87140/11953580/4e74fdde-a899-11e5-9730-3b1b2e0eb096.png)

Any help getting this to an acceptable state much appreciated @fofr, @dsingleton, @quis, @gemmaleigh.
