### PR TITLE
Track values

### DIFF
--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -24,11 +24,16 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         var category = $el.attr('data-track-category'),
             action = $el.attr('data-track-action'),
             label = $el.attr('data-track-label'),
+            value = $el.attr('data-track-value'),
             dimension = $el.attr('data-track-dimension'),
             dimensionIndex = $el.attr('data-track-dimension-index');
 
         if (label) {
           options.label = label;
+        }
+
+        if (value) {
+          options.value = value;
         }
 
         if (dimension && dimensionIndex) {

--- a/spec/javascripts/modules/track-click.spec.js
+++ b/spec/javascripts/modules/track-click.spec.js
@@ -90,6 +90,28 @@ describe('A click tracker', function() {
     expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('category', 'action', {label: 'Foo', transport: 'beacon'});
   });
 
+  it('tracks clicks with values', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      '<a data-track-category="category" \
+          data-track-action="1" \
+          data-track-label="/" \
+          data-track-value="9" \
+          href="/">Home</a>'
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category',
+      '1',
+      { label: '/', value: '9', transport: 'beacon' }
+    );
+  });
+
   it('tracks all trackable links within a container', function() {
     spyOn(GOVUK.analytics, 'trackEvent');
 


### PR DESCRIPTION
This will pass an event value through to the trackers, where it is handled in [`govuk_frontend_toolkit`](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/google-analytics-universal-tracker.js#L78-L87)

This change is required to pass an event value when tracking navigation grid clicks.

Trello: https://trello.com/c/btaOSNax/426-track-position-of-clicks-in-the-new-taxon-grid-pages