### PR TITLE
Fix webchat buttons

### DIFF
--- a/app/assets/javascripts/webchat-iframe.html.erb
+++ b/app/assets/javascripts/webchat-iframe.html.erb
@@ -52,10 +52,10 @@
         if (message.evt === 'load') {
           loadIFrame(message.url, message.title);
         } else if (message.evt === 'accept') {
-          document.querySelector('.egofr-hmrc-btnOK').click();
+          document.querySelector('input[id$=btnOK]').click();
           signalOfferStatus();
         } else if (message.evt === 'reject') {
-          document.querySelector('.egofr-hmrc-btnCancel').click();
+          document.querySelector('input[id$=btnCancel]').click();
           signalOfferStatus();
         }
       }


### PR DESCRIPTION
The ids on the buttons have also changed. This changes the selectors to use an ends-with attribute selector which should be resilient if the id’s value changes again.