### PR TITLE
Validate analytics against schemas

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 
 group :test do
   gem 'capybara', '~> 2.5.0'
+  gem 'govuk-content-schema-test-helpers', '~> 1.4'
   gem 'mocha', '~> 1.1.0', :require => false
   gem 'shoulda'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,8 @@ GEM
       rest-client (~> 1.8.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    govuk-content-schema-test-helpers (1.4.0)
+      json-schema (~> 2.5.1)
     govuk-lint (0.3.0)
       rubocop (~> 0.32)
     govuk_frontend_toolkit (4.6.0)
@@ -104,6 +106,8 @@ GEM
       railties (>= 3.2.0)
       sprockets-rails
     json (1.8.3)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     kgio (2.10.0)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -242,6 +246,7 @@ DEPENDENCIES
   binding_of_caller
   capybara (~> 2.5.0)
   gds-api-adapters (= 26.7.0)
+  govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.3.0)
   govuk_frontend_toolkit (~> 4.6.0)
   govuk_template (= 0.16.1)

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,10 +4,54 @@ set -e
 
 git clean -fdx
 
-bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
-
 export GOVUK_APP_DOMAIN=dev.gov.uk
 export GOVUK_WEBSITE_ROOT=http://www.dev.gov.uk
+
+REPO_NAME=${REPO_NAME:-"alphagov/static"}
+CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
+GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+
+env
+
+function github_status {
+  REPO_NAME="$1"
+  STATUS="$2"
+  MESSAGE="$3"
+  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+}
+
+function error_handler {
+  trap - ERR # disable error trap to avoid recursion
+  local parent_lineno="$1"
+  local message="$2"
+  local code="${3:-1}"
+  if [[ -n "$message" ]] ; then
+    echo "Error on or near line ${parent_lineno}: ${message}; exiting with status ${code}"
+  else
+    echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
+  fi
+  github_status "$REPO_NAME" error "errored on Jenkins"
+  exit "${code}"
+}
+
+trap 'error_handler ${LINENO}' ERR
+github_status "$REPO_NAME" pending "is running on Jenkins"
+
+# Try to merge master into the current branch, and abort if it doesn't exit
+# cleanly (ie there are conflicts). This will be a noop if the current branch
+# is master.
+git merge --no-commit origin/master || git merge --abort
+
+# Clone govuk-content-schemas depedency for contract tests
+rm -rf tmp/govuk-content-schemas
+git clone git@github.com:alphagov/govuk-content-schemas.git tmp/govuk-content-schemas
+(
+  cd tmp/govuk-content-schemas
+  git checkout ${SCHEMA_GIT_COMMIT:-"master"}
+)
+export GOVUK_CONTENT_SCHEMAS_PATH=tmp/govuk-content-schemas
+
+bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
 
 # Lint changes introduced in this branch, but not for master
 if [[ ${GIT_BRANCH} != "origin/master" ]]; then
@@ -25,3 +69,13 @@ fi
 RAILS_ENV=test bundle exec rake test
 RAILS_ENV=test bundle exec rake spec:javascript
 RAILS_ENV=production bundle exec rake assets:precompile
+
+export EXIT_STATUS=$?
+
+if [ "$EXIT_STATUS" == "0" ]; then
+  github_status "$REPO_NAME" success "succeeded on Jenkins"
+else
+  github_status "$REPO_NAME" failure "failed on Jenkins"
+fi
+
+exit $EXIT_STATUS

--- a/jenkins_schema.sh
+++ b/jenkins_schema.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+export REPO_NAME="alphagov/govuk-content-schemas"
+export CONTEXT_MESSAGE="Verify static components against schema examples"
+
+exec ./jenkins.sh

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -6,6 +6,19 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     "analytics_meta_tags"
   end
 
+  def example_document_for(format, example_name)
+    JSON.parse(GovukContentSchemaTestHelpers::Examples.new.get(format, example_name))
+  end
+
+  test "renders with an example case study" do
+    render_component(content_item: example_document_for('case_study', 'case_study'))
+
+    assert_meta_tag('govuk:format', 'case_study')
+    assert_meta_tag('govuk:need-ids', '100001,100002')
+    assert_meta_tag('govuk:analytics:organisations', '<L2><W4>')
+    assert_meta_tag('govuk:analytics:world-locations', '<WL3>')
+  end
+
   test "no meta tags are rendered when there's no trackable data" do
     assert_empty render_component(content_item: {})
   end

--- a/test/govuk_component_test_helper.rb
+++ b/test/govuk_component_test_helper.rb
@@ -1,4 +1,10 @@
 require 'test_helper'
+require 'govuk-content-schema-test-helpers'
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = 'frontend'
+  config.project_root = Rails.root
+end
 
 class ComponentTestCase < ActionView::TestCase
   def component_name


### PR DESCRIPTION
Verifies the analytics component against the example case study document in the content schemas project. So far, we only integrate with a single case study example. Ideally we'd integrate with as many different examples as possible, but before this can happen we'll need a way of expressing just which capabilities or attributes each component requires from the example documents.

I'll complete the CI configuration to ensure that content schema commits are triggering builds over here, once this is merged.