### PR TITLE
Make register-to-vote callout copy clearer

### DIFF
--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -16,8 +16,8 @@
       <% if has_promo_callout %>
         <div class="inner group related-callout">
           <h2 id="parent-promo">Register to vote</h2>
-          <p>You need to register if you want to vote in elections and referendums.</p>
-          <p>You can <a href="/register-to-vote?source=related">register online</a> in less than 5 minutes.</p>
+          <p>You need to be registered if you want to vote in elections and referendums.</p>
+          <p>You can <a href="/register-to-vote?source=related">register online</a> in less than 5 minutes</p>
         </div>
       <% end %>
 


### PR DESCRIPTION
We've seen some issues with users mistakenly thinking they need to register
for the referendum specifically. Be clearer.

![screenshot 2016-05-09 13 59 59](https://cloud.githubusercontent.com/assets/63201/15113802/5f26f886-15ee-11e6-8081-7a4869b3ab65.png)
