### PR TITLE
Fallback to static host if GOVUK_ASSET_ROOT not set

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,9 +25,7 @@ Static::Application.configure do
   # rev filenames for assets
   config.assets.digest = false
 
-  if ENV['GOVUK_ASSET_ROOT'].present?
-    config.action_controller.asset_host = ENV['GOVUK_ASSET_ROOT']
-  end
+  config.asset_host = ENV['GOVUK_ASSET_ROOT'] || Plek.current.find('static')
 
   # Expands the lines which load the assets
   config.assets.debug = true


### PR DESCRIPTION
This allows be run more easily in more situations;

- On the VM, but not under `bowl`, eg, `bowl frontend --without static` and
  running static in another tab (which is common).
- Outside the VM, setting `PLEK_SERVICE_STATIC_URI=http://localhost:3013`,
  which is also a common use pattern outside the VM.

Ideally `static` would generate absolute, including host, URLs for
assets and avoid needing the extra additional Plek service ENV var, but
this fixes the two issues described above for now

CC @erikse who was having this issue too, and @alext who I discussed the fix with.