### PR TITLE
Add starting of govuk_toolkit modules

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -1,6 +1,7 @@
 //= require libs/jquery/plugins/jquery.base64
 //= require vendor/polyfills/bind
 //= require analytics
+//= require start-modules
 //= require user-satisfaction-survey
 //= require core
 //= require report-a-problem-form

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,0 +1,5 @@
+//= require govuk/modules
+
+$(document).ready(function () {
+  GOVUK.modules.start();
+});


### PR DESCRIPTION
Static will now start any govuk_toolkit modules available on the page.

Further info about the modules can be found [here](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/javascript.md#modules).