### PR TITLE
[Merge on Wed 25th] Remove register to vote promo slots on Transaction pages

### DIFF
--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -16,8 +16,8 @@
       <% if has_promo_callout %>
         <div class="inner group related-callout">
           <h2 id="parent-promo">Register to vote</h2>
-          <p>You need to be registered if you want to vote in elections and referendums.</p>
-          <p>You can <a href="/register-to-vote?source=related">register online</a> in less than 5 minutes</p>
+          <p>You need to register if you want to vote in elections and referendums.</p>
+          <p>You can <a href="/register-to-vote?source=related">register online</a> in less than 5 minutes.</p>
         </div>
       <% end %>
 

--- a/app/views/root/related.raw.html.erb
+++ b/app/views/root/related.raw.html.erb
@@ -1,34 +1,10 @@
 <%# Whilst they are both in use, this and the test copy in slimmer should be kept in sync %>
-
-<%
-  promo_target_formats = ['completed_transaction', 'transaction']
-  promo_excluded_regex = /register-to-vote/
-
-  has_promo_callout = (artefact and promo_target_formats.include?(artefact.format) and not promo_excluded_regex.match(URI.decode(artefact.slug)))
-%>
-<%# Whilst they are both in use, this and the test copy in slimmer should be kept in sync %>
-<% if artefact and (artefact.related_artefacts.any? or (artefact.related_external_links and artefact.related_external_links.any?) or has_promo_callout) %>
+<% if artefact and (artefact.related_artefacts.any? or (artefact.related_external_links and artefact.related_external_links.any?)) %>
   <!-- related -->
   <div class="related-container">
 
     <aside class="related" id="related">
-
-      <% if has_promo_callout %>
-        <div class="inner group related-callout">
-          <h2 id="parent-promo">Register to vote</h2>
-          <p>You need to register if you want to vote in elections and referendums.</p>
-          <p>You can <a href="/register-to-vote?source=related">register online</a> in less than 5 minutes.</p>
-        </div>
-      <% end %>
-
-      <% related_artefacts = artefact.related_artefacts || [] %>
-
-      <%# Exclude '/register-to-vote', only if we're adding it manually (its easier to do by `content_id` than full `web_url`) %>
-      <% related_artefacts = related_artefacts.reject { |artefact|
-        artefact.content_id == "834a7921-260b-4061-9de1-edda3e998c68" and has_promo_callout
-      } %>
-
-      <% related_artefacts.group_by(&:group).each do |group, related_artefacts| %>
+      <% artefact.related_artefacts.group_by(&:group).each do |group, related_artefacts| %>
         <%
           section = case group
                     when 'subsection' then artefact.primary_section
@@ -36,7 +12,6 @@
                     when 'other' then { "title" => "Elsewhere on GOV.UK" }
                     end
           section = section['parent'] if artefact.format == "travel-advice" and group == "subsection"
-
         %>
         <div class="inner group related-<%= group %>">
           <% if section %>

--- a/test/integration/related_template_test.rb
+++ b/test/integration/related_template_test.rb
@@ -10,15 +10,15 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
 
   context "with related artefacts" do
     setup do
-      @related1 = stub("Artefact", :web_url => "http://www.example.com/foo", :title => "Foo", :group => "subsection")
-      @related2 = stub("Artefact", :web_url => "http://www.example.com/bar", :title => "Bar", :group => "section")
-      @related3 = stub("Artefact", :web_url => "http://www.example.com/baz", :title => "Baz", :group => "other")
+      @related1 = stub("Artefact", web_url: "http://www.example.com/foo", title: "Foo", group: "subsection")
+      @related2 = stub("Artefact", web_url: "http://www.example.com/bar", title: "Bar", group: "section")
+      @related3 = stub("Artefact", web_url: "http://www.example.com/baz", title: "Baz", group: "other")
       @artefact = stub("Artefact",
-        :related_artefacts => [@related1, @related2, @related3],
-        :related_external_links => [],
-        :primary_root_section => { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" }},
-        :primary_section => { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
-        :format => "guide"
+        related_artefacts: [@related1, @related2, @related3],
+        related_external_links: [],
+        primary_root_section: { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" } },
+        primary_section: { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
+        format: "guide"
       )
     end
 
@@ -148,11 +148,11 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   context "adding related_external_links with no internal related links" do
     setup do
       @artefact = stub("Artefact",
-        :related_artefacts => [],
-        :related_external_links => [],
-        :primary_root_section => { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" }},
-        :primary_section => { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
-        :format => "guide"
+        related_artefacts: [],
+        related_external_links: [],
+        primary_root_section: { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" } },
+        primary_section: { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
+        format: "guide"
       )
     end
 
@@ -207,7 +207,7 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   should "be blank with an artefact with no related_artefacts or related_external_links" do
     template = get_template
 
-    artefact = stub("Artefact", :related_artefacts => [], :related_external_links => [])
+    artefact = stub("Artefact", related_artefacts: [], related_external_links: [])
     result = ERB.new(template).result(binding)
 
     assert_match /\A\s+\z/, result
@@ -216,7 +216,7 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   should "be blank with no related_artefacts and nil related_external_links" do
     template = get_template
 
-    artefact = stub("Artefact", :related_artefacts => [], :related_external_links => nil)
+    artefact = stub("Artefact", related_artefacts: [], related_external_links: nil)
     result = ERB.new(template).result(binding)
 
     assert_match /\A\s+\z/, result

--- a/test/integration/related_template_test.rb
+++ b/test/integration/related_template_test.rb
@@ -10,15 +10,15 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
 
   context "with related artefacts" do
     setup do
-      @related1 = stub("Artefact", web_url: "http://www.example.com/foo", title: "Foo", group: "subsection", content_id: 1)
-      @related2 = stub("Artefact", web_url: "http://www.example.com/bar", title: "Bar", group: "section", content_id: 2)
-      @related3 = stub("Artefact", web_url: "http://www.example.com/baz", title: "Baz", group: "other", content_id: 3)
+      @related1 = stub("Artefact", :web_url => "http://www.example.com/foo", :title => "Foo", :group => "subsection")
+      @related2 = stub("Artefact", :web_url => "http://www.example.com/bar", :title => "Bar", :group => "section")
+      @related3 = stub("Artefact", :web_url => "http://www.example.com/baz", :title => "Baz", :group => "other")
       @artefact = stub("Artefact",
-        related_artefacts: [@related1, @related2, @related3],
-        related_external_links: [],
-        primary_root_section: { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" } },
-        primary_section: { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
-        format: "guide"
+        :related_artefacts => [@related1, @related2, @related3],
+        :related_external_links => [],
+        :primary_root_section => { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" }},
+        :primary_section => { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
+        :format => "guide"
       )
     end
 
@@ -148,11 +148,11 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   context "adding related_external_links with no internal related links" do
     setup do
       @artefact = stub("Artefact",
-        related_artefacts: [],
-        related_external_links: [],
-        primary_root_section: { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" } },
-        primary_section: { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
-        format: "guide"
+        :related_artefacts => [],
+        :related_external_links => [],
+        :primary_root_section => { "title" => "Section", "content_with_tag" => { "web_url" => "/browse/section" }},
+        :primary_section => { "title" => "Sub-section", "content_with_tag" => { "web_url" => "/browse/section/subsection" } },
+        :format => "guide"
       )
     end
 
@@ -207,7 +207,7 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   should "be blank with an artefact with no related_artefacts or related_external_links" do
     template = get_template
 
-    artefact = stub("Artefact", related_artefacts: [], related_external_links: [], format: "smart_answer")
+    artefact = stub("Artefact", :related_artefacts => [], :related_external_links => [])
     result = ERB.new(template).result(binding)
 
     assert_match /\A\s+\z/, result
@@ -216,24 +216,9 @@ class RelatedTemplateTest < ActionDispatch::IntegrationTest
   should "be blank with no related_artefacts and nil related_external_links" do
     template = get_template
 
-    artefact = stub("Artefact", related_artefacts: [], related_external_links: nil, format: "smart_answer")
+    artefact = stub("Artefact", :related_artefacts => [], :related_external_links => nil)
     result = ERB.new(template).result(binding)
 
     assert_match /\A\s+\z/, result
-  end
-
-  context "adding promo block to related links" do
-    should "have promo block for target formats" do
-      artefact = stub("Artefact", related_artefacts: [], related_external_links: nil, format: "completed_transaction", slug: "book-theory-test")
-      result = ERB.new(get_template).result(binding)
-      doc = Nokogiri::HTML.parse(result)
-      assert doc.at_css("h2#parent-promo")
-    end
-
-    should "not have promo block for artefact with excluded path" do
-      artefact = stub("Artefact", related_artefacts: [], related_external_links: nil, format: "completed_transaction", slug: "done/register-to-vote")
-      result = ERB.new(get_template).result(binding)
-      assert_match(/\A\s+\z/, result)
-    end
   end
 end


### PR DESCRIPTION
These were added as a short-term promotion on Start and Done pages/ We'll be removing them tomorrow. Please give a thumbsup review but don't merge. I'll do that tomorrow before the deploy slot. 

Reverts 
- https://github.com/alphagov/static/pull/784
- https://github.com/alphagov/static/pull/772

<Del>Tests are failing due to CI, they pass locally.</del>