### PR TITLE
Allow tracking of all trackable links within a container

### DIFF
--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -5,24 +5,36 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   Modules.TrackClick = function () {
     this.start = function (element) {
-      element.on('click', trackClick);
+      var trackable = '[data-track-category][data-track-action]';
 
-      var options = {transport: 'beacon'},
-          category = element.attr('data-track-category'),
-          action = element.attr('data-track-action'),
-          label = element.attr('data-track-label'),
-          dimension = element.attr('data-track-dimension'),
-          dimensionIndex = element.attr('data-track-dimension-index');
-
-      if (label) {
-        options.label = label;
+      if (element.is(trackable)) {
+        element.on('click', trackClick);
+      } else {
+        element.on('click', trackable, trackClick);
       }
 
-      if (dimension && dimensionIndex) {
-        options['dimension' + dimensionIndex] = dimension;
-      }
+      function trackClick(evt) {
+        var $el = $(evt.target),
+            options = {transport: 'beacon'};
 
-      function trackClick() {
+        if ( ! $el.is(trackable)) {
+          $el = $el.parents(trackable);
+        }
+
+        var category = $el.attr('data-track-category'),
+            action = $el.attr('data-track-action'),
+            label = $el.attr('data-track-label'),
+            dimension = $el.attr('data-track-dimension'),
+            dimensionIndex = $el.attr('data-track-dimension-index');
+
+        if (label) {
+          options.label = label;
+        }
+
+        if (dimension && dimensionIndex) {
+          options['dimension' + dimensionIndex] = dimension;
+        }
+
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           GOVUK.analytics.trackEvent(category, action, options);
         }

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,7 +1,7 @@
 <%
   breadcrumbs ||= []
 %>
-<div class="govuk-breadcrumbs">
+<div class="govuk-breadcrumbs" data-module="track-click">
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
     <li>
@@ -15,7 +15,6 @@
             track_label: crumb[:url],
             track_dimension: crumb[:title],
             track_dimension_index: 29,
-            module: 'track-click',
           }
         ) %>
       <% else %>

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,5 +1,5 @@
 <% if local_assigns[:sections] && !sections.blank? %>
-  <aside class="govuk-related-items" role="complementary">
+  <aside class="govuk-related-items" data-module="track-click" role="complementary">
     <% sections.each_with_index do |section, section_index| %>
       <h2
         <% if section[:id] %>id="<%= section[:id] %>"<% end %>
@@ -19,7 +19,6 @@
                   track_label: item[:url],
                   track_dimension: item[:title],
                   track_dimension_index: 29,
-                  module: 'track-click',
                 },
                 rel: item[:rel],
               ) %>
@@ -35,7 +34,6 @@
                   track_label: section[:url],
                   track_dimension: 'More',
                   track_dimension_index: 29,
-                  module: 'track-click',
                 },
               ) do %>
                 <%= t("govuk_component.related_items.more", default: "More") %>

--- a/spec/javascripts/modules/track-click.spec.js
+++ b/spec/javascripts/modules/track-click.spec.js
@@ -36,7 +36,6 @@ describe('A click tracker', function() {
           data-track-label="/" \
           data-track-dimension="dimension-value" \
           data-track-dimension-index="29" \
-          data-module="track-click" \
           href="/">Home</a>'
     );
 
@@ -89,5 +88,58 @@ describe('A click tracker', function() {
     element.trigger('click');
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
+  });
+
+  it('tracks all trackable links within a container', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div>\
+        <a class="first" href="#" \
+          data-track-category="cat1"\
+          data-track-action="action1"\
+          data-track-label="label1">\
+          Link 1\
+        </a>\
+        <a class="second" href="#" \
+          data-track-category="cat2"\
+          data-track-action="action2"\
+          data-track-label="label2">\
+          Link 2\
+        </a>\
+        <span class="nothing"></span>\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.find('.nothing').trigger('click');
+    expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalled();
+
+    element.find('a.first').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat1', 'action1', {label: 'label1', transport: 'beacon'});
+
+    element.find('a.second').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('cat2', 'action2', {label: 'label2', transport: 'beacon'});
+  });
+
+  it('tracks a click correctly when event target is a child element of trackable element', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $('\
+      <div>\
+        <a class="first" href="#" \
+          data-track-category="parent-category"\
+          data-track-action="parent-action"\
+          data-track-label="parent-label">\
+          <b><span class="child-of-link">I am a child</span></b>\
+        </a>\
+      </div>\
+    ');
+
+    tracker.start(element);
+
+    element.find('.child-of-link').trigger('click');
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('parent-category', 'parent-action', {label: 'parent-label', transport: 'beacon'});
   });
 });

--- a/spec/javascripts/modules/track-click.spec.js
+++ b/spec/javascripts/modules/track-click.spec.js
@@ -8,7 +8,7 @@ describe('A click tracker', function() {
     tracker = new GOVUK.Modules.TrackClick();
   });
 
-  it('tracks click events', function() {
+  it('tracks click events using "beacon" as transport', function() {
     spyOn(GOVUK.analytics, 'trackEvent');
 
     element = $('\
@@ -27,14 +27,14 @@ describe('A click tracker', function() {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
   });
 
-  it('tracks breadcrumb click events', function() {
+  it('tracks clicks with custom dimensions', function() {
     spyOn(GOVUK.analytics, 'trackEvent');
 
     element = $(
-      '<a data-track-category="breadcrumbClicked" \
+      '<a data-track-category="category" \
           data-track-action="1" \
           data-track-label="/" \
-          data-track-dimension="Home" \
+          data-track-dimension="dimension-value" \
           data-track-dimension-index="29" \
           data-module="track-click" \
           href="/">Home</a>'
@@ -45,33 +45,9 @@ describe('A click tracker', function() {
     element.trigger('click');
 
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'breadcrumbClicked',
+      'category',
       '1',
-      { label: '/', dimension29: 'Home', transport: 'beacon' }
-    );
-  });
-
-  it('tracks related item click events', function() {
-    spyOn(GOVUK.analytics, 'trackEvent');
-
-    element = $(
-      '<a data-track-category="relatedLinkClicked" \
-          data-track-action="1.1" \
-          data-track-label="/item" \
-          data-track-dimension="Related" \
-          data-track-dimension-index="29" \
-          data-module="track-click" \
-          href="/">Related</a>'
-    );
-
-    tracker.start(element);
-
-    element.trigger('click');
-
-    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-      'relatedLinkClicked',
-      '1.1',
-      { label: '/item', dimension29: 'Related', transport: 'beacon' }
+      { label: '/', dimension29: 'dimension-value', transport: 'beacon' }
     );
   });
 

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -21,12 +21,12 @@ class BreadcrumbsTestCase < ComponentTestCase
   test "renders all data attributes for tracking" do
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 
+    assert_select '.govuk-breadcrumbs[data-module="track-click"]', 1
     assert_select 'ol li:first-child a[data-track-action="1"]', 1
     assert_select 'ol li:first-child a[data-track-label="/section"]', 1
     assert_select 'ol li:first-child a[data-track-dimension="Section"]', 1
     assert_select 'ol li:first-child a[data-track-category="breadcrumbClicked"]', 1
     assert_select 'ol li:first-child a[data-track-dimension-index="29"]', 1
-    assert_select 'ol li:first-child a[data-module="track-click"]', 1
   end
 
   test "renders a list of breadcrumbs" do

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -142,9 +142,10 @@ class RelatedItemsTestCase < ComponentTestCase
       ],
     )
 
+    assert_select '.govuk-related-items[data-module="track-click"]', 1
+
     assert_select "a[data-track-category=\"relatedLinkClicked\"]", 5
     assert_select "a[data-track-dimension-index=\"29\"]", 5
-    assert_select "a[data-module=\"track-click\"]", 5
     assert_select "a[data-track-dimension=\"More\"]", 2
 
     assert_select "a[data-track-action=\"1.1\"]", 1


### PR DESCRIPTION
Creating a single event listener is more efficient than one for every link that could be clicked. It also reduces the number of unique modules that must be started.

* Use new pattern on breadcrumbs and related links
* I've tested the correct events are generated in frontend

Will make https://trello.com/c/62Gy8pyj/77-track-interactions-with-contents-lists-1-s more efficient.

cc @tijmenb @alecgibson @nickcolley 