### PR TITLE
Add analytics for user navigation journeys

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -95,6 +95,8 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
+    this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
+    this.setUserJourneyStage(dimensions['user-journey-stage']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -173,6 +175,14 @@
 
   StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
     this.setDimension(21, position);
+  };
+
+  StaticAnalytics.prototype.setNavigationPageTypeDimension = function(pageType) {
+    this.setDimension(32, pageType);
+  };
+
+  StaticAnalytics.prototype.setUserJourneyStage = function(pageType) {
+    this.setDimension(33, pageType);
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -62,6 +62,8 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
+          <meta name="govuk:navigation-page-type" content="accordion">\
+          <meta name="govuk:user-journey-stage" content="navigation">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -74,10 +76,11 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(universalSetupArguments[8]).toEqual(['set', 'dimension7', 'historic']);
         expect(universalSetupArguments[9]).toEqual(['set', 'dimension9', '<D10>']);
         expect(universalSetupArguments[10]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(universalSetupArguments[11]).toEqual(['set', 'dimension32', 'accordion']);
+        expect(universalSetupArguments[12]).toEqual(['set', 'dimension33', 'navigation']);
       });
 
       it('ignores meta tags not set', function() {
-
         $('head').append('<meta name="govuk:section" content="section">');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});


### PR DESCRIPTION
Add Google Analytics dimensions:
 - Whether a user is viewing a navigation or a content page, i.e. where they are in their journey through the site
 - What type of navigation page they visit, e.g. a taxon page or a mainstream browse page

Don't merge this until we have confirmation of the GA dimensions to use. I've temporarily set them to values outside of the GA range.

Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages