### PR TITLE
Fix draft watermark for short content

### DIFF
--- a/app/assets/stylesheets/helpers/_draft.scss
+++ b/app/assets/stylesheets/helpers/_draft.scss
@@ -2,4 +2,5 @@
   background-image: image-url("draft-watermark.png");
   background-repeat: repeat-y;
   background-position: 50% 0;
+  background-size: contain;
 }


### PR DESCRIPTION
Some content is clipping the draft background watermark. This commit adds `background-size: contain` to avoid this.

Before:
<img width="978" alt="screen shot 2017-02-08 at 18 20 36" src="https://cloud.githubusercontent.com/assets/5216/22751429/40356f9a-ee2c-11e6-80ff-474fe4fe3295.png">

After:
<img width="961" alt="screen shot 2017-02-08 at 18 21 07" src="https://cloud.githubusercontent.com/assets/5216/22751442/4f5a02a6-ee2c-11e6-8d06-6103c45bbecc.png">

Before:
<img width="301" alt="screen shot 2017-02-08 at 18 25 03" src="https://cloud.githubusercontent.com/assets/5216/22751430/4037d578-ee2c-11e6-9895-7d089fe4ffcf.png">

After:
<img width="301" alt="screen shot 2017-02-08 at 18 25 20" src="https://cloud.githubusercontent.com/assets/5216/22751443/4f6129aa-ee2c-11e6-9470-bba021e96962.png">

I've not tested the effect on IE so would welcome an opinion on that.

/cc @fofr (thanks for the pointer on how to fix), @nickcolley 
