### PR TITLE
Enlarge mobile clickable areas on breadcrumbs and beta banners

### DIFF
--- a/app/assets/stylesheets/govuk-component/_beta-label.scss
+++ b/app/assets/stylesheets/govuk-component/_beta-label.scss
@@ -1,3 +1,14 @@
 .govuk-beta-label {
   @include phase-banner($state: beta);
+
+  // Enlarge clickable area on mobile & tablet
+  a {
+    padding: 0.5em;
+    margin: -0.5em;
+
+    @include media(desktop) {
+      padding: 0;
+      margin: 0;
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -14,4 +14,15 @@
     color: $secondary-text-colour;
     text-decoration: none;
   }
+
+  // Enlarge the clickable area on mobile & tablet
+  a {
+    padding: 0.7em;
+    margin: -0.7em;
+
+    @include media(desktop) {
+      padding: 0;
+      margin: 0;
+    }
+  }
 }


### PR DESCRIPTION
On mobile and tablet, the breadcrumb links and links inside the beta banner can be hard to click, because they are quite small.

This change increases their clickable area (whilst leaving their display the same).

Trello: https://trello.com/c/kSRKSoI2/326-review-styles-on-tablet-and-mobile-viewports-on-the-new-navigation-pages