### PR TITLE
Avoid rendering the side content when there's no content

### DIFF
--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,39 +1,38 @@
-<%
-  sections ||= []
-%>
-<aside class="govuk-related-items" role="complementary">
-  <% sections.each do |section| %>
-    <h2
-      <% if section[:id] %>id="<%= section[:id] %>"<% end %>
-    >
-      <%= section[:title] %>
-    </h2>
-    <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
-      <ul>
-        <% section[:items].each do |item| %>
-          <li>
-            <a
-              href="<%= item[:url] %>"
-              <% if item[:rel] %>rel="<%= item[:rel] %>"<% end %>
-            >
-              <%= item[:title] %>
-            </a>
-          </li>
-        <% end %>
-        <% if section[:url] %>
-          <li class="related-items-more">
-            <a href="<%= section[:url] %>">
-              <%= t("govuk_component.related_items.more", default: "More") %>
-              <% if section[:title] %>
-                <span class="visuallyhidden">
-                  <%= t("govuk_component.related_items.in", default: "in") %>
-                  <%= section[:title] %>
-                </span>
-              <% end %>
-            </a>
-          </li>
-        <% end %>
-      </ul>
-    </nav>
-  <% end %>
-</aside>
+<% if local_assigns[:sections] && !sections.blank? %>
+  <aside class="govuk-related-items" role="complementary">
+    <% sections.each do |section| %>
+      <h2
+        <% if section[:id] %>id="<%= section[:id] %>"<% end %>
+      >
+        <%= section[:title] %>
+      </h2>
+      <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
+        <ul>
+          <% section[:items].each do |item| %>
+            <li>
+              <a
+                href="<%= item[:url] %>"
+                <% if item[:rel] %>rel="<%= item[:rel] %>"<% end %>
+              >
+                <%= item[:title] %>
+              </a>
+            </li>
+          <% end %>
+          <% if section[:url] %>
+            <li class="related-items-more">
+              <a href="<%= section[:url] %>">
+                <%= t("govuk_component.related_items.more", default: "More") %>
+                <% if section[:title] %>
+                  <span class="visuallyhidden">
+                    <%= t("govuk_component.related_items.in", default: "in") %>
+                    <%= section[:title] %>
+                  </span>
+                <% end %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    <% end %>
+  </aside>
+<% end %>

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -7,8 +7,7 @@ class RelatedItemsTestCase < ComponentTestCase
 
   test "no error if no parameters passed in" do
     assert_nothing_raised do
-      render_component({})
-      assert_select ".govuk-related-items"
+      assert_empty render_component({})
     end
   end
 


### PR DESCRIPTION
This commit aims to superseed https://github.com/alphagov/frontend/pull/1069
We believe that is the component responsability to make sure the requirements are met
in order to do the the job, in this case, to render the content.

What this commit suggest is that we do our components with [Design by Contract](https://en.wikipedia.org/wiki/Design_by_contract) in mind,
what it means is that the component becomes responsible to dictate how it should be used.

Also there's a certain advantage of doing this at the component level,
this avoids extra work on the developer to chase all the rendering applications to make sure they should or not render the component.

So keeping it on the component side is not only beneficial code wise but also more efficient.

Trello: https://trello.com/c/5TCdhKVN/320-fix-the-hovering-blue-sidebar-on-pages-without-related-links

![screen shot 2016-12-01 at 14 57 01](https://cloud.githubusercontent.com/assets/136777/20798375/82f36314-b7d6-11e6-92cc-0196f3eedb85.png)

![screen shot 2016-12-01 at 14 57 12](https://cloud.githubusercontent.com/assets/136777/20798382/86fe78c2-b7d6-11e6-89ec-3497e14e7168.png)