### PR TITLE
Fall back to "en" locale for "en-GB"

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -30,6 +30,11 @@ class RootController < ApplicationController
   end
 
   def govuk_locales
+    # Smart Answers uses "en-GB" instead of "en". We don't have a specfic en-GB
+    # locale for the components. This will make return the English locale since
+    # it's a reasonable fallback.
+    params[:locale] = "en" if params[:locale] == "en-GB"
+
     return error_404 unless params[:locale].match(/^[a-z]{2}(-[a-z0-9]{2,3})?$/)
     locale_file_path = Rails.root.join("config", "locales", "#{params[:locale]}.yml")
     render_yaml_as_json(locale_file_path)


### PR DESCRIPTION
Smart answers uses a "en-GB" locale, but we don't have that in this app. This causes a lot of 404's to be returned and missing translations in smart answers (presumably).

Kibana reports about 3.3 million `404` on this route over the last 24 hours:

<img width="1341" alt="screen shot 2017-02-22 at 12 02 16" src="https://cloud.githubusercontent.com/assets/233676/23210732/ccb2b6ec-f8f6-11e6-8fcd-a4b97a648f58.png">

This is also caused by smart-answers cache being broken, which is fixed in https://github.com/alphagov/slimmer/pull/183.

https://trello.com/c/D9HmkJwI