### PR TITLE
Remove need IDs meta tag

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -9,9 +9,6 @@
 
   meta_tags["govuk:format"] = content_item_hash[:document_type] if content_item_hash[:document_type]
 
-  need_ids = content_item_hash[:need_ids] || []
-  meta_tags["govuk:need-ids"] = need_ids.join(',') if need_ids.any?
-
   organisations = []
   organisations += links_hash[:organisations] || []
   organisations += links_hash[:worldwide_organisations] || []

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -14,7 +14,6 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     render_component(content_item: example_document_for('case_study', 'case_study'))
 
     assert_meta_tag('govuk:format', 'case_study')
-    assert_meta_tag('govuk:need-ids', '100001,100002')
     assert_meta_tag('govuk:analytics:organisations', '<L2><W4>')
     assert_meta_tag('govuk:analytics:world-locations', '<WL3>')
   end
@@ -26,11 +25,6 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   test "renders format in a meta tag" do
     render_component(content_item: { document_type: "case_study" })
     assert_meta_tag('govuk:format', 'case_study')
-  end
-
-  test "renders need IDs as a comma separated list" do
-    render_component(content_item: { need_ids: [100001, 100002] })
-    assert_meta_tag('govuk:need-ids', '100001,100002')
   end
 
   test "renders organisations in a meta tag with angle brackets" do


### PR DESCRIPTION
This commit removes the need IDs meta tag. The performance analysts confirmed at a meeting on 12/10/2016 that this tag is no longer required.