### PR TITLE
Add component smoke testing, using fixtures

### DIFF
--- a/test/govuk_component/component_smoke_test.rb
+++ b/test/govuk_component/component_smoke_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class ComponentsTest < ActionView::TestCase
+  test "each component fixture can be rendered without errors being raised" do
+    doc_files = Rails.root.join('app', 'views', 'govuk_component', 'docs', '*.yml')
+    components = Dir[doc_files].sort.map do |file|
+      { id: File.basename(file, '.yml') }.merge(YAML::load_file(file)).deep_symbolize_keys
+    end
+
+    components.each do |component|
+      component[:fixtures].each do |_, fixture|
+        render file: "govuk_component/#{component[:id]}.raw", locals: fixture
+      end
+    end
+  end
+end


### PR DESCRIPTION
  https://en.wikipedia.org/wiki/Smoke_testing_(software)

Each component has a set of fixture data that is used to generate
examples within govuk-component-guide, and show example usage.

Use this example data to run smoke test on each component, which
should give us increased confidence in catching big regressions in
component view logic - or broken fixture data.

It only asserts that components render without exception, not that
the internal logic is correct (this should be covered by view tests).