### PR TITLE
Make sure breadcrumbs and related items look good in older apps

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -2,5 +2,11 @@
 @import "design-patterns/breadcrumbs";
 
 .govuk-breadcrumbs {
+  // reset the default browser styles
+  ol {
+    padding: 0;
+    margin: 0;
+  }
+
   @include breadcrumbs;
 }

--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -9,11 +9,18 @@
   }
 
   ul {
+    // reset the default browser styles
+    padding: 0;
+    margin: 0;
+
     @include core-16;
     list-style: none;
     margin-bottom: 1.25em;
 
     li {
+      // reset the default browser styles
+      padding: 0;
+
       margin-bottom: 0.75em;
 
       &.related-items-more {


### PR DESCRIPTION
GOV.UK Components expect that they're included in a page with a certain global CSS reset. This is the case for newly migrated pages (like the ones rendered by government-frontend), but it doesn't apply to pages in older frontend apps like calendars, calculators, smart answers, and others.

While migrating those pages to use the component we introduced the same CSS in all applications. This to prevent extra margins appearing on breadcrumb and related links.

https://github.com/search?q=org%3Aalphagov+%22might+be+pushed+up+to+static+at+some+point%22&type=Code

This puts the CSS back in here, so that we can remove the overrides in individual apps.

https://trello.com/c/5Utjs9qw

cc @carolinegreen @fofr @nickcolley 