### PR TITLE
Allow change history to be expanded with JS

### DIFF
--- a/app/views/govuk_component/docs/document_footer.yml
+++ b/app/views/govuk_component/docs/document_footer.yml
@@ -69,3 +69,15 @@ fixtures:
     published: 20 January 2012
     from: <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>
     part_of: <a href='/government/topics/energy'>Energy</a>
+  with_expandable_change_history:
+    history:
+    - display_time: 22 January 2012
+      timestamp: 22-01-2012Z14:19:00T
+      note: We updated the document
+    hidden_history:
+    - display_time: 24 January 2013
+      timestamp: 24-01-2012Z14:19:00T
+      note: We updated the document again
+    - display_time: 24 January 2014
+      timestamp: 24-01-2012Z14:19:00T
+      note: We updated the document again

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -8,6 +8,9 @@
   history ||= []
   history = Array(history)
 
+  hidden_history ||= []
+  history = Array(history)
+
   other ||= nil
 
   other_dates ||= nil
@@ -32,14 +35,31 @@
     <% if history.any? %>
       <div class="change-notes" id="history">
         <h3>Page history</h3>
-        <ol>
-          <% history.each do |change| %>
-            <li>
-              <time datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
-              <%= change[:note] %>
-            </li>
-          <% end %>
-        </ol>
+        <% if history.any? %>
+          <ol>
+            <% history.each do |change| %>
+              <li>
+                <time datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
+                <%= change[:note] %>
+              </li>
+            <% end %>
+          </ol>
+        <% end %>
+        <% if hidden_history.any? %>
+          <div data-module="toggle">
+            <a href="#change-notes-hidden-history" data-expanded="false" data-controls="change-notes-hidden-history">
+              + full page history
+            </a>
+            <ol id="change-notes-hidden-history" class="js-hidden">
+              <% hidden_history.each do |change| %>
+                <li>
+                  <time datetime="<%= change[:timestamp] %>" class="timestamp"><%= change[:display_time] %></time>
+                  <%= change[:note] %>
+                </li>
+              <% end %>
+            </ol>
+          </div>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/test/govuk_component/document_footer_test.rb
+++ b/test/govuk_component/document_footer_test.rb
@@ -94,6 +94,39 @@ class DocumentFooterTestCase < ComponentTestCase
     assert_select '.change-notes li', count: 2
   end
 
+  test "renders document hidden history" do
+    render_component(
+      expand_full_history: true,
+      history: [
+          display_time: "26 October 2016",
+          timestamp: "26-10-2016Z14:19:00T",
+          note: "We updated the document"
+      ],
+      hidden_history: [
+        {
+          display_time: "22 January 2012",
+          timestamp: "22-01-2012Z14:19:00T",
+          note: "We updated the document"
+        },
+        {
+          display_time: "24 January 2012",
+          timestamp: "24-01-2012Z14:19:00T",
+          note: "We updated the document again"
+        }
+      ]
+    )
+
+    assert_timestamp_in('.change-notes #change-notes-hidden-history li', '22-01-2012Z14:19:00T', '22 January 2012')
+    assert_select '.change-notes #change-notes-hidden-history li', text: /We updated the document$/
+
+    assert_timestamp_in('.change-notes #change-notes-hidden-history li', '24-01-2012Z14:19:00T', '24 January 2012')
+    assert_select '.change-notes #change-notes-hidden-history li', text: /We updated the document again/
+
+    assert_select '.change-notes #change-notes-hidden-history[class=js-hidden]'
+    assert_select '.change-notes a[data-expanded=false]'
+    assert_select '.change-notes a[data-controls=change-notes-hidden-history]'
+  end
+
   test "supports right to left content" do
     render_component({direction: "rtl"})
     assert_select '.govuk-document-footer.direction-rtl'


### PR DESCRIPTION
~~REVIEWERS: I'm not really happy with the way I've written these tests, and would appreciate any ideas how I can make them a bit better. Also, I'm not 100% happy with looping through the items twice in the view, but perhaps this has to be done because each set of items should be in a different unordered list.~~

This exists because we are going to show page history in Service Manual guide pages: https://trello.com/c/qzHbv9S9/181-show-change-notes-and-page-history-at-the-bottom-of-guidance-page

Allow change history to be expanded with JS

When using the document_footer component, you can now pass in
`expand_full_history`.

This will cause only the first history item to be shown, and a link will
allow you to show the rest of the history items. This uses javascript
toggle.

## Before expand has been clicked:

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-03-2016-17-16-27-quairaef.png)

## After expand has been clicked:

![image](https://dl.dropboxusercontent.com/u/1207191/screenshots/screenshot-30-03-2016-17-16-42-coatiequ.png)

[preview this locally with govuk_component_guide](http://localhost:3113/components/document_footer/fixtures/with_expandable_change_history/preview)