### PR TITLE
Add missing govspeak example callout styles

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -530,4 +530,14 @@
       margin-right: (($thumbnail-width * -1) - $gutter-half);
     }
   }
+
+  .example {
+    border-left: 10px solid $panel-colour;
+    padding-left: 1.5em;
+    margin: 2.5em 0;
+
+    strong {
+      display: block;
+    }
+  }
 }

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -507,3 +507,11 @@ fixtures:
           </div>
         </div>
       </section>
+  example:
+    content: |
+      <div class="example">
+        <p>
+          This is an indented example block.<br/>
+          It may span multiple lines, <a href="#">contain links</a>.
+        </p>
+      </div>


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1386394

The example callout styles are missing from the govspeak component and giving a different rendering when comparing private-frontend to public frontends.

![screenshot from 2016-08-01 17 22 35](https://cloud.githubusercontent.com/assets/93511/17300955/98c8dfc2-580c-11e6-822a-31fda0f33795.png)
