### PR TITLE
Alter dates for temporary survey period

### DIFF
--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -67,8 +67,8 @@
     setSurveyUrl: function(href) {
       var $surveyLink = $('#take-survey');
       var surveyUrl = $('#user-satisfaction-survey-container').data('survey-url');
-      var surveyStarts = new Date(2016, 1, 26).getTime();
-      var surveyEnds = new Date(2016, 1, 27, 23, 59, 59).getTime();
+      var surveyStarts = new Date("January 26, 2016").getTime();
+      var surveyEnds = new Date("January 27, 2016 23:59:59").getTime();
 
       if (userSatisfaction.currentDate() >= surveyStarts &&
           userSatisfaction.currentDate() <= surveyEnds) {

--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -81,7 +81,7 @@
 
       $surveyLink.attr('href', surveyUrl);
     },
-    currentDate: function() { Date.now(); }
+    currentDate: function() { new Date().getTime(); }
   };
 
   root.GOVUK.userSatisfaction = userSatisfaction;

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -34,13 +34,13 @@ describe("User Satisfaction Survey", function () {
     });
 
     it("uses the temporary survey URL on 26/01/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date(2016, 1, 26).getTime());
+      spyOn(survey, 'currentDate').and.returnValue(new Date("January 26, 2016").getTime());
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
     });
 
     it("uses the temporary survey URL on 27/01/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date(2016, 1, 27, 12, 15, 30, 0).getTime());
+      spyOn(survey, 'currentDate').and.returnValue(new Date("January 27, 2016 12:15:30").getTime());
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
     });


### PR DESCRIPTION
Trello: https://trello.com/c/DEStHomZ

There was an issue with the first implementation in that the date portions were ordinal and didn't take into account JavaScript's months being zero-based. This resolves that issue and another issue regarding `Date.now()` IE8 incompatibility.