### PR TITLE
Add button attribute to button element

### DIFF
--- a/app/assets/javascripts/govuk-component/option-select.js
+++ b/app/assets/javascripts/govuk-component/option-select.js
@@ -58,6 +58,8 @@
     // Create button and replace the preexisting html with the button.
     var $button = $('<button>');
     $button.addClass('js-container-head');
+    //Add type button to override default type submit when this component is used within a form
+    $button.attr('type', 'button');
     $button.attr('aria-expanded', this.isClosed());
     $button.attr('aria-controls', this.$optionSelect.find('.options-container').attr('id'));
     $button.html(jsContainerHeadHTML);


### PR DESCRIPTION
When this element is used with forms, pressing enter on a textbox within the same form triggers a synthetic mouselick event on the nearest button in the form.

Adding type button to the button element overrides the button default type of submit within the form.