### PR TITLE
Hide EU banner from 26 May

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -8,7 +8,7 @@
 
 <% content_for :head do %>
   <!--[if gt IE 7]><!-->
-  <script>!function(t){"use strict";function e(){return!/^\/register-to-vote|^\/done/.test(window.location.pathname)}function n(){var e=t.cookie.match("(?:^|[ ;])global_bar_seen=([0-9]+)");return e?parseInt(e.pop(),10)<3:!0}var o=t.documentElement;e()&&n()&&(o.className=o.className.concat(" show-global-bar"))}(document);</script>
+  <script>!function(e){"use strict";function t(){return!/^\/register-to-vote|^\/done/.test(window.location.pathname)}function n(){var t=e.cookie.match("(?:^|[ ;])global_bar_seen=([0-9]+)");return t?parseInt(t.pop(),10)<3:!0}function a(){var e=new Date("May 26 2016 15:59:59").getTime(),t=(new Date).getTime();return e>=t}var o=e.documentElement;a()&&t()&&n()&&(o.className=o.className.concat(" show-global-bar"))}(document);</script>
   <!--<![endif]-->
   <%= render :partial => 'stylesheet', :locals => { :css_file => local_assigns[:css_file] || 'static' } %>
 <% end %>

--- a/spec/javascripts/global-bar-class-toggle.spec.js
+++ b/spec/javascripts/global-bar-class-toggle.spec.js
@@ -9,7 +9,7 @@ describe("toggling a global bar HTML class based on cookie", function () {
     (function (document) {
       "use strict"
       var documentElement = document.documentElement;
-      if (urlPermitsShow() && viewCountPermitsShow()) {
+      if (datePermitsShow() && urlPermitsShow() && viewCountPermitsShow()) {
         documentElement.className = documentElement.className.concat(' show-global-bar');
       }
 
@@ -25,6 +25,13 @@ describe("toggling a global bar HTML class based on cookie", function () {
 
         return parseInt(c.pop(), 10) < 3;
       }
+
+      function datePermitsShow() {
+        var ends = new Date("May 26 2016 15:59:59").getTime(),
+            now = new Date().getTime();
+
+        return now <= ends;
+      }
     })(document);
 
     /* --------------------------------------- */
@@ -34,7 +41,7 @@ describe("toggling a global bar HTML class based on cookie", function () {
     var window = fakeWindow || root;
 
     /* --------------------------------------- */
-    !function(t){"use strict";function e(){return!/^\/register-to-vote|^\/done/.test(window.location.pathname)}function n(){var e=t.cookie.match("(?:^|[ ;])global_bar_seen=([0-9]+)");return e?parseInt(e.pop(),10)<3:!0}var o=t.documentElement;e()&&n()&&(o.className=o.className.concat(" show-global-bar"))}(document);
+    !function(e){"use strict";function t(){return!/^\/register-to-vote|^\/done/.test(window.location.pathname)}function n(){var t=e.cookie.match("(?:^|[ ;])global_bar_seen=([0-9]+)");return t?parseInt(t.pop(),10)<3:!0}function a(){var e=new Date("May 26 2016 15:59:59").getTime(),t=(new Date).getTime();return e>=t}var o=e.documentElement;a()&&t()&&n()&&(o.className=o.className.concat(" show-global-bar"))}(document);
     /* --------------------------------------- */
   }
 
@@ -63,48 +70,75 @@ describe("toggling a global bar HTML class based on cookie", function () {
   });
 
   function runTests(globalBarFn) {
-    it("shows when no cookie is set", function() {
-      expectGlobalBarToBeHidden();
+    describe("before May 26 4pm", function() {
+      beforeEach(function() {
+        var originalDate = Date;
+        spyOn(window, 'Date').and.callFake(function(params) {
+          if (params) {
+            return new originalDate(params);
+          } else {
+            return new originalDate("May 26, 2016 15:00:00");
+          }
+        });
+      });
+
+      it("shows when no cookie is set", function() {
+        expectGlobalBarToBeHidden();
+        globalBarFn();
+        expectGlobalBarToShow();
+      });
+
+      it("does not show when bar has been seen 3 times", function() {
+        GOVUK.setCookie('global_bar_seen', 3);
+        expectGlobalBarToBeHidden();
+        globalBarFn();
+        expectGlobalBarToBeHidden();
+      });
+
+      it("shows when the bar has been seen 2 times", function() {
+        GOVUK.setCookie('global_bar_seen', '2');
+        globalBarFn();
+        expectGlobalBarToShow();
+      });
+
+      it("shows when the bar has been seen 2 times and there are lots of cookies", function() {
+        GOVUK.setCookie('global_bar_thing', '10');
+        GOVUK.setCookie('seen_cookie_message', 'true');
+        GOVUK.setCookie('global_bar_seen', '2');
+        GOVUK.setCookie('is_global_bar_seen', '8');
+        GOVUK.setCookie('_ua', '1234873487');
+        globalBarFn();
+        expectGlobalBarToShow();
+      });
+
+      it("shows when the cookie value is not a parseable number", function() {
+        GOVUK.setCookie('global_bar_seen', 'foo_bar2');
+        globalBarFn();
+        expectGlobalBarToShow();
+      });
+
+      it("does not show on register to vote pages", function() {
+        globalBarFn({location: {pathname: '/register-to-vote'}});
+        expectGlobalBarToBeHidden();
+      });
+
+      it("does not show on done pages", function() {
+        globalBarFn({location: {pathname: '/done'}});
+        expectGlobalBarToBeHidden();
+      });
+    });
+
+    it("does not show after 26 May 4pm", function() {
+      var originalDate = Date;
+      spyOn(window, 'Date').and.callFake(function(params) {
+        if (params) {
+          return new originalDate(params);
+        } else {
+          return new originalDate("May 26, 2016 16:00:00");
+        }
+      });
+
       globalBarFn();
-      expectGlobalBarToShow();
-    });
-
-    it("does not show when bar has been seen 3 times", function() {
-      GOVUK.setCookie('global_bar_seen', 3);
-      expectGlobalBarToBeHidden();
-      globalBarFn();
-      expectGlobalBarToBeHidden();
-    });
-
-    it("shows when the bar has been seen 2 times", function() {
-      GOVUK.setCookie('global_bar_seen', '2');
-      globalBarFn();
-      expectGlobalBarToShow();
-    });
-
-    it("shows when the bar has been seen 2 times and there are lots of cookies", function() {
-      GOVUK.setCookie('global_bar_thing', '10');
-      GOVUK.setCookie('seen_cookie_message', 'true');
-      GOVUK.setCookie('global_bar_seen', '2');
-      GOVUK.setCookie('is_global_bar_seen', '8');
-      GOVUK.setCookie('_ua', '1234873487');
-      globalBarFn();
-      expectGlobalBarToShow();
-    });
-
-    it("shows when the cookie value is not a parseable number", function() {
-      GOVUK.setCookie('global_bar_seen', 'foo_bar2');
-      globalBarFn();
-      expectGlobalBarToShow();
-    });
-
-    it("does not show on register to vote pages", function() {
-      globalBarFn({location: {pathname: '/register-to-vote'}});
-      expectGlobalBarToBeHidden();
-    });
-
-    it("does not show on done pages", function() {
-      globalBarFn({location: {pathname: '/done'}});
       expectGlobalBarToBeHidden();
     });
   }


### PR DESCRIPTION
* Check the current date and hide the banner for any time after midnight 26 May
* Set the current date to 25 May for the purpose of tests
* Include a specific test for the banner not showing on 26 May

https://trello.com/c/Bv2wbXTa/403-site-wide-banner-banner-not-visible-after-26th-may

@dsingleton @boffbowsh 