### PR TITLE
Track breadcrumb clicks

### DIFF
--- a/app/assets/javascripts/modules/track-breadcrumb-click.js
+++ b/app/assets/javascripts/modules/track-breadcrumb-click.js
@@ -1,0 +1,23 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackBreadcrumbClick = function () {
+    this.start = function (element) {
+      element.on('click', trackBreadcrumbClick);
+
+      var titleDimensionId = 29,
+          dimension = element.data('track-dimension'),
+          trackClick = new GOVUK.Modules.TrackClick();
+
+      trackClick.start(element);
+
+      function trackBreadcrumbClick(e) {
+        if (GOVUK.analytics && GOVUK.analytics.setDimension) {
+          GOVUK.analytics.setDimension(titleDimensionId, dimension);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -1,0 +1,26 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function(Modules) {
+  "use strict";
+
+  Modules.TrackClick = function () {
+    this.start = function (element) {
+      element.on('click', trackClick);
+
+      var options = {},
+          category = element.data('track-category'),
+          action = element.data('track-action'),
+          label = element.data('track-label');
+
+      if (label) {
+        options.label = label;
+      }
+
+      function trackClick() {
+        if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+          GOVUK.analytics.trackEvent(category, action, options);
+        }
+      }
+    };
+  };
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -8,9 +8,9 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       element.on('click', trackClick);
 
       var options = {},
-          category = element.data('track-category'),
-          action = element.data('track-action'),
-          label = element.data('track-label');
+          category = element.attr('data-track-category'),
+          action = element.attr('data-track-action'),
+          label = element.attr('data-track-label');
 
       if (label) {
         options.label = label;

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,6 +1,7 @@
 //= require govuk/modules
 //= require modules/sticky-element-container
 //= require modules/toggle
+//= require modules/track-click
 
 $(document).ready(function () {
   GOVUK.modules.start();

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -2,6 +2,7 @@
 //= require modules/sticky-element-container
 //= require modules/toggle
 //= require modules/track-click
+//= require modules/track-breadcrumb-click
 
 $(document).ready(function () {
   GOVUK.modules.start();

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -13,7 +13,8 @@
             track_category: 'breadcrumbClicked',
             track_action: index + 1,
             track_label: crumb[:url],
-            track_dimension: crumb[:title]
+            track_dimension: crumb[:title],
+            module: 'track-breadcrumb-click'
           }
         ) %>
       <% else %>

--- a/spec/javascripts/modules/track-breadcrumb-click.spec.js
+++ b/spec/javascripts/modules/track-breadcrumb-click.spec.js
@@ -1,0 +1,35 @@
+describe('Breadcrumb click tracker', function() {
+  "use strict";
+
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    tracker = new GOVUK.Modules.TrackBreadcrumbClick();
+  });
+
+  it('tracks click events', function() {
+    spyOn(GOVUK.analytics, 'setDimension');
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      '<a data-track-category="breadcrumbClicked" \
+          data-track-action="1" \
+          data-track-label="/" \
+          data-track-dimension="Home" \
+          data-module="track-breadcrumb-click" \
+          href="/">Home</a>'
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(29, 'Home');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'breadcrumbClicked',
+      1,
+      { label: '/' }
+    );
+  });
+});

--- a/spec/javascripts/modules/track-breadcrumb-click.spec.js
+++ b/spec/javascripts/modules/track-breadcrumb-click.spec.js
@@ -28,7 +28,7 @@ describe('Breadcrumb click tracker', function() {
     expect(GOVUK.analytics.setDimension).toHaveBeenCalledWith(29, 'Home');
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
       'breadcrumbClicked',
-      1,
+      '1',
       { label: '/' }
     );
   });

--- a/spec/javascripts/modules/track-click.spec.js
+++ b/spec/javascripts/modules/track-click.spec.js
@@ -1,0 +1,29 @@
+describe('A click tracker', function() {
+  "use strict";
+
+  var tracker,
+      element;
+
+  beforeEach(function() {
+    tracker = new GOVUK.Modules.TrackClick();
+  });
+
+  it('tracks click events', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div \
+        data-track-category="category"\
+        data-track-action="action"\
+        data-track-label="Foo">\
+        Bar!\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo'});
+  });
+});


### PR DESCRIPTION
This PR adds a new tracker that tracks clicks on breadcrumb links. When a click occurs, it:
- sets a custom dimension in order to report the title of the link clicked;
- calls the `TrackLink` module to track a custom event (`trackEvent`) with the remaining data attributes (category, action and label).

**NOTE**:

Before this can be merged, we need to:
- [x] - change the dimension ID to a correct value (we agreed on 29);
- [x] - merge https://github.com/alphagov/static/pull/863

This branch was created off https://github.com/alphagov/static/pull/863, hence the first 2 commits being the same.