### PR TITLE
Migrate link href printing from template

### DIFF
--- a/app/assets/stylesheets/helpers/_print-base.scss
+++ b/app/assets/stylesheets/helpers/_print-base.scss
@@ -4,6 +4,11 @@ a {
   text-decoration: none;
 }
 
+// Override relative link printing to include gov.uk
+a[href^="/"]:after {
+  content: " (https://www.gov.uk" attr(href) ")";
+}
+
 h1,
 h2,
 h3,


### PR DESCRIPTION
[govuk_template](https://github.com/alphagov/govuk_template) prints relative links with [a forced gov.uk prefix](https://github.com/alphagov/govuk_template/blob/master/source/assets/stylesheets/_core-print.scss#L24). This works for gov.uk but not for other services that consume the template. First step to fix this is to insert the prefix as part of static. After this is live we can remove the prefix override from the template (i.e. change the link href printing selector to `a[href^="/"]:after, a[href^="http://"]:after, a[href^="https://"]:after`).