### PR TITLE
Contract "we are" to "we're" on error page

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -1,4 +1,4 @@
-<% title = "Sorry, we are experiencing technical difficulties (#{status_code} error)" unless local_assigns.include?(:title) %>
+<% title = "Sorry, we're experiencing technical difficulties (#{status_code} error)" unless local_assigns.include?(:title) %>
 <% content_for :title, "#{title} - GOV.UK" %>
 
 <% content_for :body_classes, "mainstream error" %>
@@ -11,7 +11,7 @@
       <% if local_assigns.include?(:heading) %>
         <h1><%= heading %></h1>
       <% else %>
-        <h1>Sorry, we are experiencing technical difficulties</h1>
+        <h1>Sorry, we're experiencing technical difficulties</h1>
       <% end %>
     </div>
   </header>

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -7,7 +7,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
 
     assert page.has_selector?("body.mainstream.error")
     within "head", :visible => :all do
-      assert page.has_selector?("title", :text => "Sorry, we are experiencing technical difficulties (500 error) - GOV.UK", :visible => :all)
+      assert page.has_selector?("title", text: "Sorry, we're experiencing technical difficulties (500 error) - GOV.UK", visible: :all)
 
       assert page.has_selector?("link[href='/static/static.css']", :visible => :all)
     end
@@ -22,7 +22,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
       assert page.has_selector?("#global-breadcrumb")
 
       within "#wrapper" do
-        assert page.has_selector?("h1", :text => "Sorry, we are experiencing technical difficulties")
+        assert page.has_selector?("h1", text: "Sorry, we're experiencing technical difficulties")
       end
 
       within "footer" do


### PR DESCRIPTION
This is GOV.UK style. Suggested by Tom Hughes.