### PR TITLE
Remove invalid ARIA role

### DIFF
--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -2,7 +2,7 @@
   breadcrumbs ||= []
 %>
 <div class="govuk-breadcrumbs">
-  <ol role="breadcrumbs">
+  <ol>
   <% breadcrumbs.each do |crumb| %>
     <li>
       <% if crumb[:url] %>


### PR DESCRIPTION
`role="breadcrumbs"` is not a thing.
https://www.w3.org/TR/wai-aria/roles#role_definitions

cc @alextea @robinwhittleton 