### PR TITLE
Create a breadcrumb component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -8,14 +8,14 @@
     li {
       @include core-16;
       background-image: image-url("separator.png");
-      background-position: 100% 50%;
+      background-position: 0% 50%;
       background-repeat: no-repeat;
       float: left;
       list-style: none;
-      margin-left: 0;
-      margin-right: 0.5em;
+      margin-left: 0.6em;
+      margin-right: 0;
       margin-bottom: 0.4em;
-      padding-right: 1em;
+      padding-left: 0.9em;
 
       @include device-pixel-ratio() {
         background-image: image-url("separator-2x.png");
@@ -26,9 +26,10 @@
         color: $text-colour;
       }
 
-      &:last-child {
+      &:first-child {
         background-image: none;
-        margin-right: 0
+        margin-left: 0;
+        padding-left: 0;
       }
     }
   }

--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -1,0 +1,3 @@
+.govuk-breadcrumbs {
+
+}

--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -1,3 +1,35 @@
 .govuk-breadcrumbs {
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
 
+  ol {
+    @extend %contain-floats;
+
+    li {
+      @include core-16;
+      background-image: image-url("separator.png");
+      background-position: 100% 50%;
+      background-repeat: no-repeat;
+      float: left;
+      list-style: none;
+      margin-left: 0;
+      margin-right: 0.5em;
+      margin-bottom: 0.4em;
+      padding-right: 1em;
+
+      @include device-pixel-ratio() {
+        background-image: image-url("separator-2x.png");
+        background-size: 6px 11px;
+      }
+
+      a {
+        color: $text-colour;
+      }
+
+      &:last-child {
+        background-image: none;
+        margin-right: 0
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -12,3 +12,4 @@
 @import "title";
 @import "option-select";
 @import "previous-and-next-navigation";
+@import "breadcrumbs";

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-breadcrumbs">
+  Breadcrumbs
+</div>

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,3 +1,15 @@
+<%
+  breadcrumbs ||= []
+%>
 <div class="govuk-breadcrumbs">
-  Breadcrumbs
+  <ol role="breadcrumbs">
+    <li>
+      <a href="/">Home</a>
+    </li>
+  <% breadcrumbs.each do |crumb| %>
+    <li>
+      <a href="<%= crumb[:url] %>"><%= crumb[:title] %></a>
+    </li>
+  <% end %>
+  </ol>
 </div>

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -1,0 +1,10 @@
+name: "Breadcrumbs"
+description: "Navigational breadcrumbs, showing section hierarchy"
+body: |
+  A long form description of the Breadcrumbs component, which may
+  include markdown formatting.
+
+  It should try and descrive the intent of the component, and document
+  any parameters passed to the component.
+fixtures:
+  default: {}

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -1,10 +1,31 @@
 name: "Breadcrumbs"
-description: "Navigational breadcrumbs, showing section hierarchy"
+description: "Navigational breadcrumbs, showing page hierarchy"
 body: |
-  A long form description of the Breadcrumbs component, which may
-  include markdown formatting.
-
-  It should try and descrive the intent of the component, and document
-  any parameters passed to the component.
+  Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
 fixtures:
-  default: {}
+  default:
+    breadcrumbs:
+    - title: 'Section'
+      url: '/section'
+    - title: 'Sub-section'
+      url: '/section/sub-section'
+  no_breadcrumbs:
+    breadcrumbs: []
+  single_section:
+    breadcrumbs:
+    - title: 'Section'
+      url: '/section'
+  many_breadcrumbs:
+    breadcrumbs:
+    - title: 'Section'
+      url: '/section'
+    - title: 'Sub-section'
+      url: '/section/sub-section'
+    - title: 'Sub Sub-section'
+      url: '/section/sub-section/sub-sub-section'
+  real:
+    breadcrumbs:
+    - title: 'Passports, travel and living abroad'
+      url: '/browse/abroad'
+    - title: 'Travel abroad'
+      url: '/browse/abroad/travel-abroad'

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -1,0 +1,14 @@
+require 'govuk_component_test_helper'
+
+class BreadcrumbsTestCase < ComponentTestCase
+  def component_name
+    "breadcrumbs"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".govuk-breadcrumbs"
+    end
+  end
+end

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -11,4 +11,24 @@ class BreadcrumbsTestCase < ComponentTestCase
       assert_select ".govuk-breadcrumbs"
     end
   end
+
+  test "renders a single breadcrumb" do
+    render_component({ breadcrumbs: [{title: 'Section', url: '/section'}] })
+
+    assert_link_with_text_in('ol li:first-child', '/', 'Home')
+    assert_link_with_text_in('ol li:last-child', '/section', 'Section')
+  end
+
+  test "renders a list of breadcrumbs" do
+    render_component({
+      breadcrumbs: [
+        {title: 'Section', url: '/section'},
+        {title: 'Sub-section', url: '/sub-section'},
+      ]
+    })
+
+    assert_link_with_text_in('ol li:first-child', '/', 'Home')
+    assert_link_with_text_in('ol li:first-child + li', '/section', 'Section')
+    assert_link_with_text_in('ol li:last-child', '/sub-section', 'Sub-section')
+  end
 end


### PR DESCRIPTION
> __Navigational breadcrumbs, showing page hierarchy.__
> Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.

Create a breadcrumbs component based on 20505dd, existing markup, and existing styles in `_header.scss`. Includes a couple of changes:
* Removes `strong` styles as those don’t appear in the markup
* Tweak the styles for better display in IE8 and below

https://trello.com/c/lNdlHrdq/235-component-creation-breadcrumbs-medium

![screen shot 2016-01-08 at 16 23 39](https://cloud.githubusercontent.com/assets/319055/12202931/417d6754-b624-11e5-8cf3-ddea7313f36c.png)

cc @dsingleton @steventux 