### PR TITLE
Add additional margin-top to govspeak contacts.

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -357,6 +357,7 @@
   .contact {
     @extend %contain-floats;
     margin-bottom: $gutter;
+    margin-top: $gutter;
     position: relative;
 
     .content {

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -394,6 +394,9 @@
 
       .comments {
         @include core-16;
+        @include media(tablet) {
+          margin-bottom: 0;
+        }
       }
     }
   }

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -179,6 +179,42 @@ fixtures:
           </div>
         </div>
       </div>
+  contact_with_surrounding_text:
+    content: |
+      <h2>This is a title</h2>
+      <div class="contact" id="contact_1018">
+        <div class="content">
+          <h3>Media enquiries</h3>
+          <div class="vcard contact-inner">
+            <p class="adr">
+              <span class="street-address">2 Marsham Street<br>London</span><br>
+              <span class="postal-code">SW1P 4DF</span>
+            </p>
+            <div class="email-url-number">
+              <p class="tel"><span class="type">Press enquiries</span> 020 7XXX XXXX</p>
+              <p class="tel"><span class="type">Out of hours</span> 020 7XXX XXXX</p>
+            </div>
+            <p class="comments">A comment about the contact</p>
+          </div>
+        </div>
+      </div>
+      <p>This is a paragraph.</p>
+      <div class="contact" id="contact_1019">
+        <div class="content">
+          <h3>Media enquiries</h3>
+          <div class="vcard contact-inner">
+            <p class="adr">
+              <span class="street-address">2 Marsham Street<br>London</span><br>
+              <span class="postal-code">SW1P 4DF</span>
+            </p>
+            <div class="email-url-number">
+              <p class="tel"><span class="type">Press enquiries</span> 020 7XXX XXXX</p>
+              <p class="tel"><span class="type">Out of hours</span> 020 7XXX XXXX</p>
+            </div>
+            <p class="comments">A comment about the contact</p>
+          </div>
+        </div>
+      </div>
   footnotes:
     content: |
       <p>This is a text with a footnote<sup id="fnref:1a"><a href="#fn:1a" class="footnote">1</a></sup>.</p>


### PR DESCRIPTION
Makes them align better when around headers and other items which don't have an implicit margin-bottom.

Updates documentation with example where this change is visible.

Part of migrating HTML publications in https://trello.com/c/cJGrtnc1/286-5-html-publications-migration-front-end-work-large.

### Before

![screen shot 2016-03-30 at 11 13 31](https://cloud.githubusercontent.com/assets/1650875/14139101/e6d4c560-f668-11e5-80f3-a287afeca835.png)

### After

![screen shot 2016-03-30 at 11 14 23](https://cloud.githubusercontent.com/assets/1650875/14139105/eb8bc216-f668-11e5-9009-85777732abaa.png)
