### PR TITLE
Define .crest-eo for organisation_logos.

### DIFF
--- a/app/assets/stylesheets/govuk-component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk-component/_organisation-logo.scss
@@ -112,6 +112,7 @@
   }
 
   .crest-single-identity,
+  .crest-eo,
   .crest-org {
     @include crest('org_crest');
   }

--- a/app/views/govuk_component/docs/organisation_logo.yml
+++ b/app/views/govuk_component/docs/organisation_logo.yml
@@ -30,7 +30,7 @@ fixtures:
       name: Prime Minister's Office, 10 Downing Street
       url: '/government/organisations/prime-ministers-office-10-downing-street'
       brand: 'executive-office'
-      crest: 'single-identity'
+      crest: 'eo'
   home_office:
     organisation:
       name: 'Home Office'


### PR DESCRIPTION
This will match the executive office crest styling to the single identity one, which will bring html publications on `government-frontend` more in line with the ones on `whitehall`.

Part of fixing this visual regression:

![prime-minister s-office](https://cloud.githubusercontent.com/assets/1650875/13926125/de409b3c-ef82-11e5-87e9-01a3f88d4dd7.png)

Relevant Trello ticket: https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large