### PR TITLE
Change insertion point selector so webchat banner appears on new pages

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -50,7 +50,7 @@
       if (window.sessionStorage && window.postMessage) {
         if (webchat.shouldOpen()) {
 
-          insertionPoint = $('.beta-wrapper').length ? $('.beta-wrapper') : $('.heading-block');
+          insertionPoint = $('.beta-wrapper').length ? $('.beta-wrapper') : $('#content > header');
           insertionPoint.after('<div class="webchat-banner" aria-hidden="true"><h2>Talk to an HMRC adviser online</h2><p>You can use web chat instead of calling HMRC’s helpline.</p><a href="#" class="accept">Start web chat</a> <a href="#" class="reject">I’m not interested</a></div>');
 
           webchat.$chatFrame = $('<iframe class="hidden" />');

--- a/spec/javascripts/hmrc-webchat-spec.js
+++ b/spec/javascripts/hmrc-webchat-spec.js
@@ -1,5 +1,5 @@
 describe('HMRC webchat', function () {
-  var INSERTION_HOOK = '<div class="heading-block"></div>';
+  var INSERTION_HOOK = '<main id="content"><header></header></div>';
 
   beforeEach(function() {
     spyOn(GOVUK.webchat, 'shouldOpen').and.returnValue(true);


### PR DESCRIPTION
Webchat has been working on 1 out of the 3 pages because only one has a
.beta-wrapper element. The headers also have different class names on
different pages so I decided to point the selector to a fairly
consistent #content element.