### PR TITLE
Add and init button role shim

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -25,11 +25,13 @@ $(document).ready(function() {
     var buttonsSelector = "label.selectable input[type='radio'], label.selectable input[type='checkbox']";
     new GOVUK.SelectionButtons(buttonsSelector);
 
+    if (GOVUK.shimLinksWithButtonRole) {
+      GOVUK.shimLinksWithButtonRole.init();
+    }
+
     // HMRC webchat
     if (GOVUK.webchat) {
       GOVUK.webchat.init();
     }
   }
 });
-
-

--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -11,3 +11,4 @@
 //= require libs/govuk-component/govspeak-magna-charta.min
 //= require govuk-component/govspeak-convert-html-pub-charts
 //= require govuk-component/option-select
+//= require govuk/shim-links-with-button-role


### PR DESCRIPTION
Closes #825

Shims any applications that are using `[role="button"]` so that using the spacebar will click them as expected.

# How to test

Check out this branch locally and also a frontend application with a button (for example a start page).

Tab to the button, then press the spacebar, the button should be clicked in the same behaviour as pressing enter.
