### PR TITLE
Remove webchat banner on VAT Enquiries page

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -20,7 +20,6 @@
         '/government/organisations/hm-revenue-customs/contact/self-assessment',
         '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
         '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
-        '/government/organisations/hm-revenue-customs/contact/vat-enquiries',
         '/lost-national-insurance-number',
         '/manage-your-tax-credits',
         '/renewing-your-tax-credits-claim',


### PR DESCRIPTION
This page will be getting the new style of HMRC webchat content. So the banners are no longer required.

Related to a PR on `contacts-frontend` to enable the new webchat there. Must be deployed before, or alongside that change.