### PR TITLE
Remove stylesheets duplicated in header-footer-only

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,17 +1,12 @@
-/* govuk_frontend_toolkit includes */
 @import "header-footer-only";
 
+/* govuk_frontend_toolkit includes */
 @import "shims";
 @import "design-patterns/buttons";
-
-/* local styleguide includes */
-@import "styleguide/conditionals2";
 
 /* styles */
 @import "helpers/buttons";
 @import "helpers/core";
-@import "helpers/footer";
-@import "helpers/header";
 @import "helpers/multi-step";
 @import "helpers/organisations";
 @import "helpers/publisher";


### PR DESCRIPTION
`styleguide/conditionals2`, `helpers/footer` and `helpers/header` are
all already included in `header-footer-only`. This means their styles are duplicated in the generated CSS.

It seems odd that header and footer weren't removed when switching to `header-footer-only`, but I haven't found any explicit reason for them to be kept. Nothing appears to override those styles.

For an example, search for `#user-satisfaction` in https://assets.digital.cabinet-office.gov.uk/static/static-35b681259fdcd07f543889e5711c8dbcf7728a3fa318c4881d0ba2e3d8bb3ac0.css