### PR TITLE
Fix transaction bug introduced in 8f1f835

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -106,15 +106,15 @@
     },
 
     userCompletedTransaction: function() {
-      var currentURL = window.location.pathname;
+      var path = userSurveys.currentPath();
 
       function stringContains(str, substr) {
         return str.indexOf(substr) > -1;
       }
 
-      if (stringContains(currentURL, "/done") &&
-          stringContains(currentURL, "/transaction-finished") &&
-          stringContains(currentURL, "/driving-transaction-finished")) {
+      if (stringContains(path, "/done") ||
+          stringContains(path, "/transaction-finished") ||
+          stringContains(path, "/driving-transaction-finished")) {
             return true;
       }
     },
@@ -147,7 +147,8 @@
       return "govuk_" + cookieStub;
     },
 
-    currentTime: function() { return new Date().getTime(); }
+    currentTime: function() { return new Date().getTime(); },
+    currentPath: function() { return window.location.pathname; }
   };
 
   root.GOVUK.userSurveys = userSurveys;

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -99,6 +99,28 @@ describe("Surveys", function() {
     });
   });
 
+  describe("userCompletedTransaction", function() {
+    it("normally returns false", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/');
+      expect(surveys.userCompletedTransaction()).toBeFalsy();
+    });
+
+    it("returns true when /done", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/done');
+      expect(surveys.userCompletedTransaction()).toBeTruthy();
+    });
+
+    it("returns true when /transaction-finished", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/transaction-finished');
+      expect(surveys.userCompletedTransaction()).toBeTruthy();
+    });
+
+    it("returns true when /driving-transaction-finished", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/driving-transaction-finished');
+      expect(surveys.userCompletedTransaction()).toBeTruthy();
+    });
+  });
+
   describe("Event handlers", function () {
       beforeEach(function() {
         surveys.displaySurvey(defaultSurvey);


### PR DESCRIPTION
In 8f1f835 when attempting to refactor the transaction detection logic, I inverted the match (returning true if inside a transaction URL, not false if *not* inside a transaction URL) but forgot to invert the if statement to "OR" from "AND".

This commit fixes that, and adds some tests to ensure the mistake can't happen again.

Credit to @knewter who spotted this when I showed him my GOV.UK PR :(.

👍 for coding in the open, though!