### PR TITLE
Create a test for video embedding within the govspeak component

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -24,6 +24,14 @@
     }
   }
 
+  function checkPrototcolScheme(){
+    var scheme = document.location.protocol;
+    if (scheme == "file:") {
+      scheme = "https:";
+      return scheme;
+    }
+  }
+
   function enhanceYoutubeVideoLinks($el){
     $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
       var $link = $(this),
@@ -34,11 +42,13 @@
       if(typeof videoId !== 'undefined'){
         $link.parent().replaceWith($holder);
 
+        var protocol = checkPrototcolScheme();
+
         $holder.player({
           id: 'youtube-'+i,
           media: videoId,
           captions: $captions.length > 0 ? $captions.attr('href') : null,
-          url: ('https://www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+          url: (protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
         });
       }
     });

--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -38,7 +38,7 @@
           id: 'youtube-'+i,
           media: videoId,
           captions: $captions.length > 0 ? $captions.attr('href') : null,
-          url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+          url: ('https://www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
         });
       }
     });

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links.spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links.spec.js
@@ -1,0 +1,20 @@
+describe('A YouTube link to be converted to an embedded player in govspeak content', function () {
+  "use strict";
+
+  it("is converted to an embedded player", function () {
+
+    var enhanceYoutubeVideoLinksFixture, $enhanceYoutubeVideoLinksHTML;
+
+    enhanceYoutubeVideoLinksFixture = '<div class="govuk-govspeak">'
+    +'<p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>'
+    +'<p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developers guide, by Anna Shipman</a></p>'
+    +'</div>';
+
+    $enhanceYoutubeVideoLinksHTML = $(enhanceYoutubeVideoLinksFixture);
+    $('body').append($enhanceYoutubeVideoLinksHTML);
+    GOVUK.enhanceYoutubeVideoLinks($(".govuk-govspeak"));
+
+    expect($('.media-player')).toHaveLength(1);
+  });
+
+});


### PR DESCRIPTION
I've created a minimal test for the [govspeak component with YouTube video embed](http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/with_youtube_embed/preview). 

I'm getting the following error: 

```
  TypeError: 'null' is not an object (evaluating 'media.container') 
```

@fofr I saw your PR over on the repo for the [fork of the accessible media player](https://github.com/alphagov/Accessible-Media-Player/commit/94107068ed6cef422e92890d52e87b3133a71563). 

I think these issues might be related, as the YouTube player is also missing a file extension (it shouldn't be required).