### PR TITLE
Style breadcrumb anchor links

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -10,7 +10,7 @@
 
   @include breadcrumbs;
 
-  a[href^="#"] {
+  .breadcrumb-for-current-page {
     color: $secondary-text-colour;
     text-decoration: none;
   }

--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -9,4 +9,9 @@
   }
 
   @include breadcrumbs;
+
+  a[href^="#"] {
+    color: $secondary-text-colour;
+    text-decoration: none;
+  }
 }

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -5,16 +5,27 @@
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
     <li>
-      <% if crumb[:url] %>
+      <%
+        is_link = crumb[:url].present? || crumb[:is_current_page]
+        path = crumb[:is_current_page] ? '#content' : crumb[:url]
+        aria_current = crumb[:is_current_page] ? 'page' : 'false'
+        css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+
+        if is_link
+      %>
         <%= link_to(
           crumb[:title],
-          crumb[:url],
+          path,
           data: {
             track_category: 'breadcrumbClicked',
             track_action: index + 1,
-            track_label: crumb[:url],
+            track_label: path,
             track_dimension: crumb[:title],
             track_dimension_index: 29,
+          },
+          class: css_class,
+          aria: {
+            current: aria_current,
           }
         ) %>
       <% else %>


### PR DESCRIPTION
This style any breadcrumbs linking to anchors on the current page. This is used in conjunction with https://github.com/alphagov/govuk_navigation_helpers/pull/30 to show users which page they are currently on, when browsing the new taxonomy.

Before:
![govuk_frontend_toolkit-current-breadcrumb-before](https://cloud.githubusercontent.com/assets/12036746/22889355/ba6b697c-f200-11e6-86bb-c69a85b2c845.png)

After:
![govuk_frontend_toolkit-current-breadcrumb-after](https://cloud.githubusercontent.com/assets/12036746/22889392/de40c6e4-f200-11e6-9d77-bfd8dca4fbc4.png)

Trello: https://trello.com/c/MVM5bueS/386-add-current-page-to-taxonomy-breadcrumbs