### PR TITLE
Add development defaults to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM ruby:2.2.3
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 
+ENV RAILS_ENV development
+ENV PORT 3013
+
 ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
@@ -9,3 +12,5 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 
 ADD . $APP_HOME
+
+CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
Means less set-up required to use with docker-compose.