### PR TITLE
Create HTML publication flavour of the govspeak component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -11,6 +11,7 @@
 @import "beta-label";
 @import "document-footer";
 @import "govspeak";
+@import "govspeak-html-publication";
 @import "metadata";
 @import "title";
 @import "option-select";

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -2,6 +2,7 @@
 .govuk-govspeak-html-publication {
   @extend %contain-floats;
   position: relative;
+  margin-bottom: $gutter * 1.5;
   z-index: 2;
 
   .govuk-govspeak {

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -14,73 +14,73 @@
         float: left;
       }
     }
-  }
-
-  .number {
-    background: $white;
-  }
-
-  h2 {
-    @include bold-36;
-    padding-right: $gutter-one-third;
 
     .number {
-      @include media(tablet) {
-        @include bold-80;
-        position: absolute;
-        margin-top: -$gutter;
-        margin-left: -25%;
-        width: 22%;
-        padding: ($gutter + $gutter / 6) 0 $gutter 3%;
+      background: $white;
+    }
 
-        @include ie(7) {
-          margin-left: -35%;
+    h2 {
+      @include bold-36;
+      padding-right: $gutter-one-third;
+
+      .number {
+        @include media(tablet) {
+          @include bold-80;
+          position: absolute;
+          margin-top: -$gutter;
+          margin-left: -25%;
+          width: 22%;
+          padding: ($gutter + $gutter / 6) 0 $gutter 3%;
+
+          @include ie(7) {
+            margin-left: -35%;
+          }
         }
       }
     }
-  }
 
-  .direction-rtl & h2 {
-    padding-right: 0;
-    padding-left: $gutter-one-third;
-
-    .number {
-      @include media(tablet) {
-        margin-left: 0;
-        margin-right: -25%;
-        padding-left: 0;
-        padding-right: 3%;
-      }
-    }
-  }
-
-  h3 {
-    @include bold-27;
-    padding-right: $gutter-one-third;
-
-    @include media(table) {
+    &.direction-rtl h2 {
       padding-right: 0;
-    }
+      padding-left: $gutter-one-third;
 
-    .number {
-      color: $secondary-text-colour;
-
-      @include media(tablet) {
-        position: absolute;
-        width: $gutter * 2.5;
-        margin-left: $gutter * -2.5;
+      .number {
+        @include media(tablet) {
+          margin-left: 0;
+          margin-right: -25%;
+          padding-left: 0;
+          padding-right: 3%;
+        }
       }
     }
-  }
 
-  .direction-rtl & h3 {
-    padding-right: 0;
-    padding-left: $gutter-one-third;
+    h3 {
+      @include bold-27;
+      padding-right: $gutter-one-third;
 
-    .number {
-      @include media(tablet) {
-        margin-left: 0;
-        margin-right: $gutter * -2.5;
+      @include media(table) {
+        padding-right: 0;
+      }
+
+      .number {
+        color: $secondary-text-colour;
+
+        @include media(tablet) {
+          position: absolute;
+          width: $gutter * 2.5;
+          margin-left: $gutter * -2.5;
+        }
+      }
+    }
+
+    &.direction-rtl h3 {
+      padding-right: 0;
+      padding-left: $gutter-one-third;
+
+      .number {
+        @include media(tablet) {
+          margin-left: 0;
+          margin-right: $gutter * -2.5;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -16,8 +16,13 @@
     }
   }
 
+  .number {
+    background: $white;
+  }
+
   h2 {
     @include bold-36;
+    padding-right: $gutter-one-third;
 
     .number {
       @include media(tablet) {
@@ -28,13 +33,6 @@
         width: 22%;
         padding: ($gutter + $gutter / 6) 0 $gutter 3%;
 
-        .direction-rtl & {
-          margin-left: 0;
-          margin-right: -25%;
-          padding-left: 0;
-          padding-right: 0;
-        }
-
         @include ie(7) {
           margin-left: -35%;
         }
@@ -42,8 +40,27 @@
     }
   }
 
+  .direction-rtl & h2 {
+    padding-right: 0;
+    padding-left: $gutter-one-third;
+
+    .number {
+      @include media(tablet) {
+        margin-left: 0;
+        margin-right: -25%;
+        padding-left: 0;
+        padding-right: 3%;
+      }
+    }
+  }
+
   h3 {
     @include bold-27;
+    padding-right: $gutter-one-third;
+
+    @include media(table) {
+      padding-right: 0;
+    }
 
     .number {
       color: $secondary-text-colour;
@@ -52,22 +69,19 @@
         position: absolute;
         width: $gutter * 2.5;
         margin-left: $gutter * -2.5;
-
-        .direction-rtl & {
-          margin-left: 0;
-          margin-right: $gutter * -2.5;
-        }
       }
     }
   }
 
-  h2 .number,
-  h3 .number {
-    background: $white;
-    padding-right: $gutter-one-third;
+  .direction-rtl & h3 {
+    padding-right: 0;
+    padding-left: $gutter-one-third;
 
-    @include media(tablet) {
-      padding-right: 0;
+    .number {
+      @include media(tablet) {
+        margin-left: 0;
+        margin-right: $gutter * -2.5;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -69,19 +69,4 @@
       padding-right: 0;
     }
   }
-
-  .stat-headline {
-    margin-bottom: $gutter;
-
-    p {
-      @include bold-19;
-      margin: 0;
-    }
-
-    em {
-      display: block;
-      @include bold-80;
-      margin: 3px 0 -5px;
-    }
-  }
 }

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -1,0 +1,80 @@
+// Override govspeak styles with HTML publication specific ones
+.govuk-govspeak-html-publication {
+  @extend %contain-floats;
+  position: relative;
+  z-index: 2;
+
+  .govuk-govspeak {
+    width: 75%;
+    float: right;
+
+    &.direction-rtl {
+      float: left;
+    }
+  }
+
+  h2 {
+    @include bold-36;
+
+    .number {
+      @include media(tablet) {
+        @include bold-80;
+        position: absolute;
+        margin-top: -$gutter;
+        margin-left: -25%;
+        width: 22%;
+        padding: ($gutter + $gutter / 6) 0 $gutter 3%;
+
+        .direction-rtl & {
+          margin-left: 0;
+          margin-right: -25%;
+          padding-left: 0;
+          padding-right: 0;
+        }
+
+        @include ie(7) {
+          margin-left: -35%;
+        }
+      }
+    }
+  }
+
+  h3 {
+    @include bold-27;
+
+    .number {
+      color: $secondary-text-colour;
+
+      @include media(tablet) {
+        display: inline-block;
+        width: $gutter * 2.5;
+        margin-left: $gutter * -2.5;
+      }
+    }
+  }
+
+  h2 .number,
+  h3 .number {
+    background: $white;
+    padding-right: $gutter-one-third;
+
+    @include media(tablet) {
+      padding-right: 0;
+    }
+  }
+
+  .stat-headline {
+    margin-bottom: $gutter;
+
+    p {
+      @include bold-19;
+      margin: 0;
+    }
+
+    em {
+      display: block;
+      @include bold-80;
+      margin: 3px 0 -5px;
+    }
+  }
+}

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -46,9 +46,14 @@
       color: $secondary-text-colour;
 
       @include media(tablet) {
-        display: inline-block;
+        position: absolute;
         width: $gutter * 2.5;
         margin-left: $gutter * -2.5;
+
+        .direction-rtl & {
+          margin-left: 0;
+          margin-right: $gutter * -2.5;
+        }
       }
     }
   }

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -5,11 +5,13 @@
   z-index: 2;
 
   .govuk-govspeak {
-    width: 75%;
-    float: right;
+    @include media(tablet) {
+      width: 75%;
+      float: right;
 
-    &.direction-rtl {
-      float: left;
+      &.direction-rtl {
+        float: left;
+      }
     }
   }
 

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -346,6 +346,21 @@
     }
   }
 
+  .stat-headline {
+    margin-bottom: $gutter;
+
+    p {
+      @include bold-19;
+      margin: 0;
+    }
+
+    em {
+      display: block;
+      @include bold-80;
+      margin: 3px 0 -5px;
+    }
+  }
+
   .address,
   .contact {
     border-left: 1px solid $border-colour;

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -170,6 +170,18 @@ fixtures:
     content: |
       <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>
       <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
+  statistic_headlines:
+    content: |
+      <aside class="stat-headline">
+        <p><em>£6bn</em>
+        Total Departmental Expenditure Limit (<abbr title="Departmental Expenditure Limit">DEL</abbr>) in financial year 2015 to 2016</p>
+      </aside>
+      <p>This includes £5.8 billion Resource <abbr title="Departmental Expenditure Limit">DEL</abbr> and £0.2 billion Capital <abbr title="Departmental Expenditure Limit">DEL</abbr>. In addition, <abbr title="Department for Work and Pensions">DWP</abbr> Annually Managed Expenditure (<abbr title="Annually Managed Expenditure">AME</abbr>) in financial year 2015 to 2016 is £170.5 billion, as forecast by the Office for Budget Responsibility.</p>
+      <aside class="stat-headline">
+        <p>UK employment rate
+        <em>74.1%</em>
+        between October and December 2015</p>
+      </aside>
   specialist_content:
     content: |
       <h2 id="bisphosphonates">Bisphosphonates</h2>

--- a/app/views/govuk_component/docs/govspeak_html_publication.yml
+++ b/app/views/govuk_component/docs/govspeak_html_publication.yml
@@ -1,0 +1,10 @@
+name: "Govspeak html publication"
+description: "A short description of the Govspeak html publication component"
+body: |
+  A long form description of the Govspeak html publication component, which may
+  include markdown formatting.
+
+  It should try and describe the intent of the component, and document
+  any parameters passed to the component.
+fixtures:
+  default: {}

--- a/app/views/govuk_component/docs/govspeak_html_publication.yml
+++ b/app/views/govuk_component/docs/govspeak_html_publication.yml
@@ -1,10 +1,65 @@
-name: "Govspeak html publication"
-description: "A short description of the Govspeak html publication component"
+name: "Govspeak content (HTML Publications)"
+description: "To display long form text with numbered parts, which has been converted from Govspeak"
 body: |
-  A long form description of the Govspeak html publication component, which may
-  include markdown formatting.
+  This component calls the standard [Govspeak component](/components/govspeak), and layers a set of overriding styles on top. Styles for numbered parts are added, and heading sizes are increased.
 
-  It should try and describe the intent of the component, and document
-  any parameters passed to the component.
+  Requires Slimmer >= 9.1.0 for nested component support.
 fixtures:
-  default: {}
+  basic_content:
+    content: |
+      <p>This is a Budget that puts security first. It ensures economic security for working people by putting the public finances in order and setting out a bold plan for a more productive, balanced economy.</p>
+  heading_level_2:
+    content: |
+      <h2>
+        <span class="number">1. </span>Executive summary
+      </h2>
+      <p>This is a Budget that puts security first. It ensures economic security for working people by putting the public finances in order and setting out a bold plan for a more productive, balanced economy.</p>
+  heading_level_3:
+    content: |
+      <h3>
+        <span class="number">1.1 </span>Fixing the public finances and running a surplus
+      </h3>
+      <p>The government’s long-term economic plan has laid the foundations for a stronger economy, and the UK’s recovery is now well established. The labour market remains strong, and in the 3 months to April 2015, employment was around record levels at 31.1 million.</p>
+  numbered_content:
+    content: |
+      <h2 id="executive-summary">
+        <span class="number">1. </span>Executive summary
+      </h2>
+      <p>This is a Budget that puts security first. It ensures economic security for working people by putting the public finances in order and setting out a bold plan for a more productive, balanced economy.</p>
+      <h3 id="fixing-the-public-finances-and-running-a-surplus">
+        <span class="number">1.1 </span>Fixing the public finances and running a surplus
+      </h3>
+      <p>The government’s long-term economic plan has laid the foundations for a stronger economy, and the UK’s recovery is now well established. The labour market remains strong, and in the 3 months to April 2015, employment was around record levels at 31.1 million.</p>
+      <h3 id="economic-forecast">
+        <span class="number">1.2 </span>Economic forecast
+      </h3>
+      <p>The Office for Budget Responsibility (OBR) forecasts GDP growth of 2.4% in 2015, 2.3% in 2016, and 2.4% for the remainder of the forecast period.</p>
+      <h2 id="the-uk-economy-and-public-finances">
+        <span class="number">2. </span>The UK economy and public finances
+      </h2>
+      <h3 id="uk-economy">
+        <span class="number">2.1 </span>UK economy
+      </h3>
+      <p>The government’s long‑term economic plan has secured the recovery. The government’s fiscal responsibility has allowed monetary activism to support demand in the economy alongside repair of the financial sector. This has been supported by supply-side reform to deliver sustainable increases in standards of living.</p>
+  right_to_left:
+    direction: 'rtl'
+    content: |
+      <h2>
+        <span class="number">1. </span>Executive summary
+      </h2>
+      <p>This is a Budget that puts security first. It ensures economic security for working people by putting the public finances in order and setting out a bold plan for a more productive, balanced economy.</p>
+      <h3>
+        <span class="number">1.1 </span>Fixing the public finances and running a surplus
+      </h3>
+      <p>The government’s long-term economic plan has laid the foundations for a stronger economy, and the UK’s recovery is now well established. The labour market remains strong, and in the 3 months to April 2015, employment was around record levels at 31.1 million.</p>
+      <h3>
+        <span class="number">1.2 </span>Economic forecast
+      </h3>
+      <p>The Office for Budget Responsibility (OBR) forecasts GDP growth of 2.4% in 2015, 2.3% in 2016, and 2.4% for the remainder of the forecast period.</p>
+      <h2>
+        <span class="number">2. </span>The UK economy and public finances
+      </h2>
+      <h3>
+        <span class="number">2.1 </span>UK economy
+      </h3>
+      <p>The government’s long‑term economic plan has secured the recovery. The government’s fiscal responsibility has allowed monetary activism to support demand in the economy alongside repair of the financial sector. This has been supported by supply-side reform to deliver sustainable increases in standards of living.</p>

--- a/app/views/govuk_component/govspeak_html_publication.raw.html.erb
+++ b/app/views/govuk_component/govspeak_html_publication.raw.html.erb
@@ -1,0 +1,8 @@
+<%
+  govspeak_locals = { content: content }
+  govspeak_locals[:direction] = local_assigns.fetch(:direction) if local_assigns.include?(:direction)
+  govspeak_locals[:rich_govspeak] = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+%>
+<div class="govuk-govspeak-html-publication">
+  <%= render file: 'govuk_component/govspeak.raw', locals: govspeak_locals %>
+</div>

--- a/test/govuk_component/govspeak_html_publication_test.rb
+++ b/test/govuk_component/govspeak_html_publication_test.rb
@@ -1,0 +1,8 @@
+require 'govuk_component_test_helper'
+require 'govuk_component/govspeak_test'
+
+class GovspeakHtmlPublicationTestCase < GovspeakTestCase
+  def component_name
+    "govspeak_html_publication"
+  end
+end


### PR DESCRIPTION
Create a nested component, an HTML publication wrapper calls the govspeak component and overrides styles specific to the format. It also includes a width constraint for handling large floating numbers that HTML publications use.

Nested components only work with Slimmer 9.1.0 and above.

* Port HTML publication number styles from Whitehall
* Include stat-headline styles in govspeak component
* Switch from right-to-left mixin to `direction-rtl` class
  * Improve right-to-left rendering of HTML publications
* Tie tests to govspeak ones so that the two components don't diverge
* Fix alignment bug in current HTML publications (inline-block switched to position absolute)

# Component guide screenshot

<img width="800" alt="govspeak-html-publications" src="https://cloud.githubusercontent.com/assets/319055/13290468/9990ed9c-db0b-11e5-8771-56b6a0d10531.png">