### PR TITLE
Update emergency banner link styling.

### DIFF
--- a/app/assets/stylesheets/helpers/_emergency-publishing-notifications.scss
+++ b/app/assets/stylesheets/helpers/_emergency-publishing-notifications.scss
@@ -32,14 +32,11 @@
   a {
     color: #fff;
 
-    &.right {
+    &.more-information {
       display: block;
-      padding: 0;
 
       @include media(tablet) {
-        padding: 0 30px 0 0;
-        margin-top: (25 / 19) * -1em;
-        text-align: right;
+        padding: 0 30px;
       }
     }
   }

--- a/app/views/notifications/banner.erb.example
+++ b/app/views/notifications/banner.erb.example
@@ -10,4 +10,4 @@ notification that you would like to show.
 <p>Your message goes here<br />
 This is the second line of your message!</p>
 
-<a href="#" class="right">More information</a>
+<a href="#" class="more-information">More information</a>


### PR DESCRIPTION
The link will overlap the text if the last line of the text is too long.

This causes the link to display as it does on mobile, which is left aligned and block-level. I've signed this off with @dsingleton and @Shotclog. It also changes to a semantic CSS class name.

Relevant Trello ticket: https://trello.com/c/cm6VO0q4/341-emergency-publishing-frontend-bugs-medium

A follow-up PR will be submitted to alphagov/fabric-scripts to update the class name. **Update**: comme ça: https://github.com/alphagov/fabric-scripts/pull/214

### Before

![screen shot 2016-03-31 at 13 02 18](https://cloud.githubusercontent.com/assets/1650875/14175271/da0c6322-f741-11e5-9eb9-a0a4ba587719.png)

### After

![screen shot 2016-03-31 at 13 02 33](https://cloud.githubusercontent.com/assets/1650875/14175273/ddec6a3c-f741-11e5-8c27-18ef0b58da62.png)