### PR TITLE
Add an alias for 1/3 width column class

### DIFF
--- a/app/assets/stylesheets/helpers/_layouts.scss
+++ b/app/assets/stylesheets/helpers/_layouts.scss
@@ -30,6 +30,7 @@
     }
   }
 
+  .column-one-third,
   .column-third {
     @include grid-column( 1/3 );
 


### PR DESCRIPTION
The class for 2/3 columns is `column-two-thirds`, but the 1/3
column class is `column-third`, which has led to me using
`column-one-third` in templates a few times and being confused
why it doesn't work.

Add `column-one-third` as an alias, for ease of use.

Related: https://github.com/alphagov/govuk_elements/pull/127