### PR TITLE
Fix breadcrumb and section matchers for Education survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -80,13 +80,13 @@
         frequency: 10,
         activeWhen: function() {
           function breadcrumbMatches() {
-            var text = $('#global-breadcrumb').text() || "";
+            var text = $('.govuk-breadcrumbs').text() || "";
             return (/Education/i.test(text) || /Childcare/i.test(text) || /Schools/i.test(text));
           }
 
           function sectionMatches() {
             var sectionName = $('meta[name="govuk:section"]').attr('content');
-            return (sectionName === 'education' || sectionName === 'childcare' || sectionName === 'schools');
+            return (/education/i.test(sectionName) || /childcare/i.test(sectionName) || /schools/i.test(sectionName));
           }
 
           function organisationMatches() {


### PR DESCRIPTION
In #879 we replaced the `#global-breadcrumb` container for breadcrumbs
with the govuk component rendered version which uses `.govuk-breadcrumbs`
as the container instead.  This broke our `breadcrumbMatches()` function
so we change the function to grab the correct selector.

We also change the section matcher to use a regexp test instead of direct
equality to check for a matching section.  It's not clear if the section
names have recently changed, or if the matcher never worked but it wasn't
detected because the breadcrumbs worked instead.