### PR TITLE
Add analytics dimension for A/B tests

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -94,6 +94,7 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
+    this.setAbTestDimension(dimensions['ab-test']);
   };
 
   StaticAnalytics.prototype.trackPageview = function(path, title, options) {
@@ -154,6 +155,10 @@
 
   StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
     this.setDimension(21, position);
+  };
+
+  StaticAnalytics.prototype.setAbTestDimension = function(testNameAndBucket) {
+    this.setDimension(40, testNameAndBucket);
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -62,6 +62,7 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
+          <meta name="govuk:ab-test" content="name-of-test:name-of-ab-bucket">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -74,6 +75,7 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(universalSetupArguments[8]).toEqual(['set', 'dimension7', 'historic']);
         expect(universalSetupArguments[9]).toEqual(['set', 'dimension9', '<D10>']);
         expect(universalSetupArguments[10]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(universalSetupArguments[11]).toEqual(['set', 'dimension40', 'name-of-test:name-of-ab-bucket']);
       });
 
       it('ignores meta tags not set', function() {


### PR DESCRIPTION
Link meta tags named `govuk:ab-test` to a custom Google Analytics dimension. The value of the meta tag and the dimension is a combination of the test name and bucket name, such as `EducationNavigation:B`.

~~This links to existing session dimension 13, which has been used for A/B tests in the past.~~ We're not going to use the existing A/B test dimension (13) so that it can continue to be used by JS-based A/B tests. Tara has reserved dimension 40 instead.

Note that only one A/B test can use this dimension at once, otherwise the value will be overridden by different tests.

Trello: https://trello.com/c/g9OyC7Pn/310-tell-google-analytics-about-a-b-tests

- [x] Check with a performance analyst that we can use this dimension, and ideally create a few more so that there's a pre-existing list that teams can use when creating a new A/B test.
- [x] Update the `meta` tag on the A/B example page in `frontend` to match the expected structure (alphagov/frontend#1110). When I added it, I thought it would just be used by the Chrome extension, but it's simpler to update the tag and the extension than to add more logic to this analytics code.
- [x] Update the Chrome extension to match (alphagov/govuk-toolkit-chrome#57).