### PR TITLE
Add translations for all govuk components

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -24,14 +24,15 @@ class RootController < ApplicationController
   end
 
   def govuk_available_locales
-    locale_files = Rails.root.join('app', 'views', 'locales', '*.yml')
+    locale_files = Rails.root.join("config", "locales", "*.yml")
     locales = Dir[locale_files].map { |file| File.basename(file, '.yml') }
     render :json => locales
   end
 
   def govuk_locales
     return error_404 unless params[:locale].match(/^[a-z]{2}(-[a-z0-9]{2,3})?$/)
-    render_yaml_as_json("locales", "#{params[:locale]}.yml")
+    locale_file_path = Rails.root.join("config", "locales", "#{params[:locale]}.yml")
+    render_yaml_as_json(locale_file_path)
   end
 
   NON_LAYOUT_TEMPLATES = %w(
@@ -50,8 +51,7 @@ class RootController < ApplicationController
 
   private
 
-  def render_yaml_as_json(folder, file)
-    file_path = Rails.root.join('app', 'views', folder, file)
+  def render_yaml_as_json(file_path)
     error_404 and return unless File.exists?(file_path)
     render :json => YAML::load_file(file_path)
   end

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -17,18 +17,18 @@
 %>
 <div class="govuk-document-footer<%= direction_class %>">
   <h2 class="visuallyhidden">
-    <%= translate("govuk_component.document_footer.document_information", default: "Document information") %>
+    <%= t("govuk_component.document_footer.document_information", default: "Document information") %>
   </h2>
   <div class="history-information" id="history">
     <% if local_assigns.include?(:published) && published %>
       <p>
-        <%= translate("govuk_component.document_footer.published", default: "Published") %>
+        <%= t("govuk_component.document_footer.published", default: "Published") %>
         <span class="published definition"><%= published %></span>
       </p>
     <% end %>
     <% if local_assigns.include?(:updated) && updated %>
       <p>
-        <%= translate("govuk_component.document_footer.updated", default: "Updated") %>
+        <%= t("govuk_component.document_footer.updated", default: "Updated") %>
         <span class="updated definition"><%= updated %></span>
       </p>
     <% end %>
@@ -41,7 +41,7 @@
       <div class="change-notes" data-module="toggle">
         <p>
           <a href="#full-history" data-controls="full-history" data-expanded="false">
-            + <%= translate("govuk_component.document_footer.full_page_history", default: "full page history") %>
+            + <%= t("govuk_component.document_footer.full_page_history", default: "full page history") %>
           </a>
         </p>
         <div class="js-hidden" id="full-history"><span class="arrow"></span>
@@ -69,7 +69,7 @@
     <% end %>
     <% if part_of.any? %>
       <p>
-        <%= translate("govuk_component.document_footer.part_of", default: "Part of") %>:
+        <%= t("govuk_component.document_footer.part_of", default: "Part of") %>:
         <span class="part-of">
         <% part_of.each do |definition| %>
         <span class="definition">

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -16,13 +16,21 @@
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
 <div class="govuk-document-footer<%= direction_class %>">
-  <h2 class="visuallyhidden">Document information</h2>
+  <h2 class="visuallyhidden">
+    <%= translate("govuk_component.document_footer.document_information", default: "Document information") %>
+  </h2>
   <div class="history-information" id="history">
     <% if local_assigns.include?(:published) && published %>
-      <p>Published: <span class="published definition"><%= published %></span></p>
+      <p>
+        <%= translate("govuk_component.document_footer.published", default: "Published") %>
+        <span class="published definition"><%= published %></span>
+      </p>
     <% end %>
     <% if local_assigns.include?(:updated) && updated %>
-      <p>Updated: <span class="updated definition"><%= updated %></span></p>
+      <p>
+        <%= translate("govuk_component.document_footer.updated", default: "Updated") %>
+        <span class="updated definition"><%= updated %></span>
+      </p>
     <% end %>
     <% if other_dates.present? %>
       <% other_dates.each do |title, date| %>
@@ -32,7 +40,9 @@
     <% if history.any? %>
       <div class="change-notes" data-module="toggle">
         <p>
-          <a href="#full-history" data-controls="full-history" data-expanded="false">+ full page history</a>
+          <a href="#full-history" data-controls="full-history" data-expanded="false">
+            + <%= translate("govuk_component.document_footer.full_page_history", default: "full page history") %>
+          </a>
         </p>
         <div class="js-hidden" id="full-history"><span class="arrow"></span>
           <ol>
@@ -58,7 +68,9 @@
       </p>
     <% end %>
     <% if part_of.any? %>
-      <p>Part of: <span class="part-of">
+      <p>
+        <%= translate("govuk_component.document_footer.part_of", default: "Part of") %>:
+        <span class="part-of">
         <% part_of.each do |definition| %>
         <span class="definition">
           <%= definition.html_safe %>

--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -22,13 +22,13 @@
   <div class="history-information" id="history">
     <% if local_assigns.include?(:published) && published %>
       <p>
-        <%= t("govuk_component.document_footer.published", default: "Published") %>
+        <%= t("govuk_component.document_footer.published", default: "Published") %>:
         <span class="published definition"><%= published %></span>
       </p>
     <% end %>
     <% if local_assigns.include?(:updated) && updated %>
       <p>
-        <%= t("govuk_component.document_footer.updated", default: "Updated") %>
+        <%= t("govuk_component.document_footer.updated", default: "Updated") %>:
         <span class="updated definition"><%= updated %></span>
       </p>
     <% end %>

--- a/app/views/govuk_component/government_navigation.raw.html.erb
+++ b/app/views/govuk_component/government_navigation.raw.html.erb
@@ -6,47 +6,47 @@
   <ul id="proposition-links">
     <li>
       <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">
-        <%= translate("govuk_component.government_navigation.departments", default: "Departments") %>
+        <%= t("govuk_component.government_navigation.departments", default: "Departments") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">
-        <%= translate("govuk_component.government_navigation.worldwide", default: "Worldwide") %>
+        <%= t("govuk_component.government_navigation.worldwide", default: "Worldwide") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">
-        <%= translate("govuk_component.government_navigation.how-government-works", default: "How government works") %>
+        <%= t("govuk_component.government_navigation.how-government-works", default: "How government works") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">
-        <%= translate("govuk_component.government_navigation.get-involved", default: "Get involved") %>
+        <%= t("govuk_component.government_navigation.get-involved", default: "Get involved") %>
       </a>
     </li>
     <li class="clear-child">
       <a class="<%= 'active' if active == 'policies' %>" href="/government/policies">
-        <%= translate("govuk_component.government_navigation.policies", default: "Policies") %>
+        <%= t("govuk_component.government_navigation.policies", default: "Policies") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'publications' %>" href="/government/publications">
-        <%= translate("govuk_component.government_navigation.publications", default: "Publications") %>
+        <%= t("govuk_component.government_navigation.publications", default: "Publications") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'consultations' %>" href="/government/publications?publication_filter_option=consultations">
-        <%= translate("govuk_component.government_navigation.consultations", default: "Consultations") %>
+        <%= t("govuk_component.government_navigation.consultations", default: "Consultations") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'statistics' %>" href="/government/statistics">
-        <%= translate("govuk_component.government_navigation.statistics", default: "Statistics") %>
+        <%= t("govuk_component.government_navigation.statistics", default: "Statistics") %>
       </a>
     </li>
     <li>
       <a class="<%= 'active' if active == 'announcements' %>" href="/government/announcements">
-        <%= translate("govuk_component.government_navigation.announcements", default: "Announcements") %>
+        <%= t("govuk_component.government_navigation.announcements", default: "Announcements") %>
       </a>
     </li>
   </ul>

--- a/app/views/govuk_component/government_navigation.raw.html.erb
+++ b/app/views/govuk_component/government_navigation.raw.html.erb
@@ -4,14 +4,50 @@
 
 <nav id="proposition-menu" class="no-proposition-name">
   <ul id="proposition-links">
-    <li><a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">Departments</a></li>
-    <li><a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">Worldwide</a></li>
-    <li><a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">How government works</a></li>
-    <li><a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">Get involved</a></li>
-    <li class="clear-child"><a class="<%= 'active' if active == 'policies' %>" href="/government/policies">Policies</a></li>
-    <li><a class="<%= 'active' if active == 'publications' %>" href="/government/publications">Publications</a></li>
-    <li><a class="<%= 'active' if active == 'consultations' %>" href="/government/publications?publication_filter_option=consultations">Consultations</a></li>
-    <li><a class="<%= 'active' if active == 'statistics' %>" href="/government/statistics">Statistics</a></li>
-    <li><a class="<%= 'active' if active == 'announcements' %>" href="/government/announcements">Announcements</a></li>
+    <li>
+      <a class="<%= 'active' if active == 'departments' %>" href="/government/organisations">
+        <%= translate("govuk_component.government_navigation.departments", default: "Departments") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'worldwide' %>" href="/government/world">
+        <%= translate("govuk_component.government_navigation.worldwide", default: "Worldwide") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'how-government-works' %>" href="/government/how-government-works">
+        <%= translate("govuk_component.government_navigation.how-government-works", default: "How government works") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'get-involved' %>" href="/government/get-involved">
+        <%= translate("govuk_component.government_navigation.get-involved", default: "Get involved") %>
+      </a>
+    </li>
+    <li class="clear-child">
+      <a class="<%= 'active' if active == 'policies' %>" href="/government/policies">
+        <%= translate("govuk_component.government_navigation.policies", default: "Policies") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'publications' %>" href="/government/publications">
+        <%= translate("govuk_component.government_navigation.publications", default: "Publications") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'consultations' %>" href="/government/publications?publication_filter_option=consultations">
+        <%= translate("govuk_component.government_navigation.consultations", default: "Consultations") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'statistics' %>" href="/government/statistics">
+        <%= translate("govuk_component.government_navigation.statistics", default: "Statistics") %>
+      </a>
+    </li>
+    <li>
+      <a class="<%= 'active' if active == 'announcements' %>" href="/government/announcements">
+        <%= translate("govuk_component.government_navigation.announcements", default: "Announcements") %>
+      </a>
+    </li>
   </ul>
 </nav>

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -13,27 +13,27 @@
 <div class="govuk-metadata<%= direction_class %>">
   <dl>
     <% if from.any? %>
-      <dt><%= translate("govuk_component.metadata.from", default: "From") %>:</dt>
+      <dt><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
       <dd><%= from.to_sentence.html_safe %></dd>
     <% end %>
     <% if part_of.any? %>
-      <dt><%= translate("govuk_component.metadata.part_of", default: "Part of") %>:</dt>
+      <dt><%= t("govuk_component.metadata.part_of", default: "Part of") %>:</dt>
       <dd><%= part_of.to_sentence.html_safe %></dd>
     <% end %>
     <% if local_assigns.include?(:history) %>
-      <dt><%= translate("govuk_component.metadata.history", default: "History") %>:</dt>
+      <dt><%= t("govuk_component.metadata.history", default: "History") %>:</dt>
       <dd><%= history %></dd>
     <% end %>
     <% if local_assigns.include?(:first_published) && first_published %>
-      <dt><%= translate("govuk_component.metadata.first_published", default: "First published") %>:</dt>
+      <dt><%= t("govuk_component.metadata.first_published", default: "First published") %>:</dt>
       <dd><%= first_published %></dd>
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt><%= translate("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
+      <dt><%= t("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
       <dd>
         <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>,
           <a href="#history">
-            <%= translate("govuk_component.metadata.see_all_updates", default: "see all updates") %>
+            <%= t("govuk_component.metadata.see_all_updates", default: "see all updates") %>
           </a>
         <% end %>
       </dd>

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -13,25 +13,29 @@
 <div class="govuk-metadata<%= direction_class %>">
   <dl>
     <% if from.any? %>
-      <dt><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
+      <dt><%= translate("govuk_component.metadata.from", default: "From") %>:</dt>
       <dd><%= from.to_sentence.html_safe %></dd>
     <% end %>
     <% if part_of.any? %>
-      <dt>Part of:</dt>
+      <dt><%= translate("govuk_component.metadata.part_of", default: "Part of") %>:</dt>
       <dd><%= part_of.to_sentence.html_safe %></dd>
     <% end %>
     <% if local_assigns.include?(:history) %>
-      <dt>History:</dt>
+      <dt><%= translate("govuk_component.metadata.history", default: "History") %>:</dt>
       <dd><%= history %></dd>
     <% end %>
     <% if local_assigns.include?(:first_published) && first_published %>
-      <dt>First published:</dt>
+      <dt><%= translate("govuk_component.metadata.first_published", default: "First published") %>:</dt>
       <dd><%= first_published %></dd>
     <% end %>
     <% if local_assigns.include?(:last_updated) && last_updated %>
-      <dt>Last updated:</dt>
+      <dt><%= translate("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
       <dd>
-        <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>, <a href="#history">see all updates</a><% end %>
+        <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>,
+          <a href="#history">
+            <%= translate("govuk_component.metadata.see_all_updates", default: "see all updates") %>
+          </a>
+        <% end %>
       </dd>
     <% end %>
     <% if other.present? %>

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -1,5 +1,9 @@
 <% if local_assigns.include?(:next_page) || local_assigns.include?(:previous_page) %>
-<nav class="govuk-previous-and-next-navigation" role="navigation" aria-label="Pagination">
+<nav
+  class="govuk-previous-and-next-navigation"
+  role="navigation"
+  aria-label="<%= translate("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
+>
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>
       <li class="previous-page">

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -2,7 +2,7 @@
 <nav
   class="govuk-previous-and-next-navigation"
   role="navigation"
-  aria-label="<%= translate("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
+  aria-label="<%= t("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
 >
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -23,7 +23,8 @@
         <% if section[:url] %>
           <li class="related-items-more">
             <a href="<%= section[:url] %>">
-              More<% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
+              <%= translate("govuk_component.related_items.more", default: "More") %>
+              <% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
             </a>
           </li>
         <% end %>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -23,7 +23,7 @@
         <% if section[:url] %>
           <li class="related-items-more">
             <a href="<%= section[:url] %>">
-              <%= translate("govuk_component.related_items.more", default: "More") %>
+              <%= t("govuk_component.related_items.more", default: "More") %>
               <% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
             </a>
           </li>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -24,7 +24,12 @@
           <li class="related-items-more">
             <a href="<%= section[:url] %>">
               <%= t("govuk_component.related_items.more", default: "More") %>
-              <% if section[:title] %> <span class="visuallyhidden">in <%= section[:title] %></span><% end %>
+              <% if section[:title] %>
+                <span class="visuallyhidden">
+                  <%= t("govuk_component.related_items.in", default: "in") %>
+                  <%= section[:title] %>
+                </span>
+              <% end %>
             </a>
           </li>
         <% end %>

--- a/app/views/locales/en.yml
+++ b/app/views/locales/en.yml
@@ -1,4 +1,0 @@
-en:
-  govuk_component:
-    metadata:
-      from: "From"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,4 @@ en:
       pagination: "Pagination"
     related_items:
       more: "More"
+      in: "in"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,5 +1,31 @@
-# Sample localization file for English. Add more files in this directory for other locales.
-# See https://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+# Passed to the Frontend app via slimmer, not used by static directly.
 
 en:
-  hello: "Hello world"
+  govuk_component:
+    document_footer:
+      document_information: "Document information"
+      published: "Published"
+      updated: "Updated"
+      full_page_history: "full page history"
+      part_of: "Part of"
+    government_navigation:
+      departments: "Departments"
+      worldwide: "Worldwide"
+      how-government-works: "How government works"
+      get-involved: "Get involved"
+      policies: "Policies"
+      publications: "Publications"
+      consultations: "Consultations"
+      statistics: "Statistics"
+      announcements: "Announcements"
+    metadata:
+      from: "From"
+      part_of: "Part of"
+      history: "History"
+      first_published: "First published"
+      last_updated: "Last updated"
+      see_all_updates: "see all updates"
+    previous_and_next_navigation:
+      pagination: "Pagination"
+    related_items:
+      more: "More"

--- a/test/govuk_component/document_footer_test.rb
+++ b/test/govuk_component/document_footer_test.rb
@@ -63,8 +63,8 @@ class DocumentFooterTestCase < ComponentTestCase
       }
     })
 
-    assert_select 'p', text: 'Published: 20 January 2092'
-    assert_select 'p', text: 'Updated: 22 January 2092'
+    assert_select 'p', text: /Published:\s+20 January 2092/
+    assert_select 'p', text: /Updated:\s+22 January 2092/
     assert_select 'p', text: 'Date opened: 1 February 2092'
     assert_select 'p', text: 'Date closed: 1 March 2093'
   end

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -33,7 +33,7 @@ class RelatedItemsTestCase < ComponentTestCase
     })
 
     assert_select "h2", text: "Section title"
-    assert_link_with_text_in("ul li:last-child", "/more-link", "More in Section title")
+    assert_link_with_text_in("ul li:last-child", "/more-link", /More\s+in\s+Section title/)
     assert_link_with_text_in("ul li:first-child", "/item", "Item title")
     assert_link_with_text_in("ul li:first-child + li", "/other-item", "Other item title")
   end
@@ -65,11 +65,11 @@ class RelatedItemsTestCase < ComponentTestCase
     })
 
     assert_select "h2", text: "Section title"
-    assert_link_with_text_in("ul li:last-child", "/more-link", "More in Section title")
+    assert_link_with_text_in("ul li:last-child", "/more-link", /More\s+in\s+Section title/)
     assert_link_with_text_in("ul li:first-child", "/item", "Item title")
 
     assert_select "h2", text: "Other section title"
-    assert_link_with_text_in("ul li:last-child", "/other-more-link", "More in Other section title")
+    assert_link_with_text_in("ul li:last-child", "/other-more-link", /More\s+in\s+Other section title/)
     assert_link_with_text_in("ul li:first-child", "/other-item", "Other item title")
   end
 


### PR DESCRIPTION
Continues the work done in https://github.com/alphagov/static/pull/505

Moves the language translation config files back into the conventional place rather than in the view directory.

