### PR TITLE
Touch-friendly links for breadcrumbs and phase banners

### DIFF
--- a/app/assets/stylesheets/govuk-component/_alpha-label.scss
+++ b/app/assets/stylesheets/govuk-component/_alpha-label.scss
@@ -1,3 +1,4 @@
 .govuk-alpha-label {
   @include phase-banner($state: alpha);
+  @include touch-friendly-links();
 }

--- a/app/assets/stylesheets/govuk-component/_beta-label.scss
+++ b/app/assets/stylesheets/govuk-component/_beta-label.scss
@@ -1,3 +1,4 @@
 .govuk-beta-label {
   @include phase-banner($state: beta);
+  @include touch-friendly-links();
 }

--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -9,6 +9,7 @@
   }
 
   @include breadcrumbs;
+  @include touch-friendly-links();
 
   .breadcrumb-for-current-page {
     color: $secondary-text-colour;

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -5,6 +5,7 @@
 
 // Component mixins
 @import "mixins/margins";
+@import "mixins/touch-friendly-links";
 
 // Components styles
 @import "alpha-label";

--- a/app/assets/stylesheets/govuk-component/mixins/_touch-friendly-links.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_touch-friendly-links.scss
@@ -1,0 +1,10 @@
+// This mixin will expand the clickable area for a link to make it easier to click on a touch-enabled
+// device.
+
+@mixin touch-friendly-links($padding: 3px) {
+  a {
+    padding: $padding;
+    margin: -1 * $padding;
+    outline-color: transparent;
+  }
+}


### PR DESCRIPTION
This change is to (slightly) improve the user experience when using the breadcrumb and phase banner links on a touch-enabled device. To do this, we make the touchable area larger.

See the screenshot below for an idea of the change. The blue area is the area that was originally clickable, but now you can also click the green area.

![breadcrumb-padding](https://cloud.githubusercontent.com/assets/12036746/23308799/40274ef4-faa4-11e6-9411-1b47b69e4892.png)

The clickable area has currently been enlarged just `3px` to match the orange `focus` outline. Ideally we would make this area even larger (I've heard numbers around 40px x 40px minimum thrown around before), but you start running into problems with clickable elements overlapping one another - for example when breadcrumbs wrap onto a second line. This particular problem should eventually be solved by [reducing breadcrumbs to a single entry on mobile](https://github.com/alphagov/govuk-content-navigation/pull/122).

For further context and discussion, see the [previous Pull Request in `govuk_frontend_toolkit`](https://github.com/alphagov/govuk_frontend_toolkit/pull/384#issuecomment-282310558).

### Trello

https://trello.com/c/kSRKSoI2/326-review-styles-on-tablet-and-mobile-viewports-on-the-new-navigation-pages