### PR TITLE
Check if links to youtube should be embedded

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -2,51 +2,77 @@
 //= require vendor/jquery/jquery.player.min
 
 (function ($) {
+  "use strict";
   window.GOVUK = window.GOVUK || {};
 
-  function parseYoutubeVideoId(string){
-    if(string.indexOf('youtube.com') > -1){
-      var i, _i, part, parts, params = {};
-      parts = string.split('?');
-      if (parts.length === 1){
-        return;
+  function GovspeakYoutubeVideoLinks () {
+
+    function getProtocol(){
+      var scheme = document.location.protocol;
+      if (scheme == "file:") {
+        scheme = "https:";
       }
-      parts = parts[1].split('&');
-      for(i=0,_i=parts.length; i<_i; i++){
-        part = parts[i].split('=');
-        params[part[0]] = part[1];
+      return scheme;
+    }
+
+    function parseYoutubeVideoId(string){
+      if(string.indexOf('youtube.com') > -1){
+        var i, _i, part, parts, params = {};
+        parts = string.split('?');
+        if (parts.length === 1){
+          return;
+        }
+        parts = parts[1].split('&');
+        for(i=0,_i=parts.length; i<_i; i++){
+          part = parts[i].split('=');
+          params[part[0]] = part[1];
+        }
+        return params.v;
       }
-      return params.v;
+      if(string.indexOf('youtu.be') > -1){
+        var parts = string.split('/');
+        return parts.pop();
+      }
     }
-    if(string.indexOf('youtu.be') > -1){
-      var parts = string.split('/');
-      return parts.pop();
+
+    function shouldConvertToEmbeddedPlayer($link){
+      return $link.attr("data-youtube-player") != "off";
     }
+
+    function enhanceYoutubeVideoLinks($el) {
+      $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function (i){
+
+        var $link = $(this);
+
+        if (shouldConvertToEmbeddedPlayer($link)) {
+          var videoId = parseYoutubeVideoId($link.attr('href'));
+
+          if(typeof videoId !== 'undefined') {
+
+            var $holder = $('<span class="media-player" />'),
+                $captions = $link.siblings('.captions');
+
+            $link.parent().replaceWith($holder);
+            var protocol = getProtocol();
+            $holder.player({
+              id: 'youtube-'+i,
+              media: videoId,
+              captions: $captions.length > 0 ? $captions.attr('href') : null,
+              url: (protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
+            });
+          }
+        }
+      });
+    }
+
+    return {
+      getProtocol: getProtocol,
+      enhanceYoutubeVideoLinks: enhanceYoutubeVideoLinks
+    }
+
   }
 
-  function enhanceYoutubeVideoLinks($el){
-    $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function(i){
-      var $link = $(this),
-          videoId = parseYoutubeVideoId($link.attr('href')),
-          $holder = $('<span class="media-player" />'),
-          $captions = $link.siblings('.captions');
+  GOVUK.enhanceYoutubeVideoLinks = new GovspeakYoutubeVideoLinks();
+  GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
 
-      if(typeof videoId !== 'undefined'){
-        $link.parent().replaceWith($holder);
-
-        $holder.player({
-          id: 'youtube-'+i,
-          media: videoId,
-          captions: $captions.length > 0 ? $captions.attr('href') : null,
-          url: (document.location.protocol + '//www.youtube.com/apiplayer?enablejsapi=1&version=3&playerapiid=')
-        });
-      }
-    });
-  }
-
-  GOVUK.enhanceYoutubeVideoLinks = enhanceYoutubeVideoLinks;
-
-  $(function(){
-    GOVUK.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
-  });
 })(jQuery);

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
@@ -1,0 +1,68 @@
+describe('Links to YouTube in govspeak content', function () {
+  "use strict";
+
+  var $enhanceYoutubeVideoLinksHTML, enhanceYoutubeVideoLinks;
+
+  var $turnOffEnhanceYoutubeVideoLinksHTML;
+
+  describe('- A YouTube link to be converted to an embedded player', function () {
+
+    beforeEach(function() {
+
+      $enhanceYoutubeVideoLinksHTML = $('<div class="govuk-govspeak">'+
+                                          '<a href="https://youtu.be/OzjogCFO4Zo">'+
+                                            'This link to YouTube'+
+                                          '</a>'+
+                                        '</div>');
+
+      $('body').append($enhanceYoutubeVideoLinksHTML);
+      GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+      spyOn(GOVUK.enhanceYoutubeVideoLinks, 'getProtocol').and.returnValue('https:');
+
+    });
+
+    afterEach(function() {
+      $enhanceYoutubeVideoLinksHTML.remove();
+      $('.media-player').remove();
+    });
+
+    it("does not have a data attribute - data-youtube-player", function () {
+      expect($('.govuk-govspeak a')).not.toHaveAttr('data-youtube-player');
+    });
+
+    it("is converted to an embedded player", function () {
+      expect($('.media-player')).toHaveLength(1);
+    });
+
+  });
+
+  describe('- An external link to YouTube', function () {
+
+    beforeEach(function() {
+
+      $turnOffEnhanceYoutubeVideoLinksHTML = $('<div class="govuk-govspeak">'+
+                                                '<a href="https://youtu.be/OzjogCFO4Zo" data-youtube-player="off">'+
+                                                  'This link to YouTube'+
+                                                '</a>'+
+                                              '</div>');
+
+      $('body').append($turnOffEnhanceYoutubeVideoLinksHTML);
+      GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+    });
+
+    afterEach(function() {
+      $turnOffEnhanceYoutubeVideoLinksHTML.remove();
+      $('.media-player').remove();
+    });
+
+    it("has a data attribute - data-youtube-player", function () {
+      expect($('.govuk-govspeak a')).toHaveAttr('data-youtube-player');
+    });
+
+    it("is not converted to an embedded player", function () {
+      expect($('.media-player')).not.toHaveLength(1);
+    });
+
+  });
+
+});


### PR DESCRIPTION
When using the [govspeak component](http://govuk-component-guide.herokuapp.com/components/govspeak), all links to YouTube are converted to an [embedded video player](http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/with_youtube_embed/preview).

This PR allows links to YouTube which aren't converted to an embedded player.

Check for a data attribute `data-youtube-player` if its value is `off`
then don’t convert that link into an embedded player.

For example:
```
<a href="http://www.youtube.com/youtubevidid" data-youtube-player="off">
Watch this related video
</a>
```