### PR TITLE
Fix display of external links in the metadata component.

### DIFF
--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -41,4 +41,8 @@
   &.direction-rtl dd {
     float: right;
   }
+
+  a[rel="external"] {
+    @include external-link-14;
+  }
 }

--- a/app/views/govuk_component/docs/metadata.yml
+++ b/app/views/govuk_component/docs/metadata.yml
@@ -31,3 +31,8 @@ fixtures:
     from: <a href='/government/organisations/cabinet-office'>Cabinet Office</a>
     history: Updated 2 weeks ago
     part_of: <a href='/government/topics/environment'>Environment</a>
+  external_link:
+    from: <a href='/government/organisations/cabinet-office'>Cabinet Office</a>
+    first_published: 14 June 2014
+    other:
+      Applies to: England, Scotland, and Wales (see detailed guidance for <a href="http://www.dardni.gov.uk/news-dard-pa022-a-13-new-procedure-for" rel="external">Northern Ireland</a>)


### PR DESCRIPTION
Because the base font-size is different on this component, the external
link icon looks a bit off.

### Before

![screen shot 2016-05-09 at 16 02 38](https://cloud.githubusercontent.com/assets/1650875/15117474/a1d477b0-15ff-11e6-997e-52880bc6705b.png)

### After

![screen shot 2016-05-09 at 16 03 40](https://cloud.githubusercontent.com/assets/1650875/15117478/a6fda9e6-15ff-11e6-99d9-7a3daa410822.png)
