### PR TITLE
Add block of Google Analytics dimensions for A/B tests

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -13,6 +13,7 @@
     setPixelDensityDimension();
     setHTTPStatusCodeDimension();
     this.setDimensionsFromMetaTags();
+    this.setAbTestDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
 
     // Track initial pageview
@@ -94,8 +95,25 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
-    this.setAbTestDimension(dimensions['ab-test']);
   };
+
+  StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
+      var $abMetas = $('meta[name^="govuk:ab-test"]'),
+          staticAnalytics = this,
+          // This is the block of dimensions assigned to A/B tests
+          minAbTestDimension = 40,
+          maxAbTestDimension = 49;
+
+      $abMetas.each(function() {
+        var $meta = $(this),
+        dimension = parseInt($meta.data('analytics-dimension')),
+        testNameAndBucket = $meta.attr('content');
+
+        if (dimension >= minAbTestDimension && dimension <= maxAbTestDimension) {
+          staticAnalytics.setDimension(dimension, testNameAndBucket);
+        }
+      });
+  }
 
   StaticAnalytics.prototype.trackPageview = function(path, title, options) {
     this.analytics.trackPageview(path, title, options);
@@ -155,10 +173,6 @@
 
   StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
     this.setDimension(21, position);
-  };
-
-  StaticAnalytics.prototype.setAbTestDimension = function(testNameAndBucket) {
-    this.setDimension(40, testNameAndBucket);
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;


### PR DESCRIPTION
The GA dimensions from 40-49 have been allocated to A/B tests. These may be reserved for any A/B test for the duration of the test.

This commit identifies which dimension to use for the A/B test based on an extra `data` attribute added to the `meta` tag. Only dimensions in the allowed range are permitted. Any others are ignored and are not reported to GA.

It would be good to have some feedback on this approach. I'm aiming to make it as simple as possible for new teams to add an A/B test. With this proposal, they would have to do the following:

- Request one of the dimensions in the 40-49 block from the performance analysts for the duration of the A/B test. They will assign one which isn't currently being used.
- Set a meta tag in the header like `<meta name="govuk:ab-test" content="NameOfTest:#{bucket}" data-analytics-dimension="43">`.
  - Ideally, this would be done through the [AB test gem](https://github.com/alphagov/govuk_ab_testing). The application code would just need to pass the experiment name and dimension to the gem.

https://trello.com/c/g9OyC7Pn/310-tell-google-analytics-about-a-b-tests

Before this can be merged:

- [x] Merge #888 and change the merge base of this PR
- [ ] Add the data attribute to the `meta` tag on the A/B example page in frontend
- [ ] Add the data attribute to the `meta` tag in the [A/B testing gem](https://github.com/alphagov/govuk_ab_testing) (alphagov/govuk_ab_testing#5)