### PR TITLE
Remove margin on first heading in HTML govspeak

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -110,6 +110,18 @@
       }
     }
 
+    h2:first-child,
+    h3:first-child {
+      margin-top: 0;
+
+      // Reduce default margin by 2x gutter for first headings
+      // This accounts for the 2x gutter margin on the HTML pub header
+      // which doesn't collapse because of containers
+      @include media(tablet) {
+        margin-top: $gutter-two-thirds;
+      }
+    }
+
     // scss-lint:disable QualifyingElement
     // this class will only be for tables and is to distinguish from a bare `table`
     // the row classes below should not be applied to anything else but `tr`s


### PR DESCRIPTION
We override the default govspeak styles with our HTML publication specific header margins. We need to put back the margin resets too.

Goes with this change: https://github.com/alphagov/government-frontend/pull/223