### PR TITLE
Check if links to Youtube should be embedded

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -1,52 +1,66 @@
 //= require libs/jquery/jquery-ui-1.10.2.custom
 //= require vendor/jquery/jquery.player.min
 
-(function ($) {
-  window.GOVUK = window.GOVUK || {};
+(function(Modules) {
+  "use strict";
 
-  function parseYoutubeVideoId(string){
-    if(string.indexOf('youtube.com') > -1){
-      var i, _i, part, parts, params = {};
-      parts = string.split('?');
-      if (parts.length === 1){
-        return;
+  Modules.YoutubeVideoLinks = function() {
+
+    this.start = function($el) {
+
+      function parseYoutubeVideoId(string){
+        if(string.indexOf('youtube.com') > -1){
+          var i, _i, part, parts, params = {};
+          parts = string.split('?');
+          if (parts.length === 1){
+            return;
+          }
+          parts = parts[1].split('&');
+          for(i=0,_i=parts.length; i<_i; i++){
+            part = parts[i].split('=');
+            params[part[0]] = part[1];
+          }
+          return params.v;
+        }
+        if(string.indexOf('youtu.be') > -1){
+          var parts = string.split('/');
+          return parts.pop();
+        }
       }
-      parts = parts[1].split('&');
-      for(i=0,_i=parts.length; i<_i; i++){
-        part = parts[i].split('=');
-        params[part[0]] = part[1];
+
+      function shouldConvertToEmbeddedPlayer($link){
+        return $link.attr("data-youtube-player") != "off";
       }
-      return params.v;
-    }
-    if(string.indexOf('youtu.be') > -1){
-      var parts = string.split('/');
-      return parts.pop();
-    }
-  }
 
-  function enhanceYoutubeVideoLinks($el){
-    $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
-      var $link = $(this),
-          videoId = parseYoutubeVideoId($link.attr('href')),
-          $holder = $('<span class="media-player" />'),
-          $captions = $link.siblings('.captions');
+      function enhanceYoutubeVideoLinks($el) {
+        $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function (i){
 
-      if(typeof videoId !== 'undefined'){
-        $link.parent().replaceWith($holder);
+          var $link = $(this);
 
-        $holder.player({
-          id: 'youtube-'+i,
-          media: videoId,
-          captions: $captions.length > 0 ? $captions.attr('href') : null,
-          url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+          if (shouldConvertToEmbeddedPlayer($link)) {
+            var videoId = parseYoutubeVideoId($link.attr('href'));
+
+            if(typeof videoId !== 'undefined') {
+
+              var $holder = $('<span class="media-player" />'),
+                  $captions = $link.siblings('.captions');
+
+              $link.parent().replaceWith($holder);
+              $holder.player({
+                id: 'youtube-'+i,
+                media: videoId,
+                captions: $captions.length > 0 ? $captions.attr('href') : null,
+                url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+              });
+            }
+          }
         });
       }
-    });
-  }
 
-  GOVUK.enhanceYoutubeVideoLinks = enhanceYoutubeVideoLinks;
+      var $element = $('.govuk-govspeak');
+      enhanceYoutubeVideoLinks($element);
 
-  $(function(){
-    GOVUK.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
-  });
-})(jQuery);
+    };
+  };
+
+})(window.GOVUK.Modules);

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
@@ -1,0 +1,51 @@
+describe('Links to YouTube in govspeak content', function () {
+  "use strict";
+
+  var $element;
+
+  beforeEach(function() {
+    $element = $('<div class="govuk-govspeak">\
+                    <a href="https://youtu.be/OzjogCFO4Zo">\
+                      This link to YouTube\
+                    </a>\
+                  </div>');
+    var YoutubeVideoLinks = new GOVUK.Modules.YoutubeVideoLinks();
+    YoutubeVideoLinks.start($element);
+  });
+
+  afterEach(function() {
+    $(document).off();
+  });
+
+  describe('- A YouTube link to be converted to an embedded player', function () {
+
+    it("does not have a data attribute - data-youtube-player", function () {
+      var YoutubeVideoLink = $element.find('a');
+      expect(YoutubeVideoLink).not.toHaveAttr('data-youtube-player');
+    });
+    it("is converted to an embedded player", function () {
+      $element = $('<div class="govuk-govspeak">\
+                    <span class="media-player"></span>\
+                  </div>');
+      var mediaPlayer = $element.find('.media-player');
+      expect(mediaPlayer).toHaveLength(1);
+    });
+  });
+
+  describe('- An external link to YouTube', function () {
+    it("has a data attribute - data-youtube-player", function () {
+      $element = $('<div class="govuk-govspeak">\
+                    <a href="https://youtu.be/OzjogCFO4Zo" data-youtube-player="off">\
+                      This link to YouTube\
+                    </a>\
+                  </div>');
+      var govspeakLink = $element.find('a');
+      expect(govspeakLink).toHaveAttr('data-youtube-player');
+    });
+    it("is not converted to an embedded player", function () {
+      var mediaPlayer = $element.find('.media-player');
+      expect(mediaPlayer).toHaveLength(0);
+    });
+  });
+
+});


### PR DESCRIPTION
When using the [govspeak component](http://govuk-component-guide.herokuapp.com/components/govspeak), all links to YouTube are converted to an [embedded video player](http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/with_youtube_embed/preview).

This PR allows links to YouTube which aren't converted to an embedded player.

Check for a data attribute `data-youtube-player` if its value is `off`
then don’t convert that link into an embedded player.

For example:
```
<a href="http://www.youtube.com/youtubevidid" data-youtube-player="off">
Watch this related video
</a>
```