### PR TITLE
Late jan 2017 survey changes

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -72,6 +72,33 @@
         },
         startTime: new Date("January 16, 2017").getTime(),
         endTime: new Date("January 29, 2017 23:59:59").getTime()
+      },
+      {
+        url: 'https://www.surveymonkey.com/s/2MRDLTW',
+        identifier: 'education_survey',
+        template: TEMPLATE,
+        frequency: 10,
+        activeWhen: function() {
+          function breadcrumbMatches() {
+            var text = $('#global-breadcrumb').text() || "";
+            return (/Education/i.test(text) || /Childcare/i.test(text) || /Schools/i.test(text));
+          }
+
+          function sectionMatches() {
+            var sectionName = $('meta[name="govuk:section"]').attr('content');
+            return (sectionName === 'education' || sectionName === 'childcare' || sectionName === 'schools');
+          }
+
+          function organisationMatches() {
+            var orgMatchingExpr = /<D6>|<D106>|<D109>|<EA243>|<EA86>|<EA242>|<EA541>/;
+            var metaText = $('meta[name="govuk:analytics:organisations"]').attr('content') || "";
+            return orgMatchingExpr.test(metaText);
+          }
+
+          return (sectionMatches() || organisationMatches() || breadcrumbMatches());
+        },
+        startTime: new Date("January 30, 2017").getTime(),
+        endTime: new Date("February 5, 2017 23:59:59").getTime()
       }
     ],
 

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -158,7 +158,9 @@
     },
 
     isSurveyToBeDisplayed: function(survey) {
-      if (userSurveys.otherNotificationVisible() ||
+      if (userSurveys.pathInBlacklist()) {
+        return false;
+      } else if (userSurveys.otherNotificationVisible() ||
           GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
         return false;
       } else if (userSurveys.userCompletedTransaction()) {
@@ -173,6 +175,16 @@
       } else {
         return false;
       }
+    },
+
+    pathInBlacklist: function() {
+      var blackList = new RegExp('^/(?:'
+        + /service-manual/.source
+        // add more blacklist paths in the form:
+        // + /|path-to\/blacklist/.source
+        + ')(?:\/|$)'
+      );
+      return blackList.test(userSurveys.currentPath());
     },
 
     userCompletedTransaction: function() {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -99,6 +99,27 @@
         },
         startTime: new Date("January 30, 2017").getTime(),
         endTime: new Date("February 5, 2017 23:59:59").getTime()
+      },
+      {
+        url: 'https://www.smartsurvey.co.uk/s/6YYKX/',
+        identifier: 'ons_survey',
+        template: '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
+                  '  <div class="wrapper">' +
+                  '    <h1>Tell us what you think of GOV.UK</h1>' +
+                  '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
+                  '    <p><a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">Give us your feedback on government statistical data</a> This will open a short survey on another website</p>' +
+                  '  </div>' +
+                  '</section>',
+        frequency: 1,
+        activeWhen: function() {
+          function pathMatches() {
+            return /^\/government\/statistics\/?$/.test(userSurveys.currentPath());
+          }
+
+          return pathMatches();
+        },
+        startTime: new Date("January 25, 2017").getTime(),
+        endTime: new Date("February 27, 2017 23:59:59").getTime()
       }
     ],
 

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -49,7 +49,7 @@
                   '    <p><a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">Answer some questions about yourself to join the research community</a>. This link opens in a new tab.</p>' +
                   '  </div>' +
                   '</section>',
-        frequency: 10,
+        frequency: 2,
         activeWhen: function() {
 
           function pathMatches() {
@@ -71,7 +71,7 @@
           return (pathMatches());
         },
         startTime: new Date("January 16, 2017").getTime(),
-        endTime: new Date("January 29, 2017 23:59:59").getTime()
+        endTime: new Date("February 12, 2017 23:59:59").getTime()
       },
       {
         url: 'https://www.surveymonkey.com/s/2MRDLTW',

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -6,6 +6,8 @@ Sometimes, a "small survey" or "test survey" needs to be run across GOV.UK for a
 
 This can easily be done by adding an entry to `GOVUK.userSurveys.smallSurveys` in `app/assets/javascripts/surveys.js`.
 
+There are sections of the site that should not show any surveys and these can be controlled via the `GOVUK.userSurveys.pathInBlacklist` function in `app/assets/javascripts/surveys.js`.  They are also never shown on "done" pages which can be controlled via the `GOVUK.userSurveys.userCompletedTransaction` function in the same file.
+
 ## Example
 
 ```javascript

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -81,6 +81,12 @@ describe("Surveys", function() {
       expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
     });
 
+    it("returns false if the path is blacklisted", function() {
+      spyOn(surveys, 'pathInBlacklist').and.returnValue(true);
+
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
+    })
+
     it("returns false if the 'survey taken' cookie is set", function () {
       GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey), 'true');
 
@@ -96,7 +102,39 @@ describe("Surveys", function() {
       spyOn(surveys, 'randomNumberMatches').and.returnValue(true);
       expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeTruthy();
     });
+  });
 
+  describe("pathInBlacklist", function() {
+    // we make sure that slash-terminated and slash-unterminated versions
+    // of these paths work
+    it("returns true if the path is /service-manual", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/service-manual', '/service-manual/');
+      expect(surveys.pathInBlacklist()).toBeTruthy();
+      expect(surveys.pathInBlacklist()).toBeTruthy();
+    });
+
+    it("returns true if the path is a sub-folder under /service-manual", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/service-manual/some-other-page', '/service-manual/some-other-page/');
+      expect(surveys.pathInBlacklist()).toBeTruthy();
+      expect(surveys.pathInBlacklist()).toBeTruthy();
+    });
+
+    it("returns false if the path is /service-manual-with-a-suffix", function() {
+      spyOn(surveys, 'currentPath').and.returnValues('/service-manual-with-a-suffix', '/service-manual-with-a-suffix/');
+      expect(surveys.pathInBlacklist()).toBeFalsy();
+      expect(surveys.pathInBlacklist()).toBeFalsy();
+    });
+
+    it("returns false if the path is /some-other-parent-of/service-manual", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/some-other-parent-of/service-manual', '/some-other-parent-of/service-manual/');
+      expect(surveys.pathInBlacklist()).toBeFalsy();
+      expect(surveys.pathInBlacklist()).toBeFalsy();
+    });
+
+    it("returns false otherwise", function() {
+      spyOn(surveys, 'currentPath').and.returnValue('/');
+      expect(surveys.pathInBlacklist()).toBeFalsy();
+    });
   });
 
   describe("userCompletedTransaction", function() {


### PR DESCRIPTION
For: 

* https://trello.com/c/8iJaA4Ey/95-gov-uk-survey-remove-standard-survey-from-service-manual-content - exclude surveys from the service-manual
* https://trello.com/c/vaotDp0x/97-gov-uk-survey-education-content-2 - Re-run the education survey added in #862 (and removed in #877)
* https://trello.com/c/d792rO1T/99-gov-uk-survey-environment-user-research-panel-sign-up-set-of-9-surveys - extend the environment user research survey added in #877
* https://trello.com/c/PXBtbvUH/100-gov-uk-survey-ons-government-data - add new ONS survey