### PR TITLE
Related items component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component-print.scss
+++ b/app/assets/stylesheets/govuk-component/_component-print.scss
@@ -3,4 +3,5 @@
 // Components styles
 @import "govspeak-print";
 @import "metadata-print";
+@import "related-items-print";
 @import "title-print";

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -13,3 +13,4 @@
 @import "option-select";
 @import "previous-and-next-navigation";
 @import "breadcrumbs";
+@import "related-items";

--- a/app/assets/stylesheets/govuk-component/_related-items-print.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items-print.scss
@@ -1,0 +1,5 @@
+.govuk-related-items {
+  ul a {
+    orphans: 2;
+  }
+}

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -20,7 +20,7 @@
     li {
       margin-bottom: 0.75em;
 
-      &.section {
+      &.related-items-more {
         font-weight: bold;
       }
 

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -3,9 +3,7 @@
   padding-top: 5px;
 
   h2 {
-    @include core-24;
-    font-weight: 600;
-    color: $text-colour;
+    @include bold-24;
     margin-top: 0.3em;
     margin-bottom: 0.5em;
   }
@@ -13,9 +11,7 @@
   ul {
     @include core-16;
     list-style: none;
-    margin: 0 0 1.25em 0;
-    padding: 0;
-    overflow: hidden;
+    margin-bottom: 1.25em;
 
     li {
       margin-bottom: 0.75em;

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -19,10 +19,6 @@
       &.related-items-more {
         font-weight: bold;
       }
-
-      a {
-        orphans: 2;
-      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -1,3 +1,32 @@
 .govuk-related-items {
+  border-top: 10px solid $mainstream-brand;
+  padding-top: 5px;
 
+  h2 {
+    @include core-24;
+    font-weight: 600;
+    color: $text-colour;
+    margin-top: 0.3em;
+    margin-bottom: 0.5em;
+  }
+
+  ul {
+    @include core-16;
+    list-style: none;
+    margin: 0 0 1.25em 0;
+    padding: 0;
+    overflow: hidden;
+
+    li {
+      margin-bottom: 0.75em;
+
+      &.section {
+        font-weight: bold;
+      }
+
+      a {
+        orphans: 2;
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -1,0 +1,3 @@
+.govuk-related-items {
+
+}

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -1,0 +1,10 @@
+name: "Related items"
+description: "A short description of the Related items component"
+body: |
+  A long form description of the Related items component, which may
+  include markdown formatting.
+
+  It should try and describe the intent of the component, and document
+  any parameters passed to the component.
+fixtures:
+  default: {}

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -1,10 +1,33 @@
 name: "Related items"
-description: "A short description of the Related items component"
+description: "Headed sections of related items."
 body: |
-  A long form description of the Related items component, which may
-  include markdown formatting.
+  Accepts an array of sections. Each section can have a title, url, id and a list of related items.
 
-  It should try and describe the intent of the component, and document
-  any parameters passed to the component.
+  Each item is a hash with a title and url. If the url is external, a rel value can also be provided.
 fixtures:
-  default: {}
+  default:
+    sections:
+    - title: 'Travel Abroad'
+      url: '/'
+      items:
+      - title: 'Link A'
+        url: /
+      - title: 'Link B'
+        url: /
+    - title: 'Travel'
+      items:
+      - title: 'Link 1'
+        url: /
+      - title: 'Link 2'
+        url: /
+  real_example:
+    # from https://www.gov.uk/register-birth
+    sections:
+    - title: Pregnancy and birth
+      url: /browse/childcare-parenting/pregnancy-birth
+      items:
+      - title: 'Register a birth'
+        url: /register-birth
+    - items:
+      - title: Check if you're a British citizen
+        url: /check-british-citizen

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -39,7 +39,8 @@ fixtures:
       items:
       - title: "Register a birth"
         url: /register-birth
-    - id: "related-elsewhere-on-govuk"
+    - title: "Elsewhere on GOV.UK"
+      id: "related-elsewhere-on-govuk"
       items:
       - title: "Check if you're a British citizen"
         url: /check-british-citizen

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -9,12 +9,14 @@ fixtures:
     sections:
     - title: "Travel Abroad"
       url: "/"
+      id: "related-travel-abroad"
       items:
       - title: "Link A"
         url: /
       - title: "Link B"
         url: /
     - title: "Travel"
+      id: "related-travel"
       items:
       - title: "Link 1"
         url: /
@@ -23,6 +25,7 @@ fixtures:
   external_links:
     sections:
       - title: "Elsewhere on the web"
+        id: "related-elsewhere-on-the-web"
         items:
         - title: "Wikivorce"
           url: "http://www.wikivorce.com"
@@ -32,9 +35,11 @@ fixtures:
     sections:
     - title: "Pregnancy and birth"
       url: /browse/childcare-parenting/pregnancy-birth
+      id: "related-pregnancy-and-birth"
       items:
       - title: "Register a birth"
         url: /register-birth
-    - items:
+    - id: "related-elsewhere-on-govuk"
+      items:
       - title: "Check if you're a British citizen"
         url: /check-british-citizen

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -7,27 +7,34 @@ body: |
 fixtures:
   default:
     sections:
-    - title: 'Travel Abroad'
-      url: '/'
+    - title: "Travel Abroad"
+      url: "/"
       items:
-      - title: 'Link A'
+      - title: "Link A"
         url: /
-      - title: 'Link B'
+      - title: "Link B"
         url: /
-    - title: 'Travel'
+    - title: "Travel"
       items:
-      - title: 'Link 1'
+      - title: "Link 1"
         url: /
-      - title: 'Link 2'
+      - title: "Link 2"
         url: /
+  external_links:
+    sections:
+      - title: "Elsewhere on the web"
+        items:
+        - title: "Wikivorce"
+          url: "http://www.wikivorce.com"
+          rel: external
   real_example:
     # from https://www.gov.uk/register-birth
     sections:
-    - title: Pregnancy and birth
+    - title: "Pregnancy and birth"
       url: /browse/childcare-parenting/pregnancy-birth
       items:
-      - title: 'Register a birth'
+      - title: "Register a birth"
         url: /register-birth
     - items:
-      - title: Check if you're a British citizen
+      - title: "Check if you're a British citizen"
         url: /check-british-citizen

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,29 +1,34 @@
 <%
   sections ||= []
 %>
-<aside class="govuk-related-items">
+<aside class="govuk-related-items" role="complementary">
   <% sections.each do |section| %>
-    <h2>
-      <%= section[:title] || "Elsewhere on GOV.UK" %>
+    <% section_title = section[:title] || "Elsewhere on GOV.UK" %>
+    <h2
+      <% if section[:id] %>id="<%= section[:id] %>"<% end %>
+    >
+      <%= section_title %>
     </h2>
-    <ul>
-      <% section[:items].each do |item| %>
-        <li>
-          <a
-            href="<%= item[:url] %>"
-            <% if item[:rel] %>rel="<%= item[:rel] %>"<% end %>
-          >
-            <%= item[:title] %>
-          </a>
-      </li>
-      <% end %>
-      <% if section[:url] %>
-        <li class="related-items-more">
-          <a href="<%= section[:url] %>">
-            More<% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
-          </a>
-        </li>
-      <% end %>
-    </ul>
+    <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
+      <ul>
+        <% section[:items].each do |item| %>
+          <li>
+            <a
+              href="<%= item[:url] %>"
+              <% if item[:rel] %>rel="<%= item[:rel] %>"<% end %>
+            >
+              <%= item[:title] %>
+            </a>
+          </li>
+        <% end %>
+        <% if section[:url] %>
+          <li class="related-items-more">
+            <a href="<%= section[:url] %>">
+              More<% if section[:title] %> <span class="visuallyhidden">in <%= section_title %></span><% end %>
+            </a>
+          </li>
+        <% end %>
+      </ul>
+    </nav>
   <% end %>
 </aside>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -11,7 +11,11 @@
         <li><a href="<%= item[:url] %>"><%= item[:title] %></a></li>
       <% end %>
       <% if section[:url] %>
-        <li class="section"><a href="<%= section[:url] %>">More</a></li>
+        <li class="related-items-more">
+          <a href="<%= section[:url] %>">
+            More<% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
+          </a>
+        </li>
       <% end %>
     </ul>
   <% end %>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -8,7 +8,14 @@
     </h2>
     <ul>
       <% section[:items].each do |item| %>
-        <li><a href="<%= item[:url] %>"><%= item[:title] %></a></li>
+        <li>
+          <a
+            href="<%= item[:url] %>"
+            <% if item[:rel] %>rel="<%= item[:rel] %>"<% end %>
+          >
+            <%= item[:title] %>
+          </a>
+      </li>
       <% end %>
       <% if section[:url] %>
         <li class="related-items-more">

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,3 +1,18 @@
-<div class="govuk-related-items">
-  Related items
-</div>
+<%
+  sections ||= []
+%>
+<aside class="govuk-related-items">
+  <% sections.each do |section| %>
+    <h2>
+      <%= section[:title] || "Elsewhere on GOV.UK" %>
+    </h2>
+    <ul>
+      <% section[:items].each do |item| %>
+        <li><a href="<%= item[:url] %>"><%= item[:title] %></a></li>
+      <% end %>
+      <% if section[:url] %>
+        <li class="section"><a href="<%= section[:url] %>">More</a></li>
+      <% end %>
+    </ul>
+  <% end %>
+</aside>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-related-items">
+  Related items
+</div>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -3,11 +3,10 @@
 %>
 <aside class="govuk-related-items" role="complementary">
   <% sections.each do |section| %>
-    <% section_title = section[:title] || "Elsewhere on GOV.UK" %>
     <h2
       <% if section[:id] %>id="<%= section[:id] %>"<% end %>
     >
-      <%= section_title %>
+      <%= section[:title] %>
     </h2>
     <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
       <ul>
@@ -24,7 +23,7 @@
         <% if section[:url] %>
           <li class="related-items-more">
             <a href="<%= section[:url] %>">
-              More<% if section[:title] %> <span class="visuallyhidden">in <%= section_title %></span><% end %>
+              More<% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
             </a>
           </li>
         <% end %>

--- a/lib/generators/govuk_component/templates/component.yml
+++ b/lib/generators/govuk_component/templates/component.yml
@@ -4,7 +4,7 @@ body: |
   A long form description of the <%= human_name %> component, which may
   include markdown formatting.
 
-  It should try and descrive the intent of the component, and document
+  It should try and describe the intent of the component, and document
   any parameters passed to the component.
 fixtures:
   default: {}

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -109,4 +109,25 @@ class RelatedItemsTestCase < ComponentTestCase
     })
     assert_select "a[rel=external]", text: "Wikivorce"
   end
+
+  test "includes an id and aria-labelledby when a section id is provided" do
+    render_component({
+      sections: [
+        {
+          title: "Elsewhere on the web",
+          url: "/more-link",
+          id: "related-elsewhere-on-the-web",
+          items: [
+            {
+              title: "Wikivorce",
+              url: "http://www.wikivorce.com",
+              rel: "external"
+            }
+          ]
+        },
+      ],
+    })
+    assert_select "#related-elsewhere-on-the-web", text: "Elsewhere on the web"
+    assert_select "nav[aria-labelledby=related-elsewhere-on-the-web]"
+  end
 end

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -1,0 +1,14 @@
+require 'govuk_component_test_helper'
+
+class RelatedItemsTestCase < ComponentTestCase
+  def component_name
+    "related_items"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".govuk-related-items"
+    end
+  end
+end

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -33,7 +33,7 @@ class RelatedItemsTestCase < ComponentTestCase
     })
 
     assert_select "h2", text: "Section title"
-    assert_link_with_text_in("ul li:last-child", "/more-link", "More")
+    assert_link_with_text_in("ul li:last-child", "/more-link", "More in Section title")
     assert_link_with_text_in("ul li:first-child", "/item", "Item title")
     assert_link_with_text_in("ul li:first-child + li", "/other-item", "Other item title")
   end
@@ -65,11 +65,11 @@ class RelatedItemsTestCase < ComponentTestCase
     })
 
     assert_select "h2", text: "Section title"
-    assert_link_with_text_in("ul li:last-child", "/more-link", "More")
+    assert_link_with_text_in("ul li:last-child", "/more-link", "More in Section title")
     assert_link_with_text_in("ul li:first-child", "/item", "Item title")
 
     assert_select "h2", text: "Other section title"
-    assert_link_with_text_in("ul li:last-child", "/other-more-link", "More")
+    assert_link_with_text_in("ul li:last-child", "/other-more-link", "More in Other section title")
     assert_link_with_text_in("ul li:first-child", "/other-item", "Other item title")
   end
 

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -90,4 +90,23 @@ class RelatedItemsTestCase < ComponentTestCase
 
     assert_select "h2", text: "Elsewhere on GOV.UK"
   end
+
+  test "renders external links with a rel attribute" do
+    render_component({
+      sections: [
+        {
+          title: "Elsewhere on the web",
+          url: "/more-link",
+          items: [
+            {
+              title: "Wikivorce",
+              url: "http://www.wikivorce.com",
+              rel: "external"
+            }
+          ]
+        },
+      ],
+    })
+    assert_select "a[rel=external]", text: "Wikivorce"
+  end
 end

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -73,24 +73,6 @@ class RelatedItemsTestCase < ComponentTestCase
     assert_link_with_text_in("ul li:first-child", "/other-item", "Other item title")
   end
 
-  test "has a default section title" do
-    render_component({
-      sections: [
-        {
-          url: "/more-link",
-          items: [
-            {
-              title: "Item title",
-              url: "/item"
-            }
-          ]
-        },
-      ],
-    })
-
-    assert_select "h2", text: "Elsewhere on GOV.UK"
-  end
-
   test "renders external links with a rel attribute" do
     render_component({
       sections: [

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -11,4 +11,83 @@ class RelatedItemsTestCase < ComponentTestCase
       assert_select ".govuk-related-items"
     end
   end
+
+  test "renders a related items block" do
+    render_component({
+      sections: [
+        {
+          title: "Section title",
+          url: "/more-link",
+          items: [
+            {
+              title: "Item title",
+              url: "/item"
+            },
+            {
+              title: "Other item title",
+              url: "/other-item"
+            }
+          ]
+        }
+      ],
+    })
+
+    assert_select "h2", text: "Section title"
+    assert_link_with_text_in("ul li:last-child", "/more-link", "More")
+    assert_link_with_text_in("ul li:first-child", "/item", "Item title")
+    assert_link_with_text_in("ul li:first-child + li", "/other-item", "Other item title")
+  end
+
+  test "renders a multiple related items block" do
+    render_component({
+      sections: [
+        {
+          title: "Section title",
+          url: "/more-link",
+          items: [
+            {
+              title: "Item title",
+              url: "/item"
+            }
+          ]
+        },
+        {
+          title: "Other section title",
+          url: "/other-more-link",
+          items: [
+            {
+              title: "Other item title",
+              url: "/other-item"
+            }
+          ]
+        }
+      ],
+    })
+
+    assert_select "h2", text: "Section title"
+    assert_link_with_text_in("ul li:last-child", "/more-link", "More")
+    assert_link_with_text_in("ul li:first-child", "/item", "Item title")
+
+    assert_select "h2", text: "Other section title"
+    assert_link_with_text_in("ul li:last-child", "/other-more-link", "More")
+    assert_link_with_text_in("ul li:first-child", "/other-item", "Other item title")
+  end
+
+  test "has a default section title" do
+    render_component({
+      sections: [
+        {
+          url: "/more-link",
+          items: [
+            {
+              title: "Item title",
+              url: "/item"
+            }
+          ]
+        },
+      ],
+    })
+
+    assert_select "h2", text: "Elsewhere on GOV.UK"
+  end
 end


### PR DESCRIPTION
> __Headed sections of related items.__
> Accepts an array of sections. Each section can have a title, url, id and a list of related items.
> Each item is a hash with a title and url. If the url is external, a rel value can also be provided.

Create a related-items component based on188e526 and on [core stylesheets](https://github.com/alphagov/static/blob/master/app/assets/stylesheets/helpers/_core.scss#L56-L147)

Care must be taken when using the component so that navigation is always
correctly labelled (pattern based on http://tink.uk/screen-readers-aria-roles-html5-support/). When passing in a section id, use this to add an id attribute and a labelledby attribute. This is in favour of generating an id (eg. by parameterising the title) so that the component isn't using rails specific
features.

![screen shot 2016-01-11 at 16 37 44](https://cloud.githubusercontent.com/assets/8225167/12239655/baf297b2-b881-11e5-8a95-eafe8822634a.png)

[Trello](https://trello.com/c/gRHBCfVy/236-component-creation-related-links-medium)

paired with @fofr 
cc @dsingleton