### PR TITLE
Add scroll tracking to Budget HTML doc

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -106,6 +106,13 @@
       ['Heading', 'Other email sending services'],
       ['Heading', 'Making DNS changes'],
       ['Heading', 'Assurance']
+    ],
+    '/government/publications/budget-2016-documents/budget-2016-document': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   };
 


### PR DESCRIPTION
HMT have requested to have % scroll tracking on the html doc version of the budget to be published on 16/03/16