### PR TITLE
Add first published and last updated to metadata component

### DIFF
--- a/app/views/govuk_component/docs/metadata.yml
+++ b/app/views/govuk_component/docs/metadata.yml
@@ -7,6 +7,12 @@ fixtures:
     part_of: <a href='/government/topics/environment'>Environment</a>
   history_only:
     history: Updated 2 weeks ago
+  published_and_updated:
+    first_published: 14 June 2014
+    last_updated: 10 September 2015
+  updated_with_links_to_see_details:
+    last_updated: 10 September 2015
+    see_updates_link: true
   extensive:
     from:
     - <a href='/government/organisations/ministry-of-defence'>Ministry of Defence</a>

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -16,13 +16,23 @@
       <dt><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
       <dd><%= from.to_sentence.html_safe %></dd>
     <% end %>
+    <% if part_of.any? %>
+      <dt>Part of:</dt>
+      <dd><%= part_of.to_sentence.html_safe %></dd>
+    <% end %>
     <% if local_assigns.include?(:history) %>
       <dt>History:</dt>
       <dd><%= history %></dd>
     <% end %>
-    <% if part_of.any? %>
-      <dt>Part of:</dt>
-      <dd><%= part_of.to_sentence.html_safe %></dd>
+    <% if local_assigns.include?(:first_published) && first_published %>
+      <dt>First published:</dt>
+      <dd><%= first_published %></dd>
+    <% end %>
+    <% if local_assigns.include?(:last_updated) && last_updated %>
+      <dt>Last updated:</dt>
+      <dd>
+        <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>, <a href="#history">see all updates</a><% end %>
+      </dd>
     <% end %>
     <% if other.present? %>
       <% other.each do |title, definition| %>


### PR DESCRIPTION
These are metadata parts that should be used consistently by formats.
* Include an option to link to “see all updates”, this isn’t currently configurable as it doesn’t yet need to be.
* Move “Part of” to be alongside contextually similar metadata, “From”. Keeps history and published terms together.

Based on:
https://github.com/alphagov/government-frontend/blob/40ff6681c44d687fdf87015f244ad7ddd36c82db/app/views/content_items/detailed_guide.html.erb#L19-L20

There's already been an expectation that this should be included:
https://github.com/alphagov/government-frontend/blob/40ff6681c44d687fdf87015f244ad7ddd36c82db/app/views/content_items/case_study.html.erb#L28-L30