### PR TITLE
Change govspeak header margin styling.

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -92,6 +92,23 @@
         }
       }
     }
+
+    .stat-headline:first-child {
+      margin-top: $gutter;
+
+      @include media(tablet) {
+        margin-top: ($gutter * 2) + $gutter-two-thirds;
+      }
+    }
+
+    h2,
+    h3 {
+      margin-top: $gutter;
+
+      @include media(tablet) {
+        margin-top: ($gutter * 2) + $gutter-two-thirds;
+      }
+    }
   }
 
   .sticky-element {

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -334,7 +334,13 @@
   }
 
   .stat-headline {
-    margin-bottom: $gutter;
+    margin-bottom: $gutter-half;
+    margin-top: $gutter-half;
+
+    @include media(tablet) {
+      margin-bottom: $gutter-two-thirds;
+      margin-top: $gutter-two-thirds;
+    }
 
     p {
       @include bold-19;


### PR DESCRIPTION
This brings it more in line with what is on whitehall, while respecting our new vertical rhythm conventions.

Before:

![heading-padding-1](https://cloud.githubusercontent.com/assets/1650875/13955919/865f575c-f03e-11e5-8d11-99b28ca0a2bb.png)
![heading-padding-2](https://cloud.githubusercontent.com/assets/1650875/13955921/86664238-f03e-11e5-9884-c01ef4c3286e.png)
![heading-padding-3](https://cloud.githubusercontent.com/assets/1650875/13955920/86660cb4-f03e-11e5-991b-8a60456cee99.png)

After (still outstanding differences due to added line-height consistency in government-frontend):

![screen shot 2016-03-22 at 14 54 14](https://cloud.githubusercontent.com/assets/1650875/13955930/8cb80d60-f03e-11e5-91b2-1bce6d2d40e3.png)


Relevant Trello ticket:
https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large