### PR TITLE
Standardise margins on components

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -1,7 +1,10 @@
 // Container file for all govuk-component specific styling
 
-// Component specifc govuk_frontend_toolkit includes
+// Component specific govuk_frontend_toolkit includes
 @import "design-patterns/alpha-beta";
+
+// Component mixins
+@import "mixins/margins";
 
 // Components styles
 @import "alpha-label";

--- a/app/assets/stylesheets/govuk-component/_document-footer.scss
+++ b/app/assets/stylesheets/govuk-component/_document-footer.scss
@@ -1,7 +1,8 @@
 .govuk-document-footer {
   @extend %grid-row;
   @include core-16;
-  margin-top: $gutter*1.5;
+  margin-top: $gutter * 1.5;
+  margin-bottom: $gutter * 1.5;
 
   &.direction-rtl {
     direction: rtl;

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -362,7 +362,7 @@
     padding-top: $gutter-one-third;
 
     ol {
-      margin-top: 0px;
+      margin-top: 0;
       padding-top: 0;
 
       li p {

--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -1,5 +1,6 @@
 .govuk-metadata {
   @include core-14;
+  @include responsive-bottom-margin;
   @extend %contain-floats;
 
   &.direction-rtl {

--- a/app/assets/stylesheets/govuk-component/_option-select.scss
+++ b/app/assets/stylesheets/govuk-component/_option-select.scss
@@ -1,6 +1,7 @@
 .govuk-option-select {
   background-color: $grey-3;
   padding: 5px;
+  margin-bottom: $gutter;
 
   @include media(desktop){
     /* Redefine scrollbars on desktop where these lists are scrollable

--- a/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
@@ -1,10 +1,6 @@
 .govuk-previous-and-next-navigation {
   display: block;
 
-  @include media-down(mobile) {
-    margin: 2em 0 0 0;
-  }
-
   ul {
     margin: 0;
     padding: 0;

--- a/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
@@ -1,5 +1,7 @@
 .govuk-previous-and-next-navigation {
   display: block;
+  margin-top: $gutter;
+  margin-bottom: $gutter;
 
   ul {
     margin: 0;
@@ -37,30 +39,26 @@
 
     }
 
-    &.next-page {
-      float: right;
-      text-align: right;
+    &.next-page a:before,
+    &.previous-page a:before {
+      margin-top: -4px;
+      display: block;
+      width: 30px;
+      height: 38px;
+      content: " ";
     }
 
     &.next-page a:before {
       background: transparent image-url("govuk-component/arrow-sprite.png") no-repeat -102px -11px;
-      margin: -4px -32px 0 0;
-      display: block;
+      margin-right: -32px;
       float: right;
-      width: 30px;
-      height: 38px;
-      content: " ";
     }
 
     &.previous-page a:before {
       background: transparent image-url("govuk-component/arrow-sprite.png") no-repeat -20px -11px;
-      margin: -4px 0 0 -32px;
-      display: block;
+      margin-left: -32px;
       float: left;
-      width: 30px;
-      height: 38px;
-      content: " ";
-      }
+    }
 
     &.previous-page {
       float: left;
@@ -69,6 +67,11 @@
 
     &.previous-page a {
       padding: 0.75em 0 0.75em 3em;
+    }
+
+    &.next-page {
+      float: right;
+      text-align: right;
     }
 
     &.next-page a {

--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -1,11 +1,5 @@
 .govuk-title {
-  margin-top: $gutter-half;
-  margin-bottom: $gutter-half;
-
-  @include media(tablet) {
-    margin-top: $gutter;
-    margin-bottom: $gutter;
-  }
+  @include responsive-vertical-margins;
 
   .context {
     @include core-24;

--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -1,8 +1,10 @@
 .govuk-title {
-  margin: $gutter-half 0;
+  margin-top: $gutter-half;
+  margin-bottom: $gutter-half;
 
-  @include media(tablet){
-    margin: $gutter 0;
+  @include media(tablet) {
+    margin-top: $gutter;
+    margin-bottom: $gutter;
   }
 
   .context {

--- a/app/assets/stylesheets/govuk-component/mixins/_margins.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_margins.scss
@@ -1,0 +1,7 @@
+@mixin responsive-bottom-margin {
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: $gutter * 1.5;
+  }
+}

--- a/app/assets/stylesheets/govuk-component/mixins/_margins.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_margins.scss
@@ -5,3 +5,16 @@
     margin-bottom: $gutter * 1.5;
   }
 }
+
+@mixin responsive-top-margin {
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: $gutter * 1.5;
+  }
+}
+
+@mixin responsive-vertical-margins {
+  @include responsive-bottom-margin;
+  @include responsive-top-margin;
+}

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -126,7 +126,7 @@ h4 {
 
     a[rel="external"]:after {
       content: "\A0\A0\A0\A0\A0\A0";
-      background-position: 5px 0px;
+      background-position: 5px 0;
     }
 
     a[rel="external"]:hover:after {


### PR DESCRIPTION
This work follows the principles:
* Include a sensible default margin so that pages can be built quickly with the same vertical spacing
* Removing a margin is easier than adding one
* A sensible default usually looks like a consistent bottom margin
* Top margin should be used sparingly. A good exception is the title component.

Changes to components:
* Remove an unused margin styles from the previous and next component (two apps use it, one was unnecessary, the other was overriding)
* Use responsive top and bottom margins on title, increasing spacing from 30px to 45px
* Add default bottom margin to document footer – this is not responsive as the larger space is useful in separating footer from content at thinner page widths. Once deployed the app specific style in government-frontend can be removed.
* Add bottom margin to option-selects, matching the styles applied in finder-frontend
* Add default bottom margin to metadata component – dependent on https://github.com/alphagov/specialist-frontend/pull/108

Other changes:
* Fix left/right margin of report a problem wrapper when indented within `#wrapper`

https://trello.com/c/zwYvoQxY/273-standardise-whitespace-margins-on-components-medium

This story has highlighted a need for Sass linting, so that styles are written consistently across apps.

cc @dsingleton 