### PR TITLE
Improve Govspeak component print styles

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-print.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-print.scss
@@ -1,5 +1,5 @@
 .govuk-govspeak {
-  .play-container {
+  .media-player {
     display: none;
   }
 

--- a/app/assets/stylesheets/govuk-component/_govspeak-print.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-print.scss
@@ -3,6 +3,13 @@
     display: none;
   }
 
+  .information-block,
+  .call-to-action {
+    margin: $gutter-half 0;
+    padding: 0 $gutter-half;
+    border: 1pt solid $border-colour;
+  }
+
   .attachment {
     margin: $gutter 0;
 


### PR DESCRIPTION
**Media player**

| Before | After |
| --- | --- |
|  ![screenshot 2016-02-25 15 00 39](https://cloud.githubusercontent.com/assets/63201/13323296/b52940f2-dbd0-11e5-85ba-b4f06e57e915.png) | ![screenshot 2016-02-25 15 01 03](https://cloud.githubusercontent.com/assets/63201/13323295/b52929be-dbd0-11e5-9821-2271ff68e021.png) |

This is a lot less, but there's not a lot of benefit to including any part of the player in print.

**Callouts**

| Before | After |
| --- | --- |
| ![screenshot 2016-02-25 14 59 52](https://cloud.githubusercontent.com/assets/63201/13323318/ca1736cc-dbd0-11e5-8311-6b7e19cb5e18.png) | ![screenshot 2016-02-25 14 59 12](https://cloud.githubusercontent.com/assets/63201/13323317/ca15c21a-dbd0-11e5-942d-0b737b50d832.png) |