### PR TITLE
Use document type for the analytics format

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -7,7 +7,7 @@
   details_hash = content_item_hash[:details] || {}
   meta_tags = {}
 
-  meta_tags["govuk:format"] = content_item_hash[:format] if content_item_hash[:format]
+  meta_tags["govuk:format"] = content_item_hash[:document_type] if content_item_hash[:document_type]
 
   need_ids = content_item_hash[:need_ids] || []
   meta_tags["govuk:need-ids"] = need_ids.join(',') if need_ids.any?

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -24,7 +24,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   end
 
   test "renders format in a meta tag" do
-    render_component(content_item: { format: "case_study" })
+    render_component(content_item: { document_type: "case_study" })
     assert_meta_tag('govuk:format', 'case_study')
   end
 


### PR DESCRIPTION
The `format` field is deprecated from the content-store. It has been split into `document_type` and `schema_name`. For compatibility reasons, `schema_name` is used to populate `format` in existing content items. So in reality, this components sets `govuk:format` to the `schema_name` of the page.

We think that `document_type` is more descriptive to use in analytics. Especially since we are adding this component to applications like frontend, calendars, calculators and smart-answers. Pages published to the content-store by those apps have a schema_name of `placeholder`, but a meaningful document type.

At the moment this component is used by 4 applications. Almost all content items rendered by those apps have an indentical document_type and schema_name, so there would be no effect to what's currently sent to analytics.

government-frontend:
```
irb(main):011:0> ContentItem.where(rendering_app: "government-frontend").pluck(:document_type, :schema_name).uniq
=> [["case_study", "case_study"], ["unpublishing", "unpublishing"], ["coming_soon", "coming_soon"], ["fatality_notice", "fatality_notice"], ["take_part", "take_part"], ["working_group", "working_group"], ["statistics_announcement", "statistics_announcement"], ["official", "statistics_announcement"], ["national", "statistics_announcement"], ["topical_event_about_page", "topical_event_about_page"], ["detailed_guide", "detailed_guide"]]
```

contacts-frontend:

```
irb(main):004:0> ContentItem.where(rendering_app: "contacts-frontend").pluck(:document_type, :schema_name).uniq
=> [["contact", "contact"]]
```

service-manual-frontend:
```
irb(main):009:0* ContentItem.where(rendering_app: "service-manual-frontend").pluck(:document_type, :schema_name).uniq
=> [["service_manual_topic", "service_manual_topic"], ["service_manual_guide", "service_manual_guide"], ["service_manual_service_standard", "service_manual_service_standard"]]
```

multipage-frontend:
```
irb(main):010:0> ContentItem.where(rendering_app: "multipage-frontend").pluck(:document_type, :schema_name).uniq
=> [["travel_advice", "travel_advice"]]
```

The exception are statistics announcements. These can have a "statistics_announcement" schema_name and a "national" or "official" document type. I think those aren't quite descriptive, so we're going to see if they can be changed.

https://trello.com/c/mOeDK914/107-epic-related-links-and-panopticon