### PR TITLE
Add political-status and publishing-government to analytics

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -4,6 +4,7 @@
   # components use symbol keys and we want consistency.
   content_item_hash = content_item.to_h.deep_symbolize_keys
   links_hash = content_item_hash[:links] || {}
+  details_hash = content_item_hash[:details] || {}
   meta_tags = {}
 
   meta_tags["govuk:format"] = content_item_hash[:format] if content_item_hash[:format]
@@ -22,6 +23,17 @@
   world_locations = links_hash[:world_locations] || []
   world_locations_content = world_locations.map { |link| "<#{link[:analytics_identifier]}>" }.join
   meta_tags["govuk:analytics:world-locations"] = world_locations_content if world_locations.any?
+
+  if details_hash.key?(:political) && details_hash.key?(:government)
+    political_status = "non-political"
+    if details_hash[:political]
+      political_status = details_hash[:government][:current] ? "political" : "historic"
+    end
+
+    meta_tags["govuk:political-status"] = political_status
+    meta_tags["govuk:publishing-government"] = details_hash[:government][:slug]
+  end
+
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -82,6 +82,45 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     assert_meta_tag('govuk:analytics:world-locations', '<WL3>')
   end
 
+  test "renders publishing government slug when government and political keys included" do
+    render_component(content_item: { details: { political: false, government: { current: true, slug: 'government' } } })
+    assert_meta_tag('govuk:publishing-government', 'government')
+  end
+
+  test "does not render publishing government or political status when political or government is missing" do
+    assert_empty render_component(content_item: { details: { government: { current: true, slug: 'government' } } })
+    assert_empty render_component(content_item: { details: { political: true } })
+  end
+
+  test "renders 'political' political status when political content and government is current" do
+    current = true
+    political = true
+    assert_political_status_for(political, current, 'political')
+  end
+
+  test "renders 'historic' political status when political content and government is historic" do
+    current = false
+    political = true
+    assert_political_status_for(political, current, 'historic')
+  end
+
+  test "renders 'non-political' political status when non-political content and government is current" do
+    current = true
+    political = false
+    assert_political_status_for(political, current, 'non-political')
+  end
+
+  test "renders 'non-political' political status when non-political content and government is historic" do
+    current = false
+    political = false
+    assert_political_status_for(political, current, 'non-political')
+  end
+
+  def assert_political_status_for(political, current, expected_political_status)
+    render_component(content_item: { details: { political: political, government: { current: current, slug: 'government' } } })
+    assert_meta_tag('govuk:political-status', expected_political_status)
+  end
+
   def assert_meta_tag(name, content)
     assert_select "meta[name='#{name}'][content='#{content}']"
   end


### PR DESCRIPTION
* Derive political status based on current-ness of government and political state of content
* Use government slug for publishing-government
* Only include analytics tags if both government and political keys are present

Based on political and government representations in content items, added in: https://github.com/alphagov/govuk-content-schemas/pull/290

And the existing logic in Whitehall:
https://github.com/alphagov/whitehall/blob/bf784b05c467d3ce576fc8729810d21078cbc69c/app/helpers/document_helper.rb#L272-L288
https://github.com/alphagov/whitehall/blob/bf784b05c467d3ce576fc8729810d21078cbc69c/test/functional/publications_controller_test.rb#L668-L691