### PR TITLE
Fix search box breaking when increasing font size

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -63,7 +63,7 @@
     }
     label {
       float: left;
-      height: 35px;
+      min-height: 36px;
       line-height: 35px;
       text-indent: 15px;
       overflow: hidden;
@@ -88,10 +88,13 @@
       display: block;
       margin: 0;
       border: 0;
-      height: 35px;
+      min-height: 36px;
       padding: 6px 0;
-      @include ie-lte(7){
-        height: 23px;
+      @include ie-lte(8) {
+        min-height: 24px;
+      }
+      @include ie-lte(6) {
+        height: 24px;
       }
       @include appearance(none);
     }
@@ -122,8 +125,8 @@
       z-index: 4;
       right: 0;
       top: 0;
-      width: 35px;
-      height: 35px;
+      width: 36px;
+      height: 36px;
 
       border: 1px solid $mainstream-brand;
       border-width: 0 0 0 1px;


### PR DESCRIPTION
Bug report: #808

This fixes the search box breaking when someone increases the font size. When something has a height (especially of px) it doesn't grow with the text (not when zooming but increasing just the font size).

Removing the height completely would be the ideal solution but that caused issues in IE9, IE10 and WindowsPhone due to the alignment with the submit button.
The `height` got substituted with `line-height` but that alone caused issues in Safari in many iOS versions and Chrome on some Android phones, the text box somehow had a height of 36px and not 35px which caused a white line to appear below the submit button.
That's why the height of all the things got increased to 36px which fixed it. (Although it is not clear what caused it.)