### PR TITLE
[Do not merge] Move unstuck logic to CSS so that breakpoints are better respected

### DIFF
--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -34,7 +34,6 @@
       var _hasResized = true;
       var _hasScrolled = true;
       var _interval = 50;
-      var _isDesktop = true;
       var _windowVerticalPosition = 1;
       var _startPosition, _stopPosition;
 
@@ -64,14 +63,8 @@
           _hasScrolled = true;
 
           var windowDimensions = self._getWindowDimensions();
-          _isDesktop = windowDimensions.width > 768;
           _startPosition = $el.offset().top;
           _stopPosition = $el.offset().top + $el.height() - windowDimensions.height;
-
-          var isMobile = !_isDesktop;
-          if (isMobile) {
-            unstick();
-          }
         }
       }
 
@@ -81,13 +74,8 @@
 
           _windowVerticalPosition = self._getWindowPositions().scrollTop;
 
-          if (_isDesktop) {
-            updateVisibility();
-            updatePosition();
-          } else {
-            show();
-            unstick();
-          }
+          updateVisibility();
+          updatePosition();
         }
       }
 
@@ -107,11 +95,6 @@
         } else {
           stickToWindow();
         }
-      }
-
-      function unstick () {
-        $element.removeClass('govuk-sticky-element--stuck-to-parent');
-        $element.removeClass('govuk-sticky-element--stuck-to-window');
       }
 
       function stickToWindow () {

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -22,4 +22,8 @@
     bottom: 0;
     position: fixed;
   }
+
+  @include media(mobile) {
+    position: static;
+  }
 }

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -64,24 +64,5 @@ describe('A sticky-element-container module', function () {
         expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(true);
       });
     });
-
-    describe('on mobile', function () {
-      beforeEach(function () {
-        instance._getWindowDimensions = function () {
-          return {
-            height: 960,
-            width: 640
-          };
-        };
-      });
-
-      it('shows the element, unstuck', function () {
-        instance.start($element);
-
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
-      });
-    });
   });
 });


### PR DESCRIPTION
Since breakpoints in the grid are determined in CSS having
the logic that forces an element to be unstuck will mean
it can track the same variable that the grid system is using.