### PR TITLE
Fix HMRC webchat offer

### DIFF
--- a/app/assets/javascripts/webchat-iframe.html.erb
+++ b/app/assets/javascripts/webchat-iframe.html.erb
@@ -11,7 +11,7 @@
     'use strict';
 
     function isOfferOpen() {
-      var ribbonContainer = document.querySelector('#egofr-hmrc-container');
+      var ribbonContainer = document.querySelector('body>div');
       return ribbonContainer && ribbonContainer.parentNode.style.visibility !== 'hidden';
     }
 


### PR DESCRIPTION
The iframe was relying on finding an element with a specific id in the offer markup loaded from KCOM. At some point recently they have updated their markup with a new id, causing the offer to fail to load.

This changes the code such that it now just looks for the first div inside the body rather than relying on a specific id which appears likely to change in future.