### PR TITLE
Bug fix: "I'm not interested" button doesn't close banner

### DIFF
--- a/app/assets/javascripts/webchat-iframe.html.erb
+++ b/app/assets/javascripts/webchat-iframe.html.erb
@@ -12,7 +12,7 @@
 
     function isOfferOpen() {
       var ribbonContainer = document.querySelector('body>div');
-      return ribbonContainer && ribbonContainer.parentNode.style.visibility !== 'hidden';
+      return ribbonContainer && ribbonContainer.style.visibility !== 'hidden';
     }
 
     function sendMessage(obj) {


### PR DESCRIPTION
The line in isOfferOpen was checking for whether the whole body
was hidden and not the chat invite div's visibility. Now it is checking
for the ribbonContainer's visibility and should return the correct value
for whether an offer is open.