### PR TITLE
Remove invalid breadcrumbs aria role from base template

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -32,7 +32,7 @@
 <% content_for :content do %>
   <% unless local_assigns[:hide_nav] %>
     <div id="global-breadcrumb" class="header-context">
-      <ol role="breadcrumbs" class="group">
+      <ol class="group">
         <li><a href="/">Home</a></li>
       </ol>
     </div>


### PR DESCRIPTION
* Breadcrumbs is not a valid ARIA role
* It is not being used for styling

We previously removed from the component: https://github.com/alphagov/static/pull/737
Was added in: https://github.com/alphagov/static/pull/238