### PR TITLE
Temporary survey

### DIFF
--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -67,12 +67,21 @@
     setSurveyUrl: function(href) {
       var $surveyLink = $('#take-survey');
       var surveyUrl = $('#user-satisfaction-survey-container').data('survey-url');
+      var surveyStarts = new Date(2016, 1, 26).getTime();
+      var surveyEnds = new Date(2016, 1, 27, 23, 59, 59).getTime();
+
+      if (userSatisfaction.currentDate() >= surveyStarts &&
+          userSatisfaction.currentDate() <= surveyEnds) {
+        surveyUrl = 'https://www.surveymonkey.co.uk/r/2MRDLTW';
+      }
+
       if (surveyUrl.indexOf('?c=') === -1) {
         surveyUrl += "?c=" + root.location.pathname;
       }
 
       $surveyLink.attr('href', surveyUrl);
-    }
+    },
+    currentDate: function() { Date.now(); }
   };
 
   root.GOVUK.userSatisfaction = userSatisfaction;

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -33,6 +33,18 @@ describe("User Satisfaction Survey", function () {
       expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false');
     });
 
+    it("uses the temporary survey URL on 26/01/2016", function() {
+      spyOn(survey, 'currentDate').and.returnValue(new Date(2016, 1, 26).getTime());
+      survey.showSurveyBar();
+      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
+    });
+
+    it("uses the temporary survey URL on 27/01/2016", function() {
+      spyOn(survey, 'currentDate').and.returnValue(new Date(2016, 1, 27, 12, 15, 30, 0).getTime());
+      survey.showSurveyBar();
+      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
+    });
+
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {
       $("#user-satisfaction-survey-container").data('survey-url', 'http://www.surveymonkey.com/some-survey-id');
       survey.showSurveyBar();


### PR DESCRIPTION
Trello: https://trello.com/c/DEStHomZ

Displays the temporary survey link between 26/01 and 27/01. The approach isn't particularly nice, but this is entirely temporary and will be reverted once the survey window closes.

This was previously done (#689) in the ERB template, but during that particular survey window we had some problems with caching. The trello card alludes to this, for reference.