### PR TITLE
Feedback form event tracking

### DIFF
--- a/app/assets/javascripts/report-a-problem-form.js
+++ b/app/assets/javascripts/report-a-problem-form.js
@@ -8,7 +8,7 @@
     $form.on('submit', this.submit.bind(this));
 
     this.appendHiddenContextInformation();
-  }
+  };
 
   ReportAProblemForm.prototype.appendHiddenContextInformation = function() {
     // form submission for reporting a problem
@@ -46,7 +46,7 @@
 
   ReportAProblemForm.prototype.setUrl = function() {
     this.$form.find('input#url').val(window.location);
-  }
+  };
 
   ReportAProblemForm.prototype.postFormViaAjax = function() {
     $.ajax({

--- a/app/assets/javascripts/report-a-problem-form.js
+++ b/app/assets/javascripts/report-a-problem-form.js
@@ -65,6 +65,7 @@
   ReportAProblemForm.prototype.submit = function(evt) {
     this.hidePrompt();
     this.setUrl();
+    this.trackEvent('GOVUK Send Feedback');
     this.disableSubmitButton();
     this.postFormViaAjax();
 
@@ -77,6 +78,12 @@
 
   ReportAProblemForm.prototype.triggerSuccess = function(data) {
     this.$form.trigger('reportAProblemForm.success', data);
+  };
+
+  ReportAProblemForm.prototype.trackEvent = function(action){
+    if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+      GOVUK.analytics.trackEvent('Onsite Feedback', action, { label: '(not set)' });
+    }
   };
 
   GOVUK.ReportAProblemForm = ReportAProblemForm;

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -4,8 +4,8 @@
 
   var ReportAProblem = function ($container) {
     this.$container = $container;
-    var $form = $container.find('form'),
-        form = new GOVUK.ReportAProblemForm($form);
+    var $form = $container.find('form');
+    new GOVUK.ReportAProblemForm($form);
 
     $form.on("reportAProblemForm.success", this.showConfirmation.bind(this));
     $form.on("reportAProblemForm.error", this.showError.bind(this));
@@ -15,12 +15,11 @@
   };
 
   ReportAProblem.prototype.addToggleLink = function() {
-    this.$container.before('\
-      <div class="report-a-problem-toggle-wrapper js-footer">\
-        <p class="report-a-problem-toggle">\
-          <a href="" class="js-report-a-problem-toggle">Is there anything wrong with this page?</a>\
-        </p>\
-      </div>');
+    this.$container.before('<div class="report-a-problem-toggle-wrapper js-footer">' +
+        '<p class="report-a-problem-toggle">' +
+          '<a href="" class="js-report-a-problem-toggle">Is there anything wrong with this page?</a>' +
+        '</p>' +
+      '</div>');
   };
 
   ReportAProblem.prototype.toggleForm = function(evt) {
@@ -39,16 +38,15 @@
 
   ReportAProblem.prototype.showConfirmation = function(evt, data) {
     this.$container.find('.report-a-problem-content').html(data.message);
-  }
+  };
 
   ReportAProblem.prototype.showError = function() {
-    var response = "\
-      <h2>Sorry, we’re unable to receive your message right now.</h2>\
-      <p>We have other ways for you to provide feedback on the \
-      <a href='/contact'>contact page</a>.</p>";
+    var response = '<h2>Sorry, we’re unable to receive your message right now.</h2>' +
+      '<p>We have other ways for you to provide feedback on the ' +
+      '<a href="/contact">contact page</a>.</p>';
 
     this.$container.find('.report-a-problem-content').html(response);
-  }
+  };
 
   ReportAProblem.prototype.trackEvent = function(action){
     if (GOVUK.analytics && GOVUK.analytics.trackEvent) {

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -26,6 +26,12 @@
   ReportAProblem.prototype.toggleForm = function(evt) {
     this.$container.toggle();
 
+    if (this.$container.is(':visible')) {
+      this.trackEvent('GOVUK Open Form');
+    } else {
+      this.trackEvent('GOVUK Close Form');
+    }
+
     if ($(evt.target).is('a')) {
       evt.preventDefault();
     }
@@ -43,6 +49,12 @@
 
     this.$container.find('.report-a-problem-content').html(response);
   }
+
+  ReportAProblem.prototype.trackEvent = function(action){
+    if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+      GOVUK.analytics.trackEvent('Onsite Feedback', action, { label: '(not set)'} );
+    }
+  };
 
   GOVUK.ReportAProblem = ReportAProblem;
 

--- a/spec/javascripts/report-a-problem-form-spec.js
+++ b/spec/javascripts/report-a-problem-form-spec.js
@@ -33,9 +33,17 @@ describe("form submission for reporting a problem", function () {
       $form.triggerHandler('submit');
 
       expect($.ajax).toHaveBeenCalled();
-
       args = $.ajax.calls.mostRecent().args;
       expect(args[0].url).toBe('ajax-endpoint');
+    });
+
+    it("should track the event", function() {
+      spyOn(GOVUK.analytics, "trackEvent");
+      $form.triggerHandler('submit');
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Onsite Feedback', 'GOVUK Send Feedback', jasmine.any(Object)
+      );
     });
   });
 

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -15,10 +15,26 @@ describe("form submission for reporting a problem", function () {
   describe("clicking on the toggle", function(){
     it("should toggle the visibility of the form", function() {
       expect($form).toBeVisible();
+
       $('.js-report-a-problem-toggle').click();
       expect($form).toBeHidden();
+
       $('.js-report-a-problem-toggle').click();
       expect($form).toBeVisible();
+    });
+
+    it("should track the event depending on the toggle state", function() {
+      spyOn(GOVUK.analytics, "trackEvent");
+
+      $('.js-report-a-problem-toggle').click();
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Onsite Feedback', 'GOVUK Close Form', jasmine.any(Object)
+      );
+
+      $('.js-report-a-problem-toggle').click();
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Onsite Feedback', 'GOVUK Open Form', jasmine.any(Object)
+      );
     });
   });
 


### PR DESCRIPTION
[Trello card](https://trello.com/c/mGyllSZu)

To make it easier to gather statistics on which areas get the most feedback, we'd like to track the feedback intent of users by tracking the revealing of the form and its submit (not success or failure).
While I was working on those file I also fixed some linting issues (but two are still in there).
