### PR TITLE
Add a taxonomy sidebar component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -19,3 +19,4 @@
 @import "breadcrumbs";
 @import "related-items";
 @import "organisation-logo";
+@import "taxonomy-sidebar";

--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,0 +1,35 @@
+.govuk-taxonomy-sidebar {
+  border-top: 10px solid $mainstream-brand;
+  padding-top: 5px;
+
+  h2 {
+    @include bold-24;
+    margin-top: 0.3em;
+    margin-bottom: 0.5em;
+  }
+
+  ul {
+    // reset the default browser styles
+    padding: 0;
+    margin: 0;
+
+    @include core-16;
+    list-style: none;
+    margin-bottom: 1.25em;
+
+    li {
+      // reset the default browser styles
+      padding: 0;
+
+      margin-bottom: 0.75em;
+
+      .taxon-link {
+        font-size: 19px;
+      }
+
+      .taxon-description {
+        margin-top: 0.5em;
+      }
+    }
+  }
+}

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -1,0 +1,19 @@
+name: "Taxonomy sidebar"
+description: "Sidebar navigation for displaying on pages tagged to the GOV.UK taxonomy."
+body: |
+  Accepts an array of sections. Each section can have a title and a list of
+  items - these items are typically the list of taxons the current content page
+  is tagged to.
+
+  Each item is a hash with a title, url, and description.
+fixtures:
+  default:
+    sections:
+      - title: "Parent taxons"
+        items:
+          - title: "School curriculum"
+            url: /education/school-curriculum
+          - title: "Tests (key stage 1)"
+            url: /key-stage-1-tests
+
+

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,0 +1,33 @@
+<% if local_assigns[:sections] && !sections.blank? %>
+  <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
+    <% sections.each_with_index do |section, section_index| %>
+
+      <h2> <%= section[:title] %> </h2>
+
+      <nav role='navigation'>
+        <ul>
+          <% section[:items].each_with_index do |item, item_index| %>
+            <li>
+              <%=
+                link_to(
+                  item[:title],
+                  item[:url],
+                  data: {
+                    track_category: 'relatedLinkClicked',
+                    track_action: "#{section_index + 1}.#{item_index + 1}",
+                    track_label: item[:url],
+                    track_dimension: item[:title],
+                    track_dimension_index: 29,
+                  },
+                  class: 'taxon-link',
+                )
+              %>
+
+              <p class='taxon-description'><%= item[:description] %></p>
+            </li>
+          <% end %>
+        </ul>
+      </nav>
+    <% end %>
+  </aside>
+<% end %>

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -1,0 +1,65 @@
+require 'govuk_component_test_helper'
+
+class TaxonomySidebarTestCase < ComponentTestCase
+  def component_name
+    "taxonomy_sidebar"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      assert_empty render_component({})
+    end
+  end
+
+  test "renders a related items block" do
+    render_component(
+      sections: [
+        {
+          title: "Section title",
+          items: [
+            {
+              title: "Item title",
+              url: "/item",
+              description: "An item",
+            },
+            {
+              title: "Other item title",
+              url: "/other-item",
+              description: "Another item",
+            }
+          ]
+        }
+      ],
+    )
+
+    assert_select "h2", text: "Section title"
+    assert_link_with_text_in("ul li:first-child", "/item", "Item title")
+    assert_select("ul li:first-child p", "An item")
+    assert_link_with_text_in("ul li:first-child + li", "/other-item", "Other item title")
+    assert_select("ul li:first-child + li p", "Another item")
+  end
+
+  test "renders all data attributes for tracking" do
+    render_component(
+      sections: [
+        {
+          title: "Section title",
+          items: [
+            {
+              title: "Item title",
+              url: "/item",
+              description: "An item",
+            },
+          ]
+        }
+      ],
+    )
+
+    assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
+    assert_select "a[data-track-category=\"relatedLinkClicked\"]", 1
+    assert_select "a[data-track-dimension=\"Item title\"]", 1
+    assert_select "a[data-track-dimension-index=\"29\"]", 1
+    assert_select "a[data-track-action=\"1.1\"]", 1
+    assert_select "a[data-track-label=\"/item\"]", 1
+  end
+end


### PR DESCRIPTION
Intended for use on content pages tagged to the GOV.UK taxonomy.
Initially this should only link to the list of taxons the current page is
tagged to, along with descriptions of each taxon.