### PR TITLE
Remove `lead_organisations` & `supporting_organisations`

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -14,8 +14,6 @@
 
   organisations = []
   organisations += links_hash[:organisations] || []
-  organisations += links_hash[:lead_organisations] || []
-  organisations += links_hash[:supporting_organisations] || []
   organisations += links_hash[:worldwide_organisations] || []
   organisations_content = organisations.map { |link| "<#{link[:analytics_identifier]}>" }.uniq.join
   meta_tags["govuk:analytics:organisations"] = organisations_content if organisations.any?

--- a/app/views/govuk_component/docs/analytics_meta_tags.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags.yml
@@ -12,10 +12,6 @@ fixtures:
         organisations:
         - analytics_identifier: D1
         - analytics_identifier: D3
-        lead_organisations:
-        - analytics_identifier: D2
-        supporting_organisations:
-        - analytics_identifier: EO3
         worldwide_organisations:
         - analytics_identifier: EO3
   with_world_locations:

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -37,14 +37,12 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     content_item = {
       links: {
         organisations:            [{ analytics_identifier: "O1" }, { analytics_identifier: "O1" }],
-        lead_organisations:       [{ analytics_identifier: "L2" }],
-        supporting_organisations: [{ analytics_identifier: "S3" }],
         worldwide_organisations:  [{ analytics_identifier: "W4" }],
       }
     }
 
     render_component(content_item: content_item)
-    assert_meta_tag('govuk:analytics:organisations', '<O1><L2><S3><W4>')
+    assert_meta_tag('govuk:analytics:organisations', '<O1><W4>')
   end
 
   test "renders world locations in a meta tag with angle brackets" do


### PR DESCRIPTION
These have been deprecated. We've ensured that all `lead_organisations` and `supporting_organisations` have been merged into `organisations` (https://github.com/alphagov/whitehall/pull/2585), so the data will be the same.