### PR TITLE
Make 'Home' breadcrumb optional

### DIFF
--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -3,9 +3,6 @@
 %>
 <div class="govuk-breadcrumbs">
   <ol role="breadcrumbs">
-    <li>
-      <a href="/">Home</a>
-    </li>
   <% breadcrumbs.each do |crumb| %>
     <li>
       <% if crumb[:url] %>

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -17,20 +17,32 @@ fixtures:
       url: '/section'
   many_breadcrumbs:
     breadcrumbs:
+    - title: 'Home'
+      url: '/'
     - title: 'Section'
       url: '/section'
     - title: 'Sub-section'
       url: '/section/sub-section'
     - title: 'Sub Sub-section'
       url: '/section/sub-section/sub-sub-section'
+  no_home:
+    breadcrumbs:
+    - title: 'Service Manual'
+      url: '/service-manual'
+    - title: 'Agile Delivery'
+      url: '/service-manual/agile-delivery'
   real:
     breadcrumbs:
+    - title: 'Home'
+      url: '/'
     - title: 'Passports, travel and living abroad'
       url: '/browse/abroad'
     - title: 'Travel abroad'
       url: '/browse/abroad/travel-abroad'
   last_breadcrumb_is_current_page:
     breadcrumbs:
+    - title: 'Home'
+      url: '/'
     - title: 'Passports, travel and living abroad'
       url: '/browse/abroad'
     - title: 'Travel abroad'

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -15,13 +15,13 @@ class BreadcrumbsTestCase < ComponentTestCase
   test "renders a single breadcrumb" do
     render_component({ breadcrumbs: [{title: 'Section', url: '/section'}] })
 
-    assert_link_with_text_in('ol li:first-child', '/', 'Home')
-    assert_link_with_text_in('ol li:last-child', '/section', 'Section')
+    assert_link_with_text_in('ol li:first-child', '/section', 'Section')
   end
 
   test "renders a list of breadcrumbs" do
     render_component({
       breadcrumbs: [
+        {title: 'Home', url: '/'},
         {title: 'Section', url: '/section'},
         {title: 'Sub-section', url: '/sub-section'},
       ]


### PR DESCRIPTION
Allow passing in `include_home: false` to omit the first 'Home' breadcrumb.

Some formats e.g. Service Manual require the root breadcrumb to link to `/service-manual` rather than GOV.UK root.