### PR TITLE
Allow text-only breadcumbs

### DIFF
--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -8,7 +8,11 @@
     </li>
   <% breadcrumbs.each do |crumb| %>
     <li>
-      <a href="<%= crumb[:url] %>"><%= crumb[:title] %></a>
+      <% if crumb[:url] %>
+        <a href="<%= crumb[:url] %>"><%= crumb[:title] %></a>
+      <% else %>
+        <%= crumb[:title] %>
+      <% end %>
     </li>
   <% end %>
   </ol>

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -29,3 +29,8 @@ fixtures:
       url: '/browse/abroad'
     - title: 'Travel abroad'
       url: '/browse/abroad/travel-abroad'
+  last_breadcrumb_is_current_page:
+    breadcrumbs:
+    - title: 'Passports, travel and living abroad'
+      url: '/browse/abroad'
+    - title: 'Travel abroad'

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -31,4 +31,14 @@ class BreadcrumbsTestCase < ComponentTestCase
     assert_link_with_text_in('ol li:first-child + li', '/section', 'Section')
     assert_link_with_text_in('ol li:last-child', '/sub-section', 'Sub-section')
   end
+
+  test "allows the last breadcrumb to be text only" do
+    render_component(
+      breadcrumbs: [
+        {title: 'Topic', url: '/topic'},
+        {title: 'Current Page'},
+      ]
+    )
+    assert_select('ol li:last-child', 'Current Page')
+  end
 end


### PR DESCRIPTION
User testing conducted by the Service Manual team has shown that users understand breadcrumbs better when the last breadcrumbs element references the current page, thus giving the user a mental anchor.

![ksyzxtir-2016 01 21-17-03-01](https://cloud.githubusercontent.com/assets/218239/12507493/07bcb4a0-c0ee-11e5-8225-3d51c8603d1c.png)

Allow passing in a breadcrumb hash with no URL that renders it as a text element. Only the last breadcrumb element should be text-only. There are not checks in code to enforce it, so it's left to a developer of each application.

However we should discuss if we want to allow different application developers to deviate from what is currently on GOV.UK.