### PR TITLE
Remove webchat banner on SA enquiries page

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -17,7 +17,6 @@
         '/childcare-costs-for-tax-credits/y/yes/yes/weekly_diff_amount',
         '/childcare-costs-for-tax-credits/y/no/regularly_less_than_year/monthly_diff_amount',
         '/government/organisations/hm-revenue-customs/contact/national-insurance-numbers',
-        '/government/organisations/hm-revenue-customs/contact/self-assessment',
         '/government/organisations/hm-revenue-customs/contact/self-assessment-online-services-helpdesk',
         '/government/organisations/hm-revenue-customs/contact/tax-credits-enquiries',
         '/lost-national-insurance-number',


### PR DESCRIPTION
This page will be getting the new style of HMRC webchat. So the banners are no longer required.

This should be merged and deployed alongside https://github.com/alphagov/contacts-frontend/pull/54