### PR TITLE
Modify Jenkinsfile to allow for schema change builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,6 +27,10 @@ node {
       throttleOption: 'category'],
     [$class: 'ParametersDefinitionProperty',
       parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
         [$class: 'StringParameterDefinition',
           name: 'SCHEMA_BRANCH',
           defaultValue: 'deployed-to-production',
@@ -36,8 +40,13 @@ node {
   try {
     govuk.setEnvar('GOVUK_APP_DOMAIN', 'dev.gov.uk')
     govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
       'SCHEMA_BRANCH': 'deployed-to-production',
     ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
 
     stage('Build') {
       checkout scm


### PR DESCRIPTION
Related to #898 

This makes some changes as per the [instructions] in the opsmanual:

- Adds a IS_SCHEMA_TEST property and sets a default value for it
- Adds a check to ensure that builds only occur if either (the branch name is not deployed-to-production) OR (the branch name is deployed-to-production AND this is a schema test)

[instructions]: https://github.gds/pages/gds/opsmanual/infrastructure/testing/application-testing.html?highlight=testing