### PR TITLE
Enable click event tracking on mailto links

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -2,6 +2,7 @@
 //= require govuk/analytics/analytics
 //= require govuk/analytics/print-intent
 //= require govuk/analytics/error-tracking
+//= require govuk/analytics/mailto-link-tracker
 //= require govuk/analytics/external-link-tracker
 //= require govuk/analytics/download-link-tracker
 

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -21,6 +21,7 @@
     // Begin error and print tracking
     GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
     GOVUK.analyticsPlugins.printIntent();
+    GOVUK.analyticsPlugins.mailtoLinkTracker();
     GOVUK.analyticsPlugins.externalLinkTracker();
     GOVUK.analyticsPlugins.downloadLinkTracker({
       selector: 'a[href*="/government/uploads"], a[href*="assets.digital.cabinet-office.gov.uk"]'


### PR DESCRIPTION
This PR enables the `GOVUK.analyticsPlugins.mailtoLinkTracker` function merged in to the analytics JS of `govuk_frontend_toolkit`.

It requires version 4.7.0 of the  `govuk_frontend_toolkit` gem, which is the current version in the Gemfile.