### PR TITLE
Re-enable HMRC web chat on self assessment URLs

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -10,6 +10,10 @@
 
     shouldOpen: function(){
       var webchatEnabledPaths = [
+        '/government/organisations/hm-revenue-customs/contact/self-assessment',
+        '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
+        '/check-if-you-need-a-tax-return/y/employed-even-if-just-for-part-of-the-year/no/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
+        '/check-if-you-need-a-tax-return/y/retired/no/no-neither-of-us-claimed-child-benefit/no/no/no/none-of-these',
         '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
         '/when-is-your-next-tax-credits-payment',
         '/renewing-your-tax-credits-claim',


### PR DESCRIPTION
HMRC have asked us to re-enable their web chat trial on various self-assessment related URLs. These were originally removed in #759.

Please note.  This should not be merged until approval is given. I'll comment below when ready.