### PR TITLE
Remove webchat banner on Tax Credits page

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -19,7 +19,6 @@
         '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
         '/government/organisations/hm-revenue-customs/contact/self-assessment',
         '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
-        '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
         '/lost-national-insurance-number',
         '/manage-your-tax-credits',
         '/renewing-your-tax-credits-claim',


### PR DESCRIPTION
This page will be getting the new style of HMRC webchat content. So the banners are no longer required.

It should be merged and deployed alongside https://github.com/alphagov/contacts-frontend/pull/53