### PR TITLE
Update special route content item

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,4 @@ if ENV['GOVUK_TEMPLATE_DEV']
 else
   gem 'govuk_template', '0.19.0'
 end
-gem 'gds-api-adapters', '26.7.0'
+gem 'gds-api-adapters', '38.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,19 +65,19 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    domain_name (0.5.25)
+    domain_name (0.5.20161129)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
     exifr (1.2.3.1)
     fspath (2.1.1)
-    gds-api-adapters (26.7.0)
+    gds-api-adapters (38.1.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
-      plek
+      plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     govuk-content-schema-test-helpers (1.4.0)
@@ -90,7 +90,7 @@ GEM
       sass (>= 3.2.0)
     govuk_template (0.19.0)
       rails (>= 3.1)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     image_optim (0.17.1)
@@ -151,7 +151,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.5)
-    rack-cache (1.5.1)
+    rack-cache (1.6.1)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -183,10 +183,10 @@ GEM
     rainbow (2.1.0)
     raindrops (0.15.0)
     rake (10.5.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -233,7 +233,7 @@ GEM
       json (>= 1.8.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -253,7 +253,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
-  gds-api-adapters (= 26.7.0)
+  gds-api-adapters (= 38.1.0)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.6.0)
   govuk_frontend_toolkit (~> 5.0.2)

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -90,14 +90,17 @@ namespace :publishing_api do
     ]
 
     routes.each do |route|
-      publisher.publish(route.merge(
-        format: "special_route",
-        type: "exact",
-        publishing_app: "static",
-        rendering_app: "static",
-        public_updated_at: Time.now.iso8601,
-        update_type: "major",
-      ))
+      publisher.publish(
+        route.merge(
+          document_type: "special_route",
+          schema_name: "special_route",
+          type: "exact",
+          publishing_app: "static",
+          rendering_app: "static",
+          public_updated_at: Time.now.iso8601,
+          update_type: "major",
+        )
+      )
     end
   end
 end


### PR DESCRIPTION
Format was deprecated in favour of `document_type` and `schema_name`.
This commit fixes it so we can publish the special routes to the
Publishing API.