### PR TITLE
Add scheduled maintenance view

### DIFF
--- a/app/views/root/scheduled_maintenance.html.erb
+++ b/app/views/root/scheduled_maintenance.html.erb
@@ -1,0 +1,13 @@
+<%
+# This view is fetched by Puppet so that the loadbalancer can serve a nice
+# error when it's put into maintenance mode (to switch off the backend).
+%>
+<%= render partial: 'error_page', locals: {
+  status_code: 503,
+  title: 'Scheduled maintenance',
+  heading: 'GOV.UK publishing tools are currently unavailable due to scheduled maintenance',
+  intro: '<p>Contact the GOV.UK lead (Single Point Of Contact) for your department or agency if you need to publish something in an <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds#emergency-support-requests">emergency</a>.</p>
+
+    <p>The Inside GOV.UK blog has <a href="https://insidegovuk.blog.gov.uk/status/">more about the scheduled maintenance</a>.</p>',
+}
+%>


### PR DESCRIPTION
This file is currently [hardcoded in the Puppet repo][1] which is definitely not the correct place for it for lots of reasons. It should be a view in static similar to our error views.

[1]: https://github.com/alphagov/govuk-puppet/blob/d717279c28008e54c0cabab2bd058306301344a8/modules/loadbalancer/templates/usr/share/nginx/html/maintenance_page.erb