### PR TITLE
Add back removed CSS for sidebar positioning

### DIFF
--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -18,6 +18,7 @@ body {
   }
 }
 
+// Needed for the positioning of the sidebar. Deprecated.
 .related-container {
   @include grid-column(1/3, $full-width: desktop);
   margin-top: 40px;

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -18,6 +18,10 @@ body {
   }
 }
 
+.related-container {
+  @include grid-column(1/3, $full-width: desktop);
+  margin-top: 40px;
+}
 
 p {
   @include core-19;


### PR DESCRIPTION
In https://github.com/alphagov/static/pull/879 I removed CSS for breadcrumbs and related links. The `related-container` CSS should not have been deleted, because it determines the size of the sidebar (rather than the appearance of it, which is determined by the govuk component).

## Before

![screen shot 2017-01-16 at 16 20 21](https://cloud.githubusercontent.com/assets/233676/21990787/007c690c-dc08-11e6-831a-7dfaa788748e.png)

## After

![screen shot 2017-01-16 at 16 19 58](https://cloud.githubusercontent.com/assets/233676/21990792/0453aa4a-dc08-11e6-9d67-3d3c009c3226.png)

https://trello.com/c/7wohUbyo