### PR TITLE
Change URLs where HMRC web chat can be displayed

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -10,10 +10,15 @@
 
     shouldOpen: function(){
       var webchatEnabledPaths = [
-        '/government/organisations/hm-revenue-customs/contact/self-assessment',
-        '/check-if-you-need-a-tax-return/y/employed-even-if-just-for-part-of-the-year/no/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
-        '/check-if-you-need-a-tax-return/y/retired/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
-        '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk'
+        '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
+        '/when-is-your-next-tax-credits-payment',
+        '/renewing-your-tax-credits-claim',
+        '/childcare-costs-for-tax-credits/y/yes/yes/weekly_diff_amount',
+        '/childcare-costs-for-tax-credits/y/no/regularly_less_than_year/monthly_diff_amount',
+        '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
+        '/tax-credits-overpayments',
+        '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
+        '/vat-registration/changes-to-your-details'
       ];
 
       return ($.inArray(window.location.pathname, webchatEnabledPaths) >= 0);


### PR DESCRIPTION
HMRC have asked for their web chat trial to show on various tax credit related pages. 

At the same time, the self assessment trial has finished so we should remove those URLs.