### PR TITLE
Add locales for components

### DIFF
--- a/config/locales/ar.yml
+++ b/config/locales/ar.yml
@@ -1,0 +1,18 @@
+---
+ar:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "ينطبق على"
+      field_of_operation: "مجال العمل"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/az.yml
+++ b/config/locales/az.yml
@@ -1,0 +1,18 @@
+---
+az:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: tətbiq olunur
+      field_of_operation: "əməliyyat sahəsi"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/be.yml
+++ b/config/locales/be.yml
@@ -1,0 +1,18 @@
+---
+be:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "У адносінах да"
+      field_of_operation: "Сфера дзейнасці"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -1,0 +1,18 @@
+---
+bg:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Отнася се към"
+      field_of_operation: "Поле на операцията"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/bn.yml
+++ b/config/locales/bn.yml
@@ -1,0 +1,18 @@
+---
+bn:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -1,0 +1,18 @@
+---
+cs:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Týká se
+      field_of_operation: Oblast působnosti
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/cy.yml
+++ b/config/locales/cy.yml
@@ -1,0 +1,18 @@
+---
+cy:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: Hanes
+      part_of: Rhan o
+    metadata:
+      from: O
+      part_of: Rhan o
+      location: 
+      applies_to_nations: Yn berthnasol i
+      field_of_operation: Maes gweithredu
+      history: Hanes
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,18 @@
+---
+de:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Gilt für
+      field_of_operation: Einsatzbereich
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/dr.yml
+++ b/config/locales/dr.yml
@@ -1,0 +1,18 @@
+---
+dr:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "اطلاق میشود به"
+      field_of_operation: "بخش عملیاتی"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/el.yml
+++ b/config/locales/el.yml
@@ -1,0 +1,18 @@
+---
+el:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Ισχύει"
+      field_of_operation: "Πεδίο δράσης"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/es-419.yml
+++ b/config/locales/es-419.yml
@@ -1,0 +1,18 @@
+---
+es-419:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Se aplica a
+      field_of_operation: Terreno de operaciones
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -1,0 +1,18 @@
+---
+es:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Sirve para
+      field_of_operation: "Ãmbito de actuación"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/et.yml
+++ b/config/locales/et.yml
@@ -1,0 +1,18 @@
+---
+et:
+  govuk_component:
+    document_footer:
+      published: Avaldatud
+      updated: Täiendatud
+      full_page_history: Tervikajalugu
+      part_of: Osa
+    metadata:
+      from: Kellelt
+      part_of: Osa
+      location: Asukoht
+      applies_to_nations: Seondub
+      field_of_operation: Tegevusvaldkond
+      history: Ajalugu
+      first_published: Esmane publikatsioon
+      last_updated: Esmane publikatsioon
+      see_all_updates: Vaadake kõiki täiendusi

--- a/config/locales/fa.yml
+++ b/config/locales/fa.yml
@@ -1,0 +1,18 @@
+---
+fa:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "در ارتباط با"
+      field_of_operation: "میدان عمل"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -1,0 +1,18 @@
+---
+fr:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: s'appliquant à
+      field_of_operation: Domaine d'activité
+      history: Historique de page
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/he.yml
+++ b/config/locales/he.yml
@@ -1,0 +1,18 @@
+---
+he:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "מתייחס ל"
+      field_of_operation: "שדה פעולה"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/hi.yml
+++ b/config/locales/hi.yml
@@ -1,0 +1,18 @@
+---
+hi:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "पर लागू"
+      field_of_operation: "प्रचालन क्षेत्र"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/hu.yml
+++ b/config/locales/hu.yml
@@ -1,0 +1,18 @@
+---
+hu:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 'A következő nemzetekre vonatkozik:'
+      field_of_operation: Működési terület
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/hy.yml
+++ b/config/locales/hy.yml
@@ -1,0 +1,18 @@
+---
+hy:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Վերաբերվում է"
+      field_of_operation: "Գործունեության ոլորտ"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/id.yml
+++ b/config/locales/id.yml
@@ -1,0 +1,18 @@
+---
+id:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Diterapkan pada
+      field_of_operation: Area operasi
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,18 @@
+---
+it:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Valido per
+      field_of_operation: Settore di lavoro
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,18 @@
+---
+ja:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "対象国"
+      field_of_operation: "担当分野"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ka.yml
+++ b/config/locales/ka.yml
@@ -1,0 +1,18 @@
+---
+ka:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ko.yml
+++ b/config/locales/ko.yml
@@ -1,0 +1,18 @@
+---
+ko:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "적용"
+      field_of_operation: "오퍼레이션 필드"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/lt.yml
+++ b/config/locales/lt.yml
@@ -1,0 +1,18 @@
+---
+lt:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Susiję su
+      field_of_operation: Veiklos laukas
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/lv.yml
+++ b/config/locales/lv.yml
@@ -1,0 +1,18 @@
+---
+lv:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Attiecas uz
+      field_of_operation: Darbības lauks
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ms.yml
+++ b/config/locales/ms.yml
@@ -1,0 +1,18 @@
+---
+ms:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -1,0 +1,18 @@
+---
+pl:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Dotyczy
+      field_of_operation: Obszar działania
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ps.yml
+++ b/config/locales/ps.yml
@@ -1,0 +1,18 @@
+---
+ps:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "پورې اړه لری"
+      field_of_operation: "د کړنو څانګه"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -1,0 +1,18 @@
+---
+pt:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Aplica-se a
+      field_of_operation: Campo de Operação
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ro.yml
+++ b/config/locales/ro.yml
@@ -1,0 +1,18 @@
+---
+ro:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Se adresează
+      field_of_operation: Domeniu de activitate
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -1,0 +1,18 @@
+---
+ru:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Применимо к"
+      field_of_operation: "Сфера деятельности"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/si.yml
+++ b/config/locales/si.yml
@@ -1,0 +1,18 @@
+---
+si:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "අදාළ වන්නේ"
+      field_of_operation: "ක්‍රියාත්මකවන ක්ෂස්ත්‍රය"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/sk.yml
+++ b/config/locales/sk.yml
@@ -1,0 +1,18 @@
+---
+sk:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/so.yml
+++ b/config/locales/so.yml
@@ -1,0 +1,18 @@
+---
+so:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Waxa lagu saleeyaa
+      field_of_operation: Nooca hawlgalka
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/sq.yml
+++ b/config/locales/sq.yml
@@ -1,0 +1,18 @@
+---
+sq:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Zbatohet mbi
+      field_of_operation: Fusha e veprimit
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/sr.yml
+++ b/config/locales/sr.yml
@@ -1,0 +1,18 @@
+---
+sr:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Odnosi se na
+      field_of_operation: polje delovanja
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/sw.yml
+++ b/config/locales/sw.yml
@@ -1,0 +1,18 @@
+---
+sw:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ta.yml
+++ b/config/locales/ta.yml
@@ -1,0 +1,18 @@
+---
+ta:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "பிரயோகமாகிறது"
+      field_of_operation: "செயற்பாட்டுத் துறை"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/th.yml
+++ b/config/locales/th.yml
@@ -1,0 +1,18 @@
+---
+th:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "นำไปใช้กับ"
+      field_of_operation: "ลักษณะงาน"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/tk.yml
+++ b/config/locales/tk.yml
@@ -1,0 +1,18 @@
+---
+tk:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 
+      field_of_operation: 
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/tr.yml
+++ b/config/locales/tr.yml
@@ -1,0 +1,18 @@
+---
+tr:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: Uygulandığı Alanlar
+      field_of_operation: Faaliyet Alanı
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/uk.yml
+++ b/config/locales/uk.yml
@@ -1,0 +1,18 @@
+---
+uk:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Застосовується до"
+      field_of_operation: "Сфера діяльності"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/ur.yml
+++ b/config/locales/ur.yml
@@ -1,0 +1,18 @@
+---
+ur:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "اطلاق ہوتا ہے"
+      field_of_operation: "کارروائی کا میدان"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/uz.yml
+++ b/config/locales/uz.yml
@@ -1,0 +1,18 @@
+---
+uz:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: 'Tegishli '
+      field_of_operation: Faoliyat sohasi
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/vi.yml
+++ b/config/locales/vi.yml
@@ -1,0 +1,18 @@
+---
+vi:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "Áp dụngng cho"
+      field_of_operation: Lĩnh vực hoạt động
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/zh-hk.yml
+++ b/config/locales/zh-hk.yml
@@ -1,0 +1,18 @@
+---
+zh-hk:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "適用於"
+      field_of_operation: "運用領域"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/zh-tw.yml
+++ b/config/locales/zh-tw.yml
@@ -1,0 +1,18 @@
+---
+zh-tw:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "應用"
+      field_of_operation: "運用領域"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,0 +1,18 @@
+---
+zh:
+  govuk_component:
+    document_footer:
+      published: 
+      updated: 
+      full_page_history: 
+      part_of: 
+    metadata:
+      from: 
+      part_of: 
+      location: 
+      applies_to_nations: "适用于"
+      field_of_operation: "操作区域"
+      history: 
+      first_published: 
+      last_updated: 
+      see_all_updates: 

--- a/script/copy_component_translations_from_whitehall
+++ b/script/copy_component_translations_from_whitehall
@@ -1,0 +1,56 @@
+#! /usr/bin/env ruby
+
+require 'yaml'
+
+class Hash
+  def dig_by_path path
+    dig(*path.split("."))
+  end
+
+  def dig(key, *rest)
+    value = self[key]
+    if value.nil? || rest.empty?
+      value
+    elsif value.respond_to?(:dig)
+      value.dig(*rest)
+    else
+      fail TypeError, "#{value.class} does not have #dig method"
+    end
+  end
+end
+
+whitehall_path = ENV["WHITEHALL_PATH"] || File.expand_path("../../whitehall", __dir__)
+whitehall_locales = Dir.glob(File.join(whitehall_path, "config/locales/*.yml"))
+
+whitehall_locales.each do |locale_file|
+  src = YAML.load_file(locale_file)
+  locale = File.basename(locale_file, ".yml")
+  next if locale == "en"
+  new_locale_data = {
+    locale => {
+      "govuk_component" => {
+        "document_footer" => {
+          "published" => src.dig_by_path("#{locale}.document.footer_meta.published"),
+          "updated" => src.dig_by_path("#{locale}.document.footer_meta.updated"),
+          "full_page_history" => src.dig_by_path("#{locale}.document.footer_meta.full_page_history"),
+          "part_of" => src.dig_by_path("#{locale}.document.headings.part_of"),
+        },
+        "metadata" => {
+          "from" => src.dig_by_path("#{locale}.document.headings.from"),
+          "part_of" => src.dig_by_path("#{locale}.document.headings.part_of"),
+          "location" => src.dig_by_path("#{locale}.document.headings.location"),
+          "applies_to_nations" => src.dig_by_path("#{locale}.document.headings.applies_to_nations"),
+          "field_of_operation" => src.dig_by_path("#{locale}.document.headings.field_of_operation"),
+          "history" => src.dig_by_path("#{locale}.change_notes.page_history"),
+          "first_published" => src.dig_by_path("#{locale}.change_notes.published_at"),
+          "last_updated" => src.dig_by_path("#{locale}.change_notes.published_at"),
+          "see_all_updates" => src.dig_by_path("#{locale}.change_notes.see_all_updates"),
+        }
+      }
+    }
+  }
+
+  File.open(File.expand_path("../config/locales/#{locale}.yml", __dir__), "w") do |f|
+    f.write(YAML.dump(new_locale_data))
+  end
+end


### PR DESCRIPTION
Components need translations for some of their labels. For now,
the best source of these is Whitehall. Not all labels are translated
but due to the way i18n works it's ok to leave an empty string for
a translation as it'll fallback to either `en` or the supplied default.

Generated by `script/copy_component_translations_from_whitehall`