### PR TITLE
Fix display of attachment thumbs in IE8

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -449,6 +449,12 @@
         outline: $thumb-border-width solid transparentize($black, 0.9);
 
         @include ie-lte(8) {
+          // IE8 incorrectly asserts the "max-width: 100%" rule to be 0
+          // because of the collapsed width on its floating container
+          // Reset the max-width so that thumbnails render at the specified
+          // width above.
+          // http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/
+          max-width: none;
           border: $thumb-border-width solid $grey-3;
         }
 


### PR DESCRIPTION
IE8 incorrectly asserts the "max-width: 100%" rule to be 0 because of the collapsed width on its floating container.

* Reset the max-width so that thumbnails render at the specified width

For reference:
http://www.456bereastreet.com/archive/201202/using_max-width_on_images_can_make_them_disappear_in_ie8/

Zendesk:
https://govuk.zendesk.com/agent/tickets/1287244

## Before
![screen shot 2016-03-29 at 11 30 31](https://cloud.githubusercontent.com/assets/319055/14105199/f886df40-f5a1-11e5-9bcb-df6994d04862.png)

## After
![screen shot 2016-03-29 at 11 30 13](https://cloud.githubusercontent.com/assets/319055/14105200/f886d824-f5a1-11e5-95ca-718ffcd92a7f.png)