### PR TITLE
Update Budget 2016 docs scroll tracking

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -107,7 +107,7 @@
       ['Heading', 'Making DNS changes'],
       ['Heading', 'Assurance']
     ],
-    '/government/publications/budget-2016-documents/budget-2016-document': [
+    '/government/publications/budget-2016-documents/budget-2016': [
       ['Percent', 20],
       ['Percent', 40],
       ['Percent', 60],


### PR DESCRIPTION
Correct typo on the Budget 2016 docs page url