### PR TITLE
Increase margins between text in govspeak component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -23,7 +23,7 @@
 
   h2 {
     @include bold-27;
-    margin-top: $gutter-half;
+    margin-top: $gutter;
 
     @include media(desktop) {
       margin-top: $gutter * 1.5;
@@ -52,11 +52,16 @@
     margin-top: $gutter + 5px;
   }
 
+  ol,
+  ul,
   p {
     @include core-19;
-    margin: 5px 0;
+    margin-top: $gutter-half;
+    margin-bottom: $gutter-half;
+
     @include media(tablet) {
-      margin: $gutter-one-third 0;
+      margin-top: $gutter-two-thirds;
+      margin-bottom: $gutter-two-thirds;
     }
   }
 
@@ -78,15 +83,12 @@
   ul {
     list-style: decimal;
     list-style-position: outside;
-    @include core-19;
-    margin: 5px 0 5px $gutter-two-thirds;
-    @include media(tablet) {
-      margin: $gutter-one-third 0 $gutter-one-third $gutter-two-thirds;
-    }
+    margin-left: $gutter-two-thirds;
 
     ul,
     ol {
-      margin: 0 0 0 $gutter-two-thirds;
+      margin-top: 0;
+      margin-bottom: 0;
       padding: 0;
     }
 
@@ -104,14 +106,13 @@
 
   &.direction-rtl ol,
   &.direction-rtl ul {
-    margin: 5px $gutter-two-thirds 5px 0;
-    @include media(tablet) {
-      margin: $gutter-one-third $gutter-two-thirds $gutter-one-third 0;
-    }
+    margin-left: 0;
+    margin-right: $gutter-two-thirds;
 
     ul,
     ol {
-      margin: 0 $gutter-two-thirds 0 0;
+      margin-top: 0;
+      margin-bottom: 0;
     }
   }
 
@@ -140,6 +141,8 @@
   }
 
   li {
+    margin-bottom: 5px;
+
     p {
       margin: 0;
       padding: 0;
@@ -152,7 +155,7 @@
     ul + ol,
     ol + p,
     ol + ul {
-      margin-top: $gutter-one-third;
+      margin-top: 5px;
     }
   }
 

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -25,8 +25,9 @@
     @include core-27;
     font-weight: bold;
     margin-top: $gutter-half;
+
     @include media(desktop) {
-      margin-top: $gutter*1.5;
+      margin-top: $gutter * 1.5;
     }
   }
 
@@ -34,10 +35,12 @@
     @include core-19;
     font-weight: bold;
     margin-top: $gutter + 5px;
+
     &.hosted-externally {
       @include core-27;
       font-weight: bold;
       padding-top: 2px;
+
       a {
         text-decoration: none;
         &:hover {
@@ -46,6 +49,7 @@
       }
     }
   }
+
   h4 {
     @include core-19;
     font-weight: bold;
@@ -65,8 +69,9 @@
   h6 {
     @include core-19;
     font-weight: bold;
-    &+p {
-      margin-top: 0;
+
+    & + p {
+      margin-top: 5px;
     }
   }
 
@@ -80,13 +85,16 @@
     list-style-position: outside;
     @include core-19;
     margin: 5px 0 5px $gutter-two-thirds;
-    @include media (tablet) {
+    @include media(tablet) {
       margin: $gutter-one-third 0 $gutter-one-third $gutter-two-thirds;
     }
-    ul, ol {
+
+    ul,
+    ol {
       margin: 0 0 0 $gutter-two-thirds;
       padding: 0;
     }
+
     @include ie(7) {
       li {
         margin-left: $gutter;
@@ -102,31 +110,36 @@
   &.direction-rtl ol,
   &.direction-rtl ul {
     margin: 5px $gutter-two-thirds 5px 0;
-    @include media(tablet){
+    @include media(tablet) {
       margin: $gutter-one-third $gutter-two-thirds $gutter-one-third 0;
     }
 
-    ul, ol {
+    ul,
+    ol {
       margin: 0 $gutter-two-thirds 0 0;
     }
   }
 
   ol.legislative-list {
     list-style: none;
-    margin: 5px 0 5px 0;
+    margin: 5px 0;
+
     li {
-      margin: 5px 0 5px 0;
+      margin: 5px 0;
     }
+
     p {
       margin: 20px 0;
     }
+
     ol {
       margin: 10px 0 10px $gutter;
       list-style: none;
     }
   }
 
-  em, i {
+  em,
+  i {
     font-style: normal;
     font-weight: inherit;
   }
@@ -136,9 +149,14 @@
       margin: 0;
       padding: 0;
     }
-    p+p, p+ul, p+ol,
-    ul+p, ul+ol,
-    ol+p, ol+ul {
+
+    p + p,
+    p + ul,
+    p + ol,
+    ul + p,
+    ul + ol,
+    ol + p,
+    ol + ul {
       margin-top: $gutter-one-third;
     }
   }
@@ -174,6 +192,7 @@
       }
     }
   }
+
   &.direction-rtl blockquote {
     padding: 0 $gutter-two-thirds 0 0;
     @include media(desktop) {
@@ -245,10 +264,12 @@
     background: $panel-colour none no-repeat 98% $gutter-two-thirds;
     padding: $gutter-one-third ($gutter*2) $gutter-one-third $gutter-half;
     position: relative;
+
     p {
       margin: 0;
       padding: 0;
     }
+
     ol {
       @include media(desktop) {
         list-style-position: outside;
@@ -283,11 +304,11 @@
       margin-bottom: 0.5em;
     }
 
-    th, td {
+    th,
+    td {
       vertical-align: top;
       padding: $gutter-one-third $gutter-one-third $gutter-one-third 0;
       border-bottom:solid 1px $grey-2;
-
     }
 
     th {
@@ -296,7 +317,7 @@
       @include bold-14;
     }
 
-    td small{
+    td small {
       font-size:1em;
     }
   }
@@ -306,6 +327,7 @@
     sub {
       @include core-14;
     }
+
     img {
       display: inline-block;
       width: auto;
@@ -323,14 +345,17 @@
     @extend %contain-floats;
     margin-bottom: $gutter;
     position: relative;
+
     .content {
       float: none;
       width: $full-width;
+
       h3 {
         @include core-19;
         font-weight: bold;
         margin-bottom: 5px;
       }
+
       .adr,
       .email-url-number,
       .comments {
@@ -339,17 +364,21 @@
           float: left;
         }
       }
+
       .email-url-number {
         p {
           margin: 0;
+
           .email {
             word-wrap: break-word;
           }
         }
+
         span {
           display: block;
         }
       }
+
       .comments {
         @include core-16;
       }

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -22,8 +22,7 @@
   }
 
   h2 {
-    @include core-27;
-    font-weight: bold;
+    @include bold-27;
     margin-top: $gutter-half;
 
     @include media(desktop) {
@@ -32,13 +31,11 @@
   }
 
   h3 {
-    @include core-19;
-    font-weight: bold;
+    @include bold-19;
     margin-top: $gutter + 5px;
 
     &.hosted-externally {
-      @include core-27;
-      font-weight: bold;
+      @include bold-27;
       padding-top: 2px;
 
       a {
@@ -51,8 +48,7 @@
   }
 
   h4 {
-    @include core-19;
-    font-weight: bold;
+    @include bold-19;
     margin-top: $gutter + 5px;
   }
 
@@ -67,8 +63,7 @@
   h4,
   h5,
   h6 {
-    @include core-19;
-    font-weight: bold;
+    @include bold-19;
 
     & + p {
       margin-top: 5px;
@@ -351,8 +346,7 @@
       width: $full-width;
 
       h3 {
-        @include core-19;
-        font-weight: bold;
+        @include bold-19;
         margin-bottom: 5px;
       }
 

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -258,14 +258,20 @@
 
   .information-block,
   .call-to-action {
-    margin: $gutter 0;
-    background: $panel-colour none no-repeat 98% $gutter-two-thirds;
-    padding: $gutter-one-third ($gutter*2) $gutter-one-third $gutter-half;
+    margin-top: $gutter;
+    margin-bottom: $gutter;
+    background-color: $panel-colour;
+    padding: $gutter-half;
     position: relative;
 
-    p {
-      margin: 0;
-      padding: 0;
+    &:first-child {
+      margin-top: 0;
+    }
+
+    p:last-child,
+    ul:last-child,
+    ol:last-child {
+      margin-bottom: 0;
     }
 
     ol {
@@ -273,6 +279,10 @@
         list-style-position: outside;
       }
     }
+  }
+
+  .information-block {
+    padding-right: $gutter * 2;
   }
 
   .information-block:after {


### PR DESCRIPTION
* Use 20px margins (15px at thinner viewports) to match GOV.UK elements. This improves the legibility of content that contains many medium to long paragraphs, it comes at the cost of legibility for content with groups of one line paragraphs, mainly specialist content.
* Add spacing between list items, 5px – matching GOV.UK elements
* Use bold mixins
* Clean up call to action styles

cc @dsingleton @gemmaleigh @alextea 

# Before and after examples
(The more spaced out examples in the GIFs are the new margins)

## Travel advice
* Better legibility on content with long paragraphs

![spacing-travel-advice 1](https://cloud.githubusercontent.com/assets/319055/13054710/233bd9a4-d403-11e5-9a1b-be32d2af4907.gif)

## Mobile
* Clearer spacing at thinner viewports

![spacing-mobile](https://cloud.githubusercontent.com/assets/319055/13054554/5b320992-d402-11e5-94f6-6430789f483d.gif)

## Specialist content
* Better positioning of call to action when it's the first piece of content
* Better padding on call to action

![spacing-specialist-content](https://cloud.githubusercontent.com/assets/319055/13054553/5b2ff670-d402-11e5-81b0-bc111ae7ac51.gif)


