### PR TITLE
Load Webchat iframe on HMRC Contact-us page

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -12,7 +12,8 @@
       var webchatEnabledPaths = [
         '/government/organisations/hm-revenue-customs/contact/self-assessment',
         '/check-if-you-need-a-tax-return/y/employed-even-if-just-for-part-of-the-year/no/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
-        '/check-if-you-need-a-tax-return/y/retired/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these'
+        '/check-if-you-need-a-tax-return/y/retired/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
+        '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'
       ];
 
       return (webchatEnabledPaths.indexOf(window.location.pathname) >= 0);


### PR DESCRIPTION
Includes a new path to said page as requested by HMRC in white_list
array. Tested code on the page where it loaded the iframe and JS when
running contacts-frontend locally.