### PR TITLE
Add a new layout that excludes footer links

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -44,46 +44,48 @@
 <% end %>
 
 <% content_for :footer_top do %>
-  <div class="footer-categories">
-    <div class="footer-explore">
-      <h2>Services and information</h2>
+  <% unless local_assigns[:hide_footer_links] %>
+    <div class="footer-categories">
+      <div class="footer-explore">
+        <h2>Services and information</h2>
 
-      <ul>
-        <li><a href="/browse/benefits">Benefits</a></li>
-        <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
-        <li><a href="/browse/business">Business and self-employed</a></li>
-        <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
-        <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
-        <li><a href="/browse/justice">Crime, justice and the law</a></li>
-        <li><a href="/browse/disabilities">Disabled people</a></li>
-        <li><a href="/browse/driving">Driving and transport</a></li>
-      </ul>
-      <ul>
-        <li><a href="/browse/education">Education and learning</a></li>
-        <li><a href="/browse/employing-people">Employing people</a></li>
-        <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
-        <li><a href="/browse/housing-local-services">Housing and local services</a></li>
-        <li><a href="/browse/tax">Money and tax</a></li>
-        <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
-        <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
-        <li><a href="/browse/working">Working, jobs and pensions</a></li>
-      </ul>
+        <ul>
+          <li><a href="/browse/benefits">Benefits</a></li>
+          <li><a href="/browse/births-deaths-marriages">Births, deaths, marriages and care</a></li>
+          <li><a href="/browse/business">Business and self-employed</a></li>
+          <li><a href="/browse/childcare-parenting">Childcare and parenting</a></li>
+          <li><a href="/browse/citizenship">Citizenship and living in the UK</a></li>
+          <li><a href="/browse/justice">Crime, justice and the law</a></li>
+          <li><a href="/browse/disabilities">Disabled people</a></li>
+          <li><a href="/browse/driving">Driving and transport</a></li>
+        </ul>
+        <ul>
+          <li><a href="/browse/education">Education and learning</a></li>
+          <li><a href="/browse/employing-people">Employing people</a></li>
+          <li><a href="/browse/environment-countryside">Environment and countryside</a></li>
+          <li><a href="/browse/housing-local-services">Housing and local services</a></li>
+          <li><a href="/browse/tax">Money and tax</a></li>
+          <li><a href="/browse/abroad">Passports, travel and living abroad</a></li>
+          <li><a href="/browse/visas-immigration">Visas and immigration</a></li>
+          <li><a href="/browse/working">Working, jobs and pensions</a></li>
+        </ul>
+      </div>
+
+      <div class="footer-inside-government">
+        <h2>Departments and policy</h2>
+
+        <ul>
+          <li><a href="/government/how-government-works">How government works</a></li>
+          <li><a href="/government/organisations">Departments</a></li>
+          <li><a href="/government/world">Worldwide</a></li>
+          <li><a href="/government/policies">Policies</a></li>
+          <li><a href="/government/publications">Publications</a></li>
+          <li><a href="/government/announcements">Announcements</a></li>
+        </ul>
+      </div>
+      <hr>
     </div>
-
-    <div class="footer-inside-government">
-      <h2>Departments and policy</h2>
-
-      <ul>
-        <li><a href="/government/how-government-works">How government works</a></li>
-        <li><a href="/government/organisations">Departments</a></li>
-        <li><a href="/government/world">Worldwide</a></li>
-        <li><a href="/government/policies">Policies</a></li>
-        <li><a href="/government/publications">Publications</a></li>
-        <li><a href="/government/announcements">Announcements</a></li>
-      </ul>
-    </div>
-    <hr>
-  </div>
+  <% end %>
 <% end %>
 <% content_for :footer_support_links do %>
   <%= render :partial => "footer_support_links" %>

--- a/app/views/root/without_footer_links.html.erb
+++ b/app/views/root/without_footer_links.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: 'base', locals: {
+  hide_footer_links: true,
+  hide_nav: true, # no breadcrumbs, you can include them using components if
+                  # you need them, rather than using slimmer
+  css_file: 'core-layout',
+  js_file: 'header-footer-only'
+} %>


### PR DESCRIPTION
The links that appear in the top half of the footer (.footer-categories) replicate the home page of GOV.UK and represent the needs of the citizens using the site.

As the primary users of the Service Manual (and forthcoming Service Toolkit) are people within government building a services these links are not relevant and may even compete (could be confused with Service Manual content).