### PR TITLE
Check for a data attribute to turn off the video player

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -26,20 +26,22 @@
 
   function enhanceYoutubeVideoLinks($el){
     $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
-      var $link = $(this),
+      if (!$(this).attr("data-youtube-player") == "off") {
+        var $link = $(this),
           videoId = parseYoutubeVideoId($link.attr('href')),
           $holder = $('<span class="media-player" />'),
           $captions = $link.siblings('.captions');
 
-      if(typeof videoId !== 'undefined'){
-        $link.parent().replaceWith($holder);
+        if(typeof videoId !== 'undefined'){
+          $link.parent().replaceWith($holder);
 
-        $holder.player({
-          id: 'youtube-'+i,
-          media: videoId,
-          captions: $captions.length > 0 ? $captions.attr('href') : null,
-          url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
-        });
+          $holder.player({
+            id: 'youtube-'+i,
+            media: videoId,
+            captions: $captions.length > 0 ? $captions.attr('href') : null,
+            url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+          });
+        }
       }
     });
   }

--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -24,15 +24,21 @@
     }
   }
 
-  function enhanceYoutubeVideoLinks($el){
-    $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
-      if (!$(this).attr("data-youtube-player") == "off") {
-        var $link = $(this),
-          videoId = parseYoutubeVideoId($link.attr('href')),
-          $holder = $('<span class="media-player" />'),
-          $captions = $link.siblings('.captions');
+  function shouldConvertToEmbeddedPlayer($link){
+    return $link.attr("data-youtube-player") != "off";
+  }
 
-        if(typeof videoId !== 'undefined'){
+  function enhanceYoutubeVideoLinks($el) {
+    $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function (i){
+
+      var $link = $(this);
+
+      if (shouldConvertToEmbeddedPlayer($link)) {
+        var videoId = parseYoutubeVideoId($link.attr('href')),
+        $holder = $('<span class="media-player" />'),
+        $captions = $link.siblings('.captions');
+
+        if(typeof videoId !== 'undefined') {
           $link.parent().replaceWith($holder);
 
           $holder.player({

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
@@ -1,0 +1,65 @@
+describe('Links to YouTube in govspeak content', function () {
+
+  describe('A YouTube link to be converted to an embedded player', function () {
+
+    var $enhanceYoutubeVideoLinksFixture, enhanceYoutubeVideoLinks;
+
+    beforeEach(function() {
+
+      $enhanceYoutubeVideoLinksFixture = $('<div class="govuk-govspeak">'+
+                                            '<a href="https://youtu.be/OzjogCFO4Zo">'+
+                                              'This link to YouTube'+
+                                            '</a>'+
+                                          '</div>');
+      $('body').append($enhanceYoutubeVideoLinksFixture);
+      enhanceYoutubeVideoLinks = new GOVUK.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+
+    });
+
+    afterEach(function() {
+      $('.govuk-govspeak').remove();
+      $('.media-player').remove();
+    });
+
+    it("does not have a data attribute - data-youtube-player", function () {
+      expect($('.govuk-govspeak a')).not.toHaveAttr('data-youtube-player');
+    });
+
+    it("creates a media player", function () {
+      expect($('.media-player')).toExist();
+    });
+
+  });
+
+  describe('An external link to YouTube', function () {
+
+    var $externalYoutubeVideoLinksFixture, externalYoutubeVideoLinks;
+
+    beforeEach(function() {
+
+      $externalYoutubeVideoLinksFixture = $('<div class="govuk-govspeak">'+
+                                            '<a href="https://youtu.be/OzjogCFO4Zo" data-youtube-player="off">'+
+                                              'This link to YouTube'+
+                                            '</a>'+
+                                          '</div>');
+      $('body').append($externalYoutubeVideoLinksFixture);
+      externalYoutubeVideoLinks = new GOVUK.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+
+    });
+
+    afterEach(function() {
+      $('.govuk-govspeak').remove();
+      $('.media-player').remove();
+    });
+
+    it("has a data attribute - data-youtube-player that prevents the link being converted to a player", function () {
+      expect($('.govuk-govspeak a')).toHaveAttr('data-youtube-player');
+    });
+
+    it("does not create a media player", function () {
+      expect($('.media-player')).not.toExist();
+    });
+
+  });
+
+});


### PR DESCRIPTION
When using the [govspeak component](http://govuk-component-guide.herokuapp.com/components/govspeak), all links to YouTube are converted to an [embedded video player](http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/with_youtube_embed/preview).

This PR allows links to YouTube which aren't converted to an embedded player.

Check for a data attribute `data-youtube-player` if its value is `off`
then don’t convert that link into an embedded player.

For example:
```
<a href="http://www.youtube.com/youtubevidid" data-youtube-player="off">
Watch this related video
</a>
```

Here's a demo: 
http://codepen.io/gemmaleigh/pen/qZJmKB

There are Jasmine tests which can be previewed in the browser.
http://static.dev.gov.uk/specs

