### PR TITLE
Make custom "other" keys behave like defined keys

### DIFF
--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -68,14 +68,19 @@
     <% end %>
     <% if other.present? %>
       <% other.each do |title, definitions| %>
-        <% definitions = Array(definitions) %>
-        <p><%= title %>: <span class="other">
-          <% definitions.each do |definition| %>
-            <span class="definition">
-              <%= definition.html_safe %>
-            </span>
-          <% end %>
-        </span></p>
+        <%
+          definitions ||= []
+          definitions = Array(definitions)
+        %>
+        <% if definitions.any? %>
+          <p><%= title %>: <span class="other">
+            <% definitions.each do |definition| %>
+              <span class="definition">
+                <%= definition.html_safe %>
+              </span>
+            <% end %>
+          </span></p>
+        <% end %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -36,9 +36,14 @@
     <% end %>
     <% if other.present? %>
       <% other.each do |title, definition| %>
-        <% definition = Array(definition) %>
-        <dt><%= title %>:</dt>
-        <dd><%= definition.to_sentence.html_safe %></dd>
+        <%
+          definition ||= []
+          definition = Array(definition)
+        %>
+        <% if definition.any? %>
+          <dt><%= title %>:</dt>
+          <dd><%= definition.to_sentence.html_safe %></dd>
+        <% end %>
       <% end %>
     <% end %>
   </dl>


### PR DESCRIPTION
When passing in an empty array for “Part of” or “From”, these defined keys don’t render any content or title – this reduces the need for logic in the frontend application. An equivalent custom key, eg “Related guides”, if passed an empty array, would output "Related guides: " and then no content after it.

* Update the `other` keys so they have the same behaviour and the components behave consistently.

<img width="352" alt="screen shot 2016-04-27 at 12 46 22" src="https://cloud.githubusercontent.com/assets/319055/14851178/188521fe-0c76-11e6-9ee7-daf8157bce2a.png">

cc @mgrassotti @dsingleton 