### PR TITLE
Improve EU referendum homepage link copy for SRs.

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -38,7 +38,7 @@
     <!--[if gt IE 7]><!-->
     <div id="global-bar" data-module="global-bar" class="dont-print">
       <div class="global-bar-message-container">
-        <p class="global-bar-message"><strong>EU Referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union. <a href="https://www.eureferendum.gov.uk/" rel="external noreferrer">More&nbsp;information</a></p>
+        <p class="global-bar-message"><strong>EU Referendum</strong> On Thursday 23 June there will be a vote on the UK’s membership of the European Union. <a href="https://www.eureferendum.gov.uk/" rel="external noreferrer">More&nbsp;information<span class="visuallyhidden"> about the EU referendum</span></a></p>
         <a href="#hide-message"
            class="dismiss"
            role="button"


### PR DESCRIPTION
Screen reader users have the option to navigate by jumping between anchor tags and reading out the content. "More information" does not provide a lot of context about what the link does.

There is another equivalent PR open on `frontend`: https://github.com/alphagov/frontend/pull/945

### After

![screen shot 2016-04-22 at 15 22 26](https://cloud.githubusercontent.com/assets/1650875/14744449/c0d4bbca-089e-11e6-8092-2bd246507c72.png)