### PR TITLE
Add HMRC webchat to more GOV.UK pages

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -22,7 +22,9 @@
         '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
         '/tax-credits-overpayments',
         '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
-        '/vat-registration/changes-to-your-details'
+        '/vat-registration/changes-to-your-details',
+        '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
+        '/lost-national-insurance-number',
       ];
 
       return ($.inArray(window.location.pathname, webchatEnabledPaths) >= 0);


### PR DESCRIPTION
- Specifically, the lost NI number information and contact pages.