### PR TITLE
Add WH attachment styling to Govspeak component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -413,4 +413,132 @@
   .media-player {
     @include media-player;
   }
+
+  // This block is duplicated from Whitehall as a transitional step, see the
+  // commit adding this warning before making changes, original version:
+  // https://github.com/alphagov/whitehall/blob/master/app/assets/stylesheets/frontend/helpers/_attachment.scss
+  $thumbnail-width: 99px;
+
+  .attachment {
+    position: relative;
+    margin: $gutter 0;
+    padding: $gutter-half 0 0 ($thumbnail-width + $gutter);
+    @extend %contain-floats;
+
+    &.inline {
+      background: transparent;
+      position: static;
+      padding: 0;
+      margin: 0;
+
+      &:after {
+        display: none;
+      }
+    }
+
+    .attachment-thumb {
+      $thumb-border-width: $gutter-one-third / 2;
+
+      position: relative;
+      float: left;
+      margin-top: $thumb-border-width;
+      margin-left: -($thumbnail-width + $gutter - $thumb-border-width);
+      padding-bottom: $gutter-half;
+
+      img {
+        display: block;
+        width: $thumbnail-width;
+        height: 140px;
+        background: $white;
+        outline: $thumb-border-width solid transparentize($black, 0.9);
+
+        @include ie-lte(8) {
+          border: $thumb-border-width solid $grey-3;
+        }
+
+        @include box-shadow(0 2px 2px rgba($black, .4));
+      }
+    }
+
+    .title a {
+      text-decoration: underline;
+    }
+
+    .attachment-details {
+      h1,
+      h2,
+      h3 {
+        @include core-27;
+        margin: 0;
+      }
+
+      h3 {
+        font-weight: bold;
+      }
+
+      p {
+        margin: $gutter-one-third 0;
+      }
+
+      .extra-description {
+        @include core-19;
+        margin: 0;
+      }
+
+      .metadata {
+        @include core-14;
+        .changed,
+        .references {
+          display: block;
+        }
+
+        .unnumbered-paper {
+          display: block;
+        }
+      }
+
+      .preview,
+      .download {
+        @include core-19;
+      }
+
+      .preview {
+        padding-right: $gutter-half;
+      }
+    }
+
+    .opendocument-help {
+      @include core-14;
+      a {
+        @include external-link-14;
+      }
+    }
+
+    .accessibility-warning {
+      h2 {
+        @include core-14;
+        margin: 0;
+        color: $text-colour;
+      }
+    }
+
+    &:first-child {
+      margin-top: 0;
+      padding-top: 0;
+    }
+
+    strong {
+      font-weight: bold;
+    }
+  }
+
+  &.direction-rtl .attachment {
+    padding: $gutter-half ($thumbnail-width + $gutter) 0 0;
+
+    .attachment-thumb {
+      float: right;
+      margin-left: 0;
+      margin-right: (($thumbnail-width * -1) - $gutter-half);
+    }
+  }
 }

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -241,3 +241,95 @@ fixtures:
           </li>
         </ol>
       </div>
+  inline_attachment:
+    content: |
+      <p>testing my attachment <span class="attachment inline" id="attachment_1399340">
+        <a href="/government/uploads/system/uploads/attachment_data/file/498071/PHE_Payments_over__25k_Jun_15.csv">testing</a>
+        (<span class="type"><abbr title="Comma-separated Values">CSV</abbr></span>, <span class="file-size">65.4KB</span>)</span> works in the middle of copy.
+      </p>
+  block_attachments:
+    content: |
+      <section class="attachment embedded" id="attachment_1399345">
+        <div class="attachment-thumb">
+            <a aria-hidden="true" class="thumbnail" href="https://www.gov.uk/government/publications/minimum-wage-jobs-in-ashfield-local-authority-since-2009"><img alt="" src="https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/496127/thumbnail_LPC_FoI_09.12.15_NMW_jobs_Ashfield_LA.pdf.png"></a>
+        </div>
+        <div class="attachment-details">
+          <h2 class="title"><a aria-describedby="attachment-1399345-accessibility-help" href="https://www.gov.uk/government/publications/minimum-wage-jobs-in-ashfield-local-authority-since-2009">PDF Attachment</a></h2>
+          <p class="metadata">
+              <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">198KB</span>, <span class="page-length">2 pages</span>
+          </p>
+        </div>
+      </section>
+      <section class="attachment embedded" id="attachment_1399344">
+        <div class="attachment-thumb">
+            <a aria-hidden="true" class="thumbnail" href="https://www.gov.uk/government/world-location-news/294043.es-419"><img alt="" src="https://assets.digital.cabinet-office.gov.uk/government/assets/pub-cover-doc-afe3b0a8a9511beeca890340170aee8b5649413f948e512c9b8ce432d8513d32.png"></a>
+        </div>
+        <div class="attachment-details">
+          <h2 class="title"><a href="https://www.gov.uk/government/world-location-news/294043.es-419">Document attachment</a></h2>
+          <p class="metadata">
+              <span class="type">MS Word Document</span>, <span class="file-size">24.2KB</span>
+          </p>
+        </div>
+      </section>
+      <section class="attachment embedded" id="attachment_1105176">
+        <div class="attachment-thumb">
+            <a aria-hidden="true" class="thumbnail" href="https://www.gov.uk/government/publications/post-legislative-memorandum-the-equality-act-2010"><img alt="" src="https://assets.digital.cabinet-office.gov.uk/government/uploads/system/uploads/attachment_data/file/441838/thumbnail_Memo_to_Women_Equalities.pdf.png"></a>
+        </div>
+        <div class="attachment-details">
+          <h2 class="title"><a href="https://www.gov.uk/government/publications/post-legislative-memorandum-the-equality-act-2010">An example of very long title, additional document metadata and an order link</a></h2>
+          <p class="metadata">
+              <span class="references">
+                Ref: ISBN <span class="isbn">9781474121767</span>, <span class="command_paper_number">CM 9101</span>
+              </span>
+              <span class="type"><abbr title="Portable Document Format">PDF</abbr></span>, <span class="file-size">2.02MB</span>, <span class="page-length">86 pages</span>
+          </p>
+            <p>
+              <a class="order_url" title="Order a copy of the publication" href="https://www.gov.uk/how-to-buy-printed-copies-of-official-documents%20">Order a copy</a>
+            </p>
+        </div>
+      </section>
+      <section class="attachment embedded" id="attachment_1399348">
+        <div class="attachment-thumb">
+            <img alt="" src="https://assets.digital.cabinet-office.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png">
+        </div>
+        <div class="attachment-details">
+          <h2 class="title">Previewable online example</h2>
+          <p class="metadata">
+              <span class="preview">
+                <strong>
+                  <a href="https://www.gov.uk/government/publications/phe-spend-over-25000-june-2015">View online</a>
+                </strong>
+              </span>
+              <span class="download">
+                <a href="https://www.gov.uk/government/publications/phe-spend-over-25000-june-2015">
+                  <strong>Download CSV</strong>
+                  65.4KB
+      </a>        </span>
+          </p>
+        </div>
+      </section>
+      <section class="attachment embedded" id="attachment_1243761">
+        <div class="attachment-thumb">
+            <a aria-hidden="true" class="thumbnail" href="https://www.gov.uk/government/statistical-data-sets/env24-fly-tipping-incidents-and-actions-taken-in-england"><img alt="" src="https://assets.digital.cabinet-office.gov.uk/government/assets/pub-cover-spreadsheet-471052e0d03e940bbc62528a05ac204a884b553e4943e63c8bffa6b8baef8967.png"></a>
+        </div>
+        <div class="attachment-details">
+          <h2 class="title"><a href="https://www.gov.uk/government/statistical-data-sets/env24-fly-tipping-incidents-and-actions-taken-in-england">Fly-tipping incidents and actions reported by local authorities in 2014 to 2015</a></h2>
+          <p class="metadata">
+              <span class="type"><abbr title="OpenDocument Spreadsheet">ODS</abbr></span>, <span class="file-size">173KB</span>
+          </p>
+          <p class="opendocument-help">
+            This file is in an <a rel="external" href="https://en.wikipedia.org/wiki/OpenDocument_software">OpenDocument</a> format
+          </p>
+          <div data-module="toggle" class="accessibility-warning" id="attachment-1243761-accessibility-help">
+            <h2>This file may not be suitable for users of assistive technology.
+              <a class="toggle" href="#attachment-1243761-accessibility-help-block" data-controls="attachment-1243761-accessibility-help-block" data-expanded="false">Request a different format.</a>
+            </h2>
+            <p id="attachment-1243761-accessibility-help-block" class="help-block hidden"><span class="arrow"></span>
+              If you use assistive technology and need a version of this document
+              in a more accessible format, please email
+              <a href="mailto:defra.helpline@defra.gsi.gov.uk?body=Details%20of%20document%20required%3A%0A%0A%20%20Title%3A%20Fly-tipping%20incidents%20and%20actions%20reported%20by%20local%20authorities%20in%202014%20to%202015%0A%20%20Original%20format%3A%20ods%0A%0APlease%20tell%20us%3A%0A%0A%20%201.%20What%20makes%20this%20format%20unsuitable%20for%20you%3F%0A%20%202.%20What%20format%20you%20would%20prefer%3F%0A%20%20%20%20%20%20&amp;subject=Request%20for%20%27Fly-tipping%20incidents%20and%20actions%20reported%20by%20local%20authorities%20in%202014%20to%202015%27%20in%20an%20alternative%20format">defra.helpline@defra.gsi.gov.uk</a>.
+              Please tell us what format you need. It will help us if you say what assistive technology you use.
+            </p>
+          </div>
+        </div>
+      </section>


### PR DESCRIPTION
As part of migration we are moving formats from WH to `content-store`
and `government-frontend`. Some of the formats in WH have `body`
content that includes embedded attachments, eg, markup describing
an attachment in the rendered HTML of a document from content-store.

To render this in a new-world frontend app, like government-frontend
the `govspeak` component, that renders a documents `body` content,
needs to be able to add styling and behaviour for the attachment
markup in the `body`.

This PR adds examples of attachments within govspeak, and ports the
CSS/JS that renders them/adds toggling behaviour, to the govspeak
component on static.

- Includes changes to work with accessible JS toggle module [1]
- Fixup the attachment SCSS to pass the new linting rules, mostly
  whitespace and not-referencing-colours-by-variable-name.
- Switch the non-standard 1/6 margin (only used in WH, not FET)
  to something specific to it's use here, avoid introducing the
  additional margin size to static.

[1] https://github.com/alphagov/whitehall/pull/2476

Note, the CSS to styling attachment govspeak is still duplicated in
WH and at some point will need to be reconsiled with the component
version, but that needs to be done for all govspeak styling, not
just attachments. But for now we're adding the ability for the
component version to render attachments at all, to unblock the
migration of formats.