### PR TITLE
Dedupe organisations in meta tags

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -17,7 +17,7 @@
   organisations += links_hash[:lead_organisations] || []
   organisations += links_hash[:supporting_organisations] || []
   organisations += links_hash[:worldwide_organisations] || []
-  organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.join
+  organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.uniq.join
   meta_tags["govuk:analytics:organisations"] = organisations_content if organisations.any?
 
   world_locations = links_hash[:world_locations] || []

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -36,7 +36,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   test "renders organisations in a meta tag with angle brackets" do
     content_item = {
       links: {
-        organisations:            [{ analytics_identifier: "O1" }],
+        organisations:            [{ analytics_identifier: "O1" }, { analytics_identifier: "O1" }],
         lead_organisations:       [{ analytics_identifier: "L2" }],
         supporting_organisations: [{ analytics_identifier: "S3" }],
         worldwide_organisations:  [{ analytics_identifier: "W4" }],


### PR DESCRIPTION
This element assumes that the `organisations`, `lead_organisations` and `supporting_organisations` links in the links hash never overlap. This is not the case, and definitely isn't since https://github.com/alphagov/govuk-content-schemas/pull/308. This commit dedupes them before generating the metatag.