### PR TITLE
Track when HMRC webchat is offered to users in analytics

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -51,6 +51,7 @@
         if (message.evt === 'opened') {
           webchat.$banner.addClass('open');
           webchat.$banner.attr('aria-hidden', false);
+          GOVUK.analytics.trackEvent('webchat', 'offered');
         } else if (message.evt === 'closed') {
           webchat.$banner.removeClass('open');
           webchat.$banner.attr('aria-hidden', true);


### PR DESCRIPTION
We currently track when users interact with HMRC’s webchat service (eg when they click the ‘accept’ or ‘reject’ buttons). This commit adds in an event to track when the webchat service is offered to users.

This event, alongside other data such as page views, will give us an idea of:

1. how many people are being presented with webchat but aren’t doing
anything with it
2. how many people are not being presented with webchat at all

cc @robinwhittleton @dsingleton @davidillsley 