### PR TITLE
Add RTL support to html publications.

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -5,6 +5,15 @@
   margin-bottom: $gutter * 1.5;
   z-index: 2;
 
+  // This fixes the positioning of the sticky element. The reason it's done on the parent element
+  // is because directly messing with the positioning of the sticky element produces undesirable results.
+  // The nested govspeak component handles its own text direction independently, but will
+  // coincide with the direction of its parent anyway in all usecases.
+  &.direction-rtl {
+    direction: rtl;
+    text-align: start;
+  }
+
   .govuk-govspeak {
     @include media(tablet) {
       width: 75%;

--- a/app/views/govuk_component/govspeak_html_publication.raw.html.erb
+++ b/app/views/govuk_component/govspeak_html_publication.raw.html.erb
@@ -3,9 +3,11 @@
   govspeak_locals[:direction] = local_assigns.fetch(:direction) if local_assigns.include?(:direction)
   govspeak_locals[:rich_govspeak] = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
   sticky_footer_html = local_assigns.fetch(:sticky_footer_html) if local_assigns.include?(:sticky_footer_html)
+  direction_class = ""
+  direction_class = " direction-#{govspeak_locals[:direction]}" if govspeak_locals[:direction]
 %>
 <div
-  class="govuk-govspeak-html-publication"
+  class="govuk-govspeak-html-publication<%= direction_class %>"
   <%= "data-module=sticky-element-container" if sticky_footer_html %>
 >
   <%= render file: 'govuk_component/govspeak.raw', locals: govspeak_locals %>

--- a/test/govuk_component/govspeak_html_publication_test.rb
+++ b/test/govuk_component/govspeak_html_publication_test.rb
@@ -15,4 +15,14 @@ class GovspeakHtmlPublicationTestCase < GovspeakTestCase
       assert_select "[data-sticky-element] #my-content"
     end
   end
+
+  test "respects direction if passed in" do
+    assert_nothing_raised do
+      render_component(
+        content: '<span>Govspeak content</span>',
+        direction: 'rtl'
+      )
+      assert_select ".govuk-govspeak-html-publication.direction-rtl"
+    end
+  end
 end


### PR DESCRIPTION
Part of the addressing the final unintended changes introduced with migrating HTML publications in https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large.

This fixes the positioning of the sticky element. The reason it's done on the parent element is because directly messing with the positioning of the element produces undesirable results.

### Before

![screen shot 2016-03-23 at 19 06 18](https://cloud.githubusercontent.com/assets/1650875/13997492/6511b3aa-f12a-11e5-8295-4b126a2a842b.png)

### After

![screen shot 2016-03-23 at 19 02 19](https://cloud.githubusercontent.com/assets/1650875/13997495/6a84048c-f12a-11e5-862a-f89ba3c7e5be.png)
