### PR TITLE
[DISCUSS] Create description component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -19,3 +19,4 @@
 @import "breadcrumbs";
 @import "related-items";
 @import "organisation-logo";
+@import "description";

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -5,6 +5,7 @@
 
 // Component mixins
 @import "mixins/margins";
+@import "mixins/rtl";
 
 // Components styles
 @import "alpha-label";

--- a/app/assets/stylesheets/govuk-component/_description.scss
+++ b/app/assets/stylesheets/govuk-component/_description.scss
@@ -1,0 +1,3 @@
+.govuk-description {
+
+}

--- a/app/assets/stylesheets/govuk-component/_description.scss
+++ b/app/assets/stylesheets/govuk-component/_description.scss
@@ -1,3 +1,5 @@
 .govuk-description {
-
+  @include direction-rtl;
+  @include core-24;
+  @include responsive-bottom-margin;
 }

--- a/app/assets/stylesheets/govuk-component/_document-footer.scss
+++ b/app/assets/stylesheets/govuk-component/_document-footer.scss
@@ -1,13 +1,9 @@
 .govuk-document-footer {
   @extend %grid-row;
   @include core-16;
+  @include direction-rtl;
   margin-top: $gutter * 1.5;
   margin-bottom: $gutter * 1.5;
-
-  &.direction-rtl {
-    direction: rtl;
-    text-align: start;
-  }
 
   .history-information {
     min-height: 1em;

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -9,10 +9,7 @@
   // is because directly messing with the positioning of the sticky element produces undesirable results.
   // The nested govspeak component handles its own text direction independently, but will
   // coincide with the direction of its parent anyway in all usecases.
-  &.direction-rtl {
-    direction: rtl;
-    text-align: start;
-  }
+  @include direction-rtl;
 
   .govuk-govspeak {
     @include media(tablet) {

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -3,10 +3,7 @@
 @import "govspeak-magna-charta";
 
 .govuk-govspeak {
-  &.direction-rtl {
-    direction: rtl;
-    text-align: start;
-  }
+  @include direction-rtl;
 
   &.rich-govspeak {
     strong {

--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -1,12 +1,8 @@
 .govuk-metadata {
   @include core-14;
   @include responsive-bottom-margin;
+  @include direction-rtl;
   @extend %contain-floats;
-
-  &.direction-rtl {
-    direction: rtl;
-    text-align: start;
-  }
 
   dt {
     float: left;

--- a/app/assets/stylesheets/govuk-component/mixins/_rtl.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_rtl.scss
@@ -1,0 +1,6 @@
+@mixin direction-rtl {
+  &.direction-rtl {
+    direction: rtl;
+    text-align: start;
+  }
+}

--- a/app/views/govuk_component/description.raw.html.erb
+++ b/app/views/govuk_component/description.raw.html.erb
@@ -1,0 +1,3 @@
+<div class="govuk-description">
+  Description
+</div>

--- a/app/views/govuk_component/description.raw.html.erb
+++ b/app/views/govuk_component/description.raw.html.erb
@@ -1,3 +1,7 @@
-<div class="govuk-description">
-  Description
-</div>
+<%
+  direction_class = ""
+  direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
+%>
+<p class="govuk-description<%= direction_class %>">
+  <%= raw description %>
+</p>

--- a/app/views/govuk_component/docs/description.yml
+++ b/app/views/govuk_component/docs/description.yml
@@ -1,10 +1,12 @@
 name: "Description"
-description: "A short description of the Description component"
-body: |
-  A long form description of the Description component, which may
-  include markdown formatting.
-
-  It should try and describe the intent of the component, and document
-  any parameters passed to the component.
+description: "A single lead (or lede) paragraph for a piece of content."
 fixtures:
-  default: {}
+  description:
+    description: Some description
+  description_with_markup:
+    description: A description that might <a href="http://www.gov.uk">link to somewhere</a>, because sometimes simple markdown is allowed in the summary or description fields.
+  description_with_non_breaking_spaces_at_the_end:
+    description: To prevent widows in description fields we sometimes include non-breaking spaces between the last two&nbsp;words.
+  right_to_left:
+    description: سوف تستثمر المملكة المتحدة مبلغا إضافيا قدره 1.2 مليار جنيه استرليني من المساعدات الدولية في سورية والمنطقة لتمويل التعليم وتوفير فرص العمل والحماية الإنسانية.
+    direction: 'rtl'

--- a/app/views/govuk_component/docs/description.yml
+++ b/app/views/govuk_component/docs/description.yml
@@ -1,0 +1,10 @@
+name: "Description"
+description: "A short description of the Description component"
+body: |
+  A long form description of the Description component, which may
+  include markdown formatting.
+
+  It should try and describe the intent of the component, and document
+  any parameters passed to the component.
+fixtures:
+  default: {}

--- a/test/govuk_component/description_test.rb
+++ b/test/govuk_component/description_test.rb
@@ -1,0 +1,14 @@
+require 'govuk_component_test_helper'
+
+class DescriptionTestCase < ComponentTestCase
+  def component_name
+    "description"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".govuk-description"
+    end
+  end
+end

--- a/test/govuk_component/description_test.rb
+++ b/test/govuk_component/description_test.rb
@@ -5,10 +5,21 @@ class DescriptionTestCase < ComponentTestCase
     "description"
   end
 
-  test "no error if no parameters passed in" do
-    assert_nothing_raised do
-      render_component({})
-      assert_select ".govuk-description"
-    end
+  test "renders a description" do
+    render_component(description: 'description')
+    assert_select ".govuk-description", text: 'description'
+  end
+
+  test "renders html in a description" do
+    render_component(description: 'description <a href="http://www.gov.uk">link</a>')
+    assert_select ".govuk-description a", text: 'link'
+  end
+
+  test "renders right to left content correctly" do
+    render_component(
+      direction: "rtl",
+      description: "right to left")
+
+    assert_select ".direction-rtl", text: 'right to left'
   end
 end


### PR DESCRIPTION
Base styles on uses in government-frontend:
* https://github.com/alphagov/government-frontend/blob/master/app/assets/stylesheets/helpers/_description.scss
* https://github.com/alphagov/government-frontend/blob/b9f350d6a5da7d3f9206b80c323a55203c36e883/app/views/shared/_description.html.erb

Also creates a `right-to-left` mixin.

Example of switching to this component in government-frontend:
https://github.com/alphagov/government-frontend/compare/use-description-component

<img width="800" alt="description - gov uk component guide 20160420" src="https://cloud.githubusercontent.com/assets/319055/14675510/3ce698b8-0701-11e6-996e-390d3da2e4b0.png">