### PR TITLE
Implement 48 hour test User Satisfaction Survey

### DIFF
--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -67,11 +67,8 @@
     setSurveyUrl: function(href) {
       var $surveyLink = $('#take-survey');
       var surveyUrl = $('#user-satisfaction-survey-container').data('survey-url');
-      var surveyStarts = new Date("March 2, 2016").getTime();
-      var surveyEnds = new Date("March 3, 2016 23:59:59").getTime();
 
-      if (userSatisfaction.currentDate() >= surveyStarts &&
-          userSatisfaction.currentDate() <= surveyEnds) {
+      if (userSatisfaction.inTestPeriod()) {
         surveyUrl = 'https://www.surveymonkey.co.uk/r/D668G5Z';
       }
 
@@ -80,6 +77,13 @@
       }
 
       $surveyLink.attr('href', surveyUrl);
+    },
+    inTestPeriod: function() {
+      var starts = new Date("March 2, 2016").getTime();
+      var ends = new Date("March 3, 2016 23:59:59").getTime();
+
+      return userSatisfaction.currentDate() >= starts &&
+        userSatisfaction.currentDate() <= ends;
     },
     currentDate: function() { return new Date().getTime(); }
   };

--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -67,12 +67,12 @@
     setSurveyUrl: function(href) {
       var $surveyLink = $('#take-survey');
       var surveyUrl = $('#user-satisfaction-survey-container').data('survey-url');
-      var surveyStarts = new Date("February 1, 2016").getTime();
-      var surveyEnds = new Date("May 1, 2016 23:59:59").getTime();
+      var surveyStarts = new Date("March 2, 2016").getTime();
+      var surveyEnds = new Date("March 3, 2016 23:59:59").getTime();
 
       if (userSatisfaction.currentDate() >= surveyStarts &&
           userSatisfaction.currentDate() <= surveyEnds) {
-        surveyUrl = 'https://www.surveymonkey.co.uk/r/2MRDLTW';
+        surveyUrl = 'https://www.surveymonkey.co.uk/r/D668G5Z';
       }
 
       if (surveyUrl.indexOf('?c=') === -1) {

--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -14,6 +14,14 @@
               '  </div>' +
               '</section>',
 
+    TEST_TEMPLATE: '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
+                   '  <div class="wrapper">' +
+                   '    <h1>Are you visiting GOV.UK for professional or personal reasons?</h1>' +
+                   '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
+                   '    <p><a href="javascript:void()" id="take-survey" target="_blank">Take the 1 question survey</a> This will open a short survey on another website</p>' +
+                   '  </div>' +
+                   '</section>',
+
     cookieNameTakenSurvey: "govuk_takenUserSatisfactionSurvey",
     trackEvent: function (action, label) {
       GOVUK.analytics.trackEvent('user_satisfaction_survey', action, {
@@ -47,7 +55,8 @@
         return;
       }
 
-      $("#user-satisfaction-survey-container").append(userSatisfaction.TEMPLATE);
+      var template = userSatisfaction.inTestPeriod() ? userSatisfaction.TEST_TEMPLATE : userSatisfaction.TEMPLATE;
+      $("#user-satisfaction-survey-container").append(template);
 
       userSatisfaction.setEventHandlers();
       userSatisfaction.setSurveyUrl();

--- a/app/assets/javascripts/user-satisfaction-survey.js
+++ b/app/assets/javascripts/user-satisfaction-survey.js
@@ -45,7 +45,7 @@
         return false;
       });
       $takeSurvey.click(function () {
-        userSatisfaction.setCookieTakenSurvey()
+        userSatisfaction.setCookieTakenSurvey();
         userSatisfaction.trackEvent('banner_taken', 'User taken survey');
       });
     },

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -22,7 +22,7 @@
 <% end %>
 
 <% content_for :after_header do %>
-  <div id="user-satisfaction-survey-container" data-survey-url="https://www.surveymonkey.com/s/6HZFSVC"></div>
+  <div id="user-satisfaction-survey-container" data-survey-url="https://www.surveymonkey.com/s/2MRDLTW"></div>
 
   <% unless local_assigns[:hide_banner_notification] %>
     <%= banner_notification %>

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -54,6 +54,28 @@ describe("User Satisfaction Survey", function () {
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.com/r/some-survey-id?");
     });
 
+    it("uses the temporary survey heading in the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(true);
+      survey.showSurveyBar();
+      expect($('#user-satisfaction-survey h1').text()).toBe("Are you visiting GOV.UK for professional or personal reasons?");
+    });
+
+    it("uses the original survey heading outside the test period", function() {
+      survey.showSurveyBar();
+      expect($('#user-satisfaction-survey h1').text()).toBe("Tell us what you think of GOV.UK");
+    });
+
+    it("uses the temporary survey link in the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(true);
+      survey.showSurveyBar();
+      expect($('#user-satisfaction-survey a#take-survey').text()).toBe("Take the 1 question survey");
+    });
+
+    it("uses the original survey link outside the test period", function() {
+      survey.showSurveyBar();
+      expect($('#user-satisfaction-survey a#take-survey').text()).toBe("Take the 3 minute survey");
+    });
+
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id');
       survey.showSurveyBar();

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -85,7 +85,7 @@ describe("User Satisfaction Survey", function () {
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending nothing when a path is already specified", function() {
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id?c=/somewhere');
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c=/somewhere")
+      expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c=/somewhere");
     });
 
     it("should randomly display the user satisfaction div", function () {

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -1,6 +1,6 @@
 describe("User Satisfaction Survey", function () {
   describe("Cookies", function () {
-    var survey, $surveyBar, $block;
+    var survey, $surveyBar, $block, inTestPeriodSpy;
 
     beforeEach(function () {
       $block = $('<div id="banner-notification" style="display: none"></div>' +
@@ -17,6 +17,12 @@ describe("User Satisfaction Survey", function () {
       });
 
       survey = GOVUK.userSatisfaction;
+
+      // By default, we're not in a test period
+      if (inTestPeriodSpy === undefined) {
+        inTestPeriodSpy = spyOn(GOVUK.userSatisfaction, 'inTestPeriod');
+      }
+      inTestPeriodSpy.and.returnValue(false);
     });
 
     afterEach(function () {
@@ -37,27 +43,24 @@ describe("User Satisfaction Survey", function () {
       expect(survey.currentDate()).not.toBe(undefined);
     });
 
-    it("uses the temporary survey URL on 02/03/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("March 2, 2016").getTime());
+    it("uses the temporary survey URL in the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(true);
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/D668G5Z?");
     });
 
-    it("uses the temporary survey URL on 03/03/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("March 3, 2016 12:15:30").getTime());
+    it("uses the original survey URL outside the test period", function() {
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.com/r/some-survey-id?");
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("January 1, 2016").getTime());
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id');
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c="+window.location.pathname);
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending nothing when a path is already specified", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("January 1, 2016").getTime());
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id?c=/somewhere');
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c=/somewhere")

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -152,5 +152,27 @@ describe("User Satisfaction Survey", function () {
         expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false);
       });
     });
+
+    describe("inTestPeriod", function () {
+      it("should be false on 1st March 2016", function() {
+        spyOn(survey, 'currentDate').and.returnValue(new Date("March 1, 2016 23:50:00").getTime());
+        expect(survey.inTestPeriod()).toBe(false);
+      });
+
+      it("should be true on 2nd March 2016", function() {
+        spyOn(survey, 'currentDate').and.returnValue(new Date("March 2, 2016 00:01:00").getTime());
+        expect(survey.inTestPeriod()).toBe(true);
+      });
+
+      it("should be true on 2nd March 2016", function() {
+        spyOn(survey, 'currentDate').and.returnValue(new Date("March 3, 2016 23:50:00").getTime());
+        expect(survey.inTestPeriod()).toBe(true);
+      });
+
+      it("should be false on 4th March 2016", function() {
+        spyOn(survey, 'currentDate').and.returnValue(new Date("March 4, 2016 00:01:00").getTime());
+        expect(survey.inTestPeriod()).toBe(false);
+      });
+    });
   });
 });

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -6,7 +6,7 @@ describe("User Satisfaction Survey", function () {
       $block = $('<div id="banner-notification" style="display: none"></div>' +
                   '<div id="global-cookie-message" style="display: none"></div>' +
                   '<div id="global-browser-prompt" style="display: none"></div>' +
-                  '<div id="user-satisfaction-survey-container" data-survey-url="http://www.surveymonkey.com/some-survey-id"></div>');
+                  '<div id="user-satisfaction-survey-container" data-survey-url="https://www.surveymonkey.com/r/some-survey-id"></div>');
 
       $('body').append($block);
       $("#user-satisfaction-survey").remove();
@@ -46,21 +46,21 @@ describe("User Satisfaction Survey", function () {
     it("uses the temporary survey URL on 03/03/2016", function() {
       spyOn(survey, 'currentDate').and.returnValue(new Date("March 3, 2016 12:15:30").getTime());
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/D668G5Z?");
+      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.com/r/some-survey-id?");
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {
       spyOn(survey, 'currentDate').and.returnValue(new Date("January 1, 2016").getTime());
-      $("#user-satisfaction-survey-container").data('survey-url', 'http://www.surveymonkey.com/some-survey-id');
+      $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id');
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toBe("http://www.surveymonkey.com/some-survey-id?c="+window.location.pathname);
+      expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c="+window.location.pathname);
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending nothing when a path is already specified", function() {
       spyOn(survey, 'currentDate').and.returnValue(new Date("January 1, 2016").getTime());
-      $("#user-satisfaction-survey-container").data('survey-url', 'http://www.surveymonkey.com/some-survey-id?c=/somewhere');
+      $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id?c=/somewhere');
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toBe("http://www.surveymonkey.com/some-survey-id?c=/somewhere")
+      expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c=/somewhere")
     });
 
     it("should randomly display the user satisfaction div", function () {

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -37,16 +37,16 @@ describe("User Satisfaction Survey", function () {
       expect(survey.currentDate()).not.toBe(undefined);
     });
 
-    it("uses the temporary survey URL on 01/02/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("February 1, 2016").getTime());
+    it("uses the temporary survey URL on 02/03/2016", function() {
+      spyOn(survey, 'currentDate').and.returnValue(new Date("March 2, 2016").getTime());
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
+      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/D668G5Z?");
     });
 
-    it("uses the temporary survey URL on 01/05/2016", function() {
-      spyOn(survey, 'currentDate').and.returnValue(new Date("May 1, 2016 12:15:30").getTime());
+    it("uses the temporary survey URL on 03/03/2016", function() {
+      spyOn(survey, 'currentDate').and.returnValue(new Date("March 3, 2016 12:15:30").getTime());
       survey.showSurveyBar();
-      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/2MRDLTW?");
+      expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.co.uk/r/D668G5Z?");
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {

--- a/spec/javascripts/user-satisfaction-survey-spec.js
+++ b/spec/javascripts/user-satisfaction-survey-spec.js
@@ -17,12 +17,6 @@ describe("User Satisfaction Survey", function () {
       });
 
       survey = GOVUK.userSatisfaction;
-
-      // By default, we're not in a test period
-      if (inTestPeriodSpy === undefined) {
-        inTestPeriodSpy = spyOn(GOVUK.userSatisfaction, 'inTestPeriod');
-      }
-      inTestPeriodSpy.and.returnValue(false);
     });
 
     afterEach(function () {
@@ -50,6 +44,7 @@ describe("User Satisfaction Survey", function () {
     });
 
     it("uses the original survey URL outside the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(false);
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toMatch("https://www.surveymonkey.com/r/some-survey-id?");
     });
@@ -61,6 +56,7 @@ describe("User Satisfaction Survey", function () {
     });
 
     it("uses the original survey heading outside the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(false);
       survey.showSurveyBar();
       expect($('#user-satisfaction-survey h1').text()).toBe("Tell us what you think of GOV.UK");
     });
@@ -72,17 +68,20 @@ describe("User Satisfaction Survey", function () {
     });
 
     it("uses the original survey link outside the test period", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(false);
       survey.showSurveyBar();
       expect($('#user-satisfaction-survey a#take-survey').text()).toBe("Take the 3 minute survey");
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending the page's current path when not already specified", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(false);
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id');
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c="+window.location.pathname);
     });
 
     it("should set the take survey link's href to the survey monkey's url as defined by the wrapper's data-survey-url, appending nothing when a path is already specified", function() {
+      spyOn(GOVUK.userSatisfaction, 'inTestPeriod').and.returnValue(false);
       $("#user-satisfaction-survey-container").data('survey-url', 'https://www.surveymonkey.com/r/some-survey-id?c=/somewhere');
       survey.showSurveyBar();
       expect($('#take-survey').attr('href')).toBe("https://www.surveymonkey.com/r/some-survey-id?c=/somewhere");


### PR DESCRIPTION
Trello: https://trello.com/c/L9Lk1l4H/308-survey-test-for-start-of-march-small-ish

This promotes the existing test to be the default, and sets up a new test for 48 hours beginning midnight UTC on 2nd March 2016.

This test includes a copy change which will also be reverted at the end of the test.

Best reviewed commit-by-commit due to some refactoring.