### PR TITLE
Fix IE8 JavaScript error on GOV.UK

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -16,7 +16,7 @@
         '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'
       ];
 
-      return (webchatEnabledPaths.indexOf(window.location.pathname) >= 0);
+      return ($.inArray(window.location.pathname, webchatEnabledPaths) >= 0);
     },
 
     validOrigin: function(origin){


### PR DESCRIPTION
IE8 is throwing an error on all of GOV.UK (reported by @maxf). Looking at the given line/column number reveals a use of `indexOf` in the webchat code. This isn’t supported by IE8, hence it’s throwing an error. We’ve got jQuery available, so the fix is to swap in `$.inArray()`.