### PR TITLE
Adds lang and hreflang attribute to Welsh translation link

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -4,6 +4,6 @@
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
   <li><a href="/help/terms-conditions">Terms and conditions</a></li>
-  <li><a href="/cymraeg">Rhestr o Wasanaethau Cymraeg</a></li>
+  <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>
 </ul>


### PR DESCRIPTION
Will enable screenreaders with multiple languages set to read the link correctly and determine the language of the document linked.