### PR TITLE
Add sticky-element-container module.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,4 @@ PLEK_SERVICE_STATIC_URI=0.0.0.0:3013 ./startup.sh
 
 Tests can run in browser at `/specs`
 
-Or in terminal to run only the jasmine tests you can use `bundle exec rake spec:javascript`
-
-
-
+Or in terminal to run only the jasmine tests you can use `RAILS_ENV=test bundle exec rake spec:javascript`

--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -1,0 +1,136 @@
+/*
+  This module will cause a child in the target element to:
+  - hide when the top of the target element is visible;
+  - stick to the bottom of the window while the parent element is in view;
+  - stick to the bottom of the target when the user scrolls past the bottom.
+
+  Use 'data-module="sticky-element-container"' to instantiate, and add
+  `[data-sticky-element]` to the child you want to position.
+*/
+(function (Modules, root) {
+  'use strict';
+
+  var $ = root.$;
+  var $window = $(root);
+
+  Modules.StickyElementContainer = function () {
+    var self = this;
+
+    self._getWindowDimensions = function _getWindowDimensions () {
+      return {
+        height: $window.height(),
+        width: $window.width()
+      };
+    };
+
+    self._getWindowPositions = function _getWindowPositions () {
+      return {
+        scrollTop: $window.scrollTop()
+      };
+    };
+
+    self.start = function start ($el) {
+      var $element = $el.find('[data-sticky-element]');
+      var _hasResized = true;
+      var _hasScrolled = true;
+      var _interval = 50;
+      var _isDesktop = true;
+      var _windowVerticalPosition = 1;
+      var _startPosition, _stopPosition;
+
+      initialise();
+
+      function initialise () {
+        $window.resize(onResize);
+        $window.scroll(onScroll);
+        setInterval(checkResize, _interval);
+        setInterval(checkScroll, _interval);
+        checkResize();
+        checkScroll();
+        $element.addClass('govuk-sticky-element');
+      }
+
+      function onResize () {
+        _hasResized = true;
+      }
+
+      function onScroll () {
+        _hasScrolled = true;
+      }
+
+      function checkResize () {
+        if (_hasResized) {
+          _hasResized = false;
+          _hasScrolled = true;
+
+          var windowDimensions = self._getWindowDimensions();
+          _isDesktop = windowDimensions.width > 768;
+          _startPosition = $el.offset().top;
+          _stopPosition = $el.offset().top + $el.height() - windowDimensions.height;
+
+          var isMobile = !_isDesktop;
+          if (isMobile) {
+            unstick();
+          }
+        }
+      }
+
+      function checkScroll () {
+        if (_hasScrolled) {
+          _hasScrolled = false;
+
+          _windowVerticalPosition = self._getWindowPositions().scrollTop;
+
+          if (_isDesktop) {
+            updateVisibility();
+            updatePosition();
+          } else {
+            show();
+            unstick();
+          }
+        }
+      }
+
+      function updateVisibility () {
+        var isPastStart = _startPosition < _windowVerticalPosition;
+        if (isPastStart) {
+          show();
+        } else {
+          hide();
+        }
+      }
+
+      function updatePosition () {
+        var isPastEnd = _stopPosition < _windowVerticalPosition;
+        if (isPastEnd) {
+          stickToParent();
+        } else {
+          stickToWindow();
+        }
+      }
+
+      function unstick () {
+        $element.removeClass('govuk-sticky-element--stuck-to-parent');
+        $element.removeClass('govuk-sticky-element--stuck-to-window');
+      }
+
+      function stickToWindow () {
+        $element.addClass('govuk-sticky-element--stuck-to-window');
+        $element.removeClass('govuk-sticky-element--stuck-to-parent');
+      }
+
+      function stickToParent () {
+        $element.addClass('govuk-sticky-element--stuck-to-parent');
+        $element.removeClass('govuk-sticky-element--stuck-to-window');
+      }
+
+      function show () {
+        $element.removeClass('govuk-sticky-element--hidden');
+      }
+
+      function hide () {
+        $element.addClass('govuk-sticky-element--hidden');
+      }
+    };
+  };
+})(window.GOVUK.Modules, window);

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,4 +1,5 @@
 //= require govuk/modules
+//= require modules/sticky-element-container
 //= require modules/toggle
 
 $(document).ready(function () {

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -84,4 +84,8 @@
       }
     }
   }
+
+  .sticky-element {
+    clear: both;
+  }
 }

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -18,6 +18,7 @@
 @import "helpers/emergency-publishing-notifications";
 @import "helpers/report-a-problem";
 @import "govuk-component/component";
+@import "modules/*";
 
 // This should be a component in the future. As the JavaScript and current
 // implementation existing in multiple apps would need to be updated to make

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -1,0 +1,25 @@
+.govuk-sticky-element {
+  @include transition (opacity, .3s, ease);
+  opacity: 1;
+
+  &--hidden {
+    opacity: 0;
+    pointer-events: none;
+
+    @include ie-lte(8) {
+      // XXX: Would be nice to `@include .visuallyhidden`.
+      position: absolute;
+      left: -9999em;
+    }
+  }
+
+  &--stuck-to-parent {
+    bottom: 0;
+    position: absolute;
+  }
+
+  &--stuck-to-window {
+    bottom: 0;
+    position: fixed;
+  }
+}

--- a/app/views/govuk_component/docs/govspeak_html_publication.yml
+++ b/app/views/govuk_component/docs/govspeak_html_publication.yml
@@ -63,3 +63,75 @@ fixtures:
         <span class="number">2.1 </span>UK economy
       </h3>
       <p>The government’s long‑term economic plan has secured the recovery. The government’s fiscal responsibility has allowed monetary activism to support demand in the economy alongside repair of the financial sector. This has been supported by supply-side reform to deliver sustainable increases in standards of living.</p>
+  sticky_footer_html:
+    sticky_footer_html: '<a href="#contents">Contents</a>'
+    content: |
+      <aside class="stat-headline">
+      <p><em>£6bn</em>
+      Total Departmental Expenditure Limit (<abbr title="Departmental Expenditure Limit">DEL</abbr>) in financial year 2015 to 2016</p>
+      </aside>
+
+      <p>This includes £5.8 billion Resource <abbr title="Departmental Expenditure Limit">DEL</abbr> and £0.2 billion Capital <abbr title="Departmental Expenditure Limit">DEL</abbr>. In addition, <abbr title="Department for Work and Pensions">DWP</abbr> Annually Managed Expenditure (<abbr title="Annually Managed Expenditure">AME</abbr>) in financial year 2015 to 2016 is £170.5 billion, as forecast by the Office for Budget Responsibility. </p>
+
+      <p>Source: <a href="/government/topical-events/autumn-statement-and-spending-review-2015">Spending Review and Autumn Statement 2015</a></p>
+
+      <p>Source: <a rel="external" href="http://cdn.budgetresponsibility.independent.gov.uk/EFO_November__2015.pdf">Office for Budget Responsibility Economic and Fiscal Outlook 2015</a></p>
+
+      <h2 id="vision">Vision</h2>
+
+      <p>Everything we do in the Department for Work and Pensions is about providing security, extending opportunity, and giving people the support they need to transform their lives.</p>
+
+      <p>We are helping the most vulnerable people in our society by addressing the root causes of disadvantage and supporting them to turn their lives around. </p>
+
+      <p>We are ensuring that everyone who is able to work is given all the support they need to do so, while those who cannot are - quite rightly - protected.</p>
+
+      <p>Through Universal Credit we are delivering a benefit system that provides the right incentives, ensures work always pays, and which supports people both to get a job and then to progress in employment. </p>
+
+      <p>We are giving people greater security, choice and dignity in retirement with a safe and sustainable state pension, and the independence of a well earned private pension.</p>
+
+      <p><a href="/government/organisations/department-for-work-pensions">Our ministers and management</a></p>
+
+      <h2 id="objectives">Objectives</h2>
+
+      <ol>
+        <li>
+          <p><a href="/government/publications/dwp-single-departmental-plan-2015-to-2020#run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</a></p>
+        </li>
+        <li>
+          <p><a href="/government/publications/dwp-single-departmental-plan-2015-to-2020#increase-saving-for-and-security-in-later-life">Increase saving for, and security in, later life</a></p>
+        </li>
+        <li>
+          <p><a href="/government/publications/dwp-single-departmental-plan-2015-to-2020#create-a-fair-and-affordable-welfare-system-which-improves-the-life-chances-of-children-and-of-adults">Create a fair and affordable welfare system which improves the life chances of children and of adults</a></p>
+        </li>
+        <li>
+          <p><a href="/government/publications/dwp-single-departmental-plan-2015-to-2020#deliver-outstanding-services-to-our-customers-and-claimants">Deliver outstanding services to our customers and claimants</a></p>
+        </li>
+        <li>
+          <p><a href="/government/publications/dwp-single-departmental-plan-2015-to-2020#transforming-the-way-we-deliver-our-services-to-reduce-costs-and-increas-efficiency">Delivering Efficiently: transforming the way we deliver our services to reduce costs and increase efficiency</a></p>
+        </li>
+      </ol>
+
+      <p><a href="/government/publications/permanent-secretaries-objectives-2015-to-2016">Our Permanent Secretary’s objectives</a></p>
+
+      <p>Progress against this plan will be measured in the Mid Year Report to Parliament and Annual Report and Accounts. </p>
+
+      <h2 id="run-an-effective-welfare-system-that-enables-people-to-achieve-financial-independence-by-providing-assistance-and-guidance-into-employment">
+      <span class="number">1. </span> Run an effective welfare system that enables people to achieve financial independence by providing assistance and guidance into employment</h2>
+
+      <p>Lead minister: <a href="/government/people/priti-patel">Rt Hon Priti Patel MP, Minister of State for Employment</a></p>
+
+      <p>Lead official: <a href="/government/people/jeremy-moore">Jeremy Moore, Director General, Strategy, Policy and Analysis</a></p>
+
+      <h3 id="what-dwp-is-doing">
+      <span class="number">1.1 </span> What <abbr title="Department for Work and Pensions">DWP</abbr> is doing</h3>
+
+      <p>We are transforming people’s life chances by supporting them to become sustainably employed and increase their earnings. This is key to our ambition to have the highest employment rate in the G7.
+      We are pursuing this by:</p>
+
+      <ul>
+        <li>continuing to roll out <a href="https://www.gov.uk/government/publications/universal-credit-and-other-benefits-quick-guide">Universal Credit</a> through to financial year 2020 to 2021 and extending job search conditionality to a further 1.3 million claimants to ensure that work always pays  </li>
+        <li>continuing to provide a range of employment support through Jobcentre Plus, the Work Programme (until 2017) and the new Work and Health Programme from 2017</li>
+        <li>supporting people to become self-employed (New Enterprise Allowance)</li>
+        <li>offering working families on Universal Credit support of up to 85% of their eligible childcare costs (where the lone parent or both parents in a couple are in work)</li>
+        <li>helping parents understand the government’s childcare offer </li>
+      </ul>

--- a/app/views/govuk_component/govspeak_html_publication.raw.html.erb
+++ b/app/views/govuk_component/govspeak_html_publication.raw.html.erb
@@ -2,7 +2,16 @@
   govspeak_locals = { content: content }
   govspeak_locals[:direction] = local_assigns.fetch(:direction) if local_assigns.include?(:direction)
   govspeak_locals[:rich_govspeak] = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+  sticky_footer_html = local_assigns.fetch(:sticky_footer_html) if local_assigns.include?(:sticky_footer_html)
 %>
-<div class="govuk-govspeak-html-publication">
+<div
+  class="govuk-govspeak-html-publication"
+  <%= "data-module=sticky-element-container" if sticky_footer_html %>
+>
   <%= render file: 'govuk_component/govspeak.raw', locals: govspeak_locals %>
+  <% if sticky_footer_html %>
+    <div data-sticky-element class="sticky-element">
+      <%= raw sticky_footer_html %>
+    </div>
+  <% end %>
 </div>

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -1,0 +1,87 @@
+/* eslint-env jasmine */
+/* eslint-disable no-multi-str */
+
+describe('A sticky-element-container module', function () {
+  'use strict';
+
+  var GOVUK = window.GOVUK;
+  var $ = window.$;
+  var instance;
+
+  beforeEach(function () {
+    instance = new GOVUK.Modules.StickyElementContainer();
+  });
+
+  describe('in a large parent element', function () {
+    var $element = $('\
+      <div data-module="sticky-element-container" style="height: 9001px; margin-bottom: 1000px">\
+        <div data-sticky-element>\
+          <span>Content</span>\
+        </div>\
+      </div>'
+    );
+    var $footer = $element.find('[data-sticky-element]');
+
+    describe('on desktop', function () {
+      beforeEach(function () {
+        instance._getWindowDimensions = function () {
+          return {
+            height: 768,
+            width: 1024
+          };
+        };
+      });
+
+      it('hides the element, when scrolled at the top', function () {
+        instance.start($element);
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(true);
+      });
+
+      it('shows the element, stuck to the window, when scrolled in the middle', function () {
+        instance._getWindowPositions = function () {
+          return {
+            scrollTop: 5000
+          };
+        };
+        instance.start($element);
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
+      });
+
+      it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
+        instance._getWindowPositions = function () {
+          return {
+            scrollTop: 9800
+          };
+        };
+        instance.start($element);
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(true);
+      });
+    });
+
+    describe('on mobile', function () {
+      beforeEach(function () {
+        instance._getWindowDimensions = function () {
+          return {
+            height: 960,
+            width: 640
+          };
+        };
+      });
+
+      it('shows the element, unstuck', function () {
+        instance.start($element);
+
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
+      });
+    });
+  });
+});

--- a/test/govuk_component/govspeak_html_publication_test.rb
+++ b/test/govuk_component/govspeak_html_publication_test.rb
@@ -5,4 +5,14 @@ class GovspeakHtmlPublicationTestCase < GovspeakTestCase
   def component_name
     "govspeak_html_publication"
   end
+
+  test "renders a govuk-sticky-element" do
+    assert_nothing_raised do
+      render_component(
+        content: '<span>Govspeak content</span>',
+        sticky_footer_html: '<div id="my-content">Content</div>'
+      )
+      assert_select "[data-sticky-element] #my-content"
+    end
+  end
 end


### PR DESCRIPTION
This module allows you to stick an element to the bottom of its parent.

This is part of migrating `html_publications` from `whitehall` to `government-frontend`, and is meant to be used to implement the little "&uarr; Contents" button on http://www.gov.uk/government/publications/dwp-single-departmental-plan-2015-to-2020/dwp-single-departmental-plan-2015-to-2020.

Another PR will be opened to `government-frontend` to update the content item template and pass in the correct parameter to use this. (Update: https://github.com/alphagov/government-frontend/issues/122)

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large

Previous implementation in Whitehall: https://github.com/alphagov/whitehall/blob/master/app/assets/javascripts/application/back-to-content.js