### PR TITLE
Replace "eg" with "like" for report a problem

### DIFF
--- a/app/views/root/report_a_problem.raw.html.erb
+++ b/app/views/root/report_a_problem.raw.html.erb
@@ -12,7 +12,7 @@
           <input id="page_owner" name="page_owner" type="hidden" value="<%= page_owner %>">
         <% end %>
 
-        <p>Don’t include personal or financial information, eg your National Insurance number or credit card details.</p>
+        <p>Don’t include personal or financial information like your National Insurance number or credit card details.</p>
 
         <label for="what_doing">What you were doing</label>
         <input id="what_doing" name="what_doing" type="text" />


### PR DESCRIPTION
https://insidegovuk.blog.gov.uk/2016/07/20/changes-to-the-style-guide-no-more-eg-and-ie-etc/

> Terms like eg, ie and etc, while common, make reading difficult for some.