### PR TITLE
Fix invalid value for rel attribute

### DIFF
--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -7,7 +7,7 @@
   <ul class="group">
     <% if local_assigns.include?(:previous_page) %>
       <li class="previous-page">
-        <a href="<%= previous_page[:url] %>" rel="previous" >
+        <a href="<%= previous_page[:url] %>" rel="prev" >
           <span class="pagination-part-title"><%= previous_page[:title] %></span>
           <span class="pagination-label"><%= previous_page[:label] %></span>
         </a>


### PR DESCRIPTION
There is a typo in the previous_and_next_navigation component as the "previous" link has an invalid [link type](https://www.w3.org/TR/html5/links.html#linkTypes).
This corrects `rel="previous"` to the correct `rel="prev"`.