### PR TITLE
Correcting header typo on scroll-tracking.js

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -65,7 +65,7 @@
       ['Percent', 75],
       ['Heading', 'Opening up work'],
       ['Heading', 'Support from your work coach'],
-      ['Heading', 'When you can claim Universal credit'],
+      ['Heading', 'When you can claim Universal Credit'],
       ['Heading', 'More detailed advice']
     ],
     '/openingupwork': [


### PR DESCRIPTION
Correcting typo on heading 'When you can claim Universal Credit' on /guidance/universal-credit-how-it-helps-you-into-work which prevented the scroll event from firing.