### PR TITLE
Add component unit test to component generator

### DIFF
--- a/doc/govuk-components.md
+++ b/doc/govuk-components.md
@@ -7,10 +7,11 @@ The partial is exposed over the network, and the CSS/JS are included by the shar
 The available components and their documentation are exposed by an API at `/templates/govuk_component/docs`, which is consumed by
 [alphagov/govuk_component_guide](https://github.com/alphagov/govuk_component_guide) to generate a living styleguide for components.
 
-* a [Partial View](app/views/govuk_component) - The template logic and markup, also defines the arguments expected
-* a [SCSS module](app/assets/stylesheets/govuk-component) - The styling of the component
+* a [Partial View](../app/views/govuk_component) - The template logic and markup, also defines the arguments expected
+* a [SCSS module](../app/assets/stylesheets/govuk-component) - The styling of the component
 * a Javascript module - no examples yet.
-* [Documentation](app/views/govuk_component/docs) - a `.yml` per component, describing the component and containing fixture data.
+* [Documentation](../app/views/govuk_component/docs) - a `.yml` per component, describing the component and containing fixture data.
+* a [unit test](../test/govuk_component) - testing the component renders correctly based on parameters passed in
 
 ## Creating a new component
 
@@ -28,7 +29,9 @@ When referenced from an application as a partial they'll be prefixed with `govuk
 
 To match rails view convention the partial itself should use an underscore, rather than a hyphen.
 
-1) views live in `app/views/govuk_component/your_compontent_name.raw.html.erb` - There should be a single root element, with a class name consisting of the prefixed component name. For example:
+### Views
+
+Views live in `app/views/govuk_component/your_compontent_name.raw.html.erb` - There should be a single root element, with a class name consisting of the prefixed component name. For example:
 ```
 <div class="govuk-your-component-name">
 <p>things</p>
@@ -37,7 +40,9 @@ To match rails view convention the partial itself should use an underscore, rath
 
 _Note_: For consistency with other components, and Rails convention, you should only use `:symbols`, rather than `"strings"`, for object keys.
 
-2) There is a SCSS module at `app/stylesheets/govuk-component/_your-component-name.scss` - there should be a single root class, the same class on the root of the partial. For example:
+### Styles
+
+There is a Sass module at `app/stylesheets/govuk-component/_your-component-name.scss` - there should be a single root class, the same class on the root of the partial. For example:
 ```
 .govuk-your-component-name {
   // CSS rules go here.
@@ -47,9 +52,11 @@ _Note_: For consistency with other components, and Rails convention, you should 
 }
 ```
 
-3) SCSS modules are included in `app/stylesheets/govuk-component/_component.scss` - which is used in the standard static layout SCSS files (application.scss, header_footer_only.scss)
+Sass modules are included in `app/stylesheets/govuk-component/_component.scss` - which is used in the standard static layout SCSS files (application.scss, header_footer_only.scss)
 
-4) Documentation lives [`app/views/govuk_component/docs`](app/views/govuk_component/docs), where each component has a `.yml` file describing:
+### Examples and documentation
+
+Documentation lives [`app/views/govuk_component/docs`](../app/views/govuk_component/docs), where each component has a `.yml` file describing:
 * `id`: The underscore version of the component name, this is what an app calling the component would use
 * `name`: The human name. eg, `Your Example Component`
 * `description`: A longer form description of what the component does, when it should be used
@@ -58,4 +65,6 @@ _Note_: For consistency with other components, and Rails convention, you should 
 Adding it to the documentation will allow you to preview it in the `govuk_component_guide`, which can be pointed to any
 version of static, including your local one running a branch. Which you should probably do.
 
+### Unit tests
 
+Unit tests for components live in [`test/govuk_component`](../test/govuk_component). Tests should extend the [`ComponentTestCase`](../test/govuk_component_test_helper.rb) which provides helper methods for rendering a component and for asserting certain markup exists, eg `assert_link_with_text`.

--- a/lib/generators/govuk_component/USAGE
+++ b/lib/generators/govuk_component/USAGE
@@ -2,4 +2,4 @@ Description:
     Generates a new GOV.UK component
 
 Example:
-    rails generate govuk_component [compontent_name]
+    rails generate govuk_component [component_name]

--- a/lib/generators/govuk_component/govuk_component_generator.rb
+++ b/lib/generators/govuk_component/govuk_component_generator.rb
@@ -5,9 +5,11 @@ class GovukComponentGenerator < Rails::Generators::NamedBase
 
   def copy_component_files
     @public_name = file_name.dasherize
+    @test_name = file_name.camelize
 
     template 'component.html.erb', "app/views/govuk_component/#{file_name}.raw.html.erb"
     template 'component.yml', "app/views/govuk_component/docs/#{file_name}.yml"
+    template 'component_test.rb.erb', "test/govuk_component/#{file_name}_test.rb"
 
     template '_component.scss', "app/assets/stylesheets/govuk-component/_#{@public_name}.scss"
     append_to_file "app/assets/stylesheets/govuk-component/_component.scss", "@import \"#{@public_name}\";\n"

--- a/lib/generators/govuk_component/templates/component_test.rb.erb
+++ b/lib/generators/govuk_component/templates/component_test.rb.erb
@@ -1,0 +1,14 @@
+require 'govuk_component_test_helper'
+
+class <%= "#{@test_name}TestCase" %> < ComponentTestCase
+  def component_name
+    "<%= file_name %>"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".govuk-<%= @public_name %>"
+    end
+  end
+end


### PR DESCRIPTION
When generating a component include a unit test.

The basic unit test asserts that the component template renders with the expected `govuk-` class and that no errors are thrown when no parameters are passed in. It’s modelled on the alpha_label_test.

Includes documentation about component unit tests

https://trello.com/c/NLkm3EDy/17-unit-test-components

cc @dsingleton 