### PR TITLE
Add Govspeak fraction examples

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-print.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-print.scss
@@ -10,6 +10,13 @@
     border: 1pt solid $border-colour;
   }
 
+  .fraction {
+    img {
+      display: inline-block;
+      margin-bottom: -7px;
+    }
+  }
+
   .attachment {
     margin: $gutter 0;
 

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -67,6 +67,54 @@ fixtures:
         <li>two</li>
         <li>three</li>
       </ol>
+  image_fractions:
+    content: |
+      <h3 id="number---fractions-1">Number - fractions</h3>
+
+      <p>Pupils should be taught to:</p>
+
+      <ul>
+      <li>recognise, find, name and write fractions <span class="fraction">
+        <img alt="1/3" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_3-9003d7f3d7cd4433647a5f6525aa7eda.png"></span>
+      , <span class="fraction">
+        <img alt="1/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_4-b6128849c8da3b46b9cb5a6918cfe084.png"></span>
+      , <span class="fraction">
+        <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+       and <span class="fraction">
+        <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+       of a length, shape, set of objects or quantity</li>
+        <li>write simple fractions, for example <span class="fraction">
+        <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+       of 6 = 3 and recognise the equivalence of <span class="fraction">
+        <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+      and <span class="fraction">
+        <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+      </li>
+      </ul>
+      <div class="call-to-action">
+        <h4>Notes and guidance (non-statutory)</h4>
+
+        <p>Pupils use fractions as ‘fractions of’ discrete and continuous quantities by solving problems using shapes, objects and quantities. They connect unit fractions to equal sharing and grouping, to numbers when they can be calculated, and to measures, finding fractions of lengths, quantities, sets of objects or shapes. They meet <span class="fraction">
+          <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+         as the first example of a non-unit fraction.<br><br>
+        Pupils should count in fractions up to 10, starting from any number and using the <span class="fraction">
+            <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+         and <span class="fraction">
+            <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+          equivalence on the number line (for example, 1<span class="fraction">
+            <img alt="1/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_4-b6128849c8da3b46b9cb5a6918cfe084.png"></span>
+        , 1<span class="fraction">
+            <img alt="2/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/2_4-e071530a44f0d7980f3442c23e3edd3b.png"></span>
+         (or 1<span class="fraction">
+            <img alt="1/2" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/1_2-6e6f542bec97cb8ea3acf39cd25690ee.png"></span>
+        ), 1<span class="fraction">
+            <img alt="3/4" height="27" src="https://assets.digital.cabinet-office.gov.uk/government/assets/fractions/3_4-cded12d0389211f864dcb27e640c64d4.png"></span>
+        , 2). This reinforces the concept of fractions as numbers and that they can add up to more than 1.
+        </p>
+      </div>
+  text_fractions:
+    content: |
+      <p>If an image is not available for a particular fraction, then we'll fallback to text based fraction using <code>sup</code>/<code>sub</code>, like this <span class="fraction"><sup>1</sup>&frasl;<sub>100</sub></span> example.</p>
   blockquote:
     content: |
       <blockquote>


### PR DESCRIPTION
The styling already existed, having been ported from Whitehall
when the Govspeak component was first created.

The migration of HTML Publications to `government-frontend` means
the fractions SCSS in the component will be used in production and
we should have some examples of how they render, to illustrate the
pattern and make testing regressions easier.

This also improves the print styling of fractions.

**Image based fractions**

| Screen | Print |
| --- | --- | 
| ![image_fractions](https://cloud.githubusercontent.com/assets/63201/13328965/79f73fb6-dbe9-11e5-908a-3f61d2327343.png) | ![image fractions print](https://cloud.githubusercontent.com/assets/63201/13328966/79f7ddc2-dbe9-11e5-88b2-402866b2c739.png) |

**Text based fractions:**

| Screen | Print |
| --- | --- | 
|  ![text_fractions](https://cloud.githubusercontent.com/assets/63201/13328980/89541240-dbe9-11e5-8399-0e2d0f64d7cd.png) | ![text fraction print](https://cloud.githubusercontent.com/assets/63201/13328979/89511338-dbe9-11e5-892a-a7f61c1ca3d3.png) |
