### PR TITLE
Improve .report-a-problem-toggle:focus contrast

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -68,6 +68,10 @@
        Guarantees correct appearance. */
     color: $secondary-text-colour !important;
     text-decoration: underline !important;
+
+    &:focus {
+      color: $text-colour !important;
+    }
   }
 
   @include ie-lte(7) {


### PR DESCRIPTION
This link seems to override the base link classes, but produces a combination that has a poor contrast ratio when focused.

This commit updates the focus styles to fix the contrast.

### Before

<img width="334" alt="screen shot 2016-05-17 at 14 44 51" src="https://cloud.githubusercontent.com/assets/1650875/15324461/6ef7b2c2-1c3e-11e6-9406-d1c3af5c084a.png">

### After

<img width="337" alt="screen shot 2016-05-17 at 14 44 55" src="https://cloud.githubusercontent.com/assets/1650875/15324467/73b812a2-1c3e-11e6-85c2-af58f9b28e9c.png">
