### PR TITLE
[Discuss] Limit line length when printing content

### DIFF
--- a/app/assets/stylesheets/helpers/_print-base.scss
+++ b/app/assets/stylesheets/helpers/_print-base.scss
@@ -1,5 +1,9 @@
 /* Global print stylesheet */
 
+main {
+  max-width: 36em;
+}
+
 a {
   text-decoration: none;
 }


### PR DESCRIPTION
On pages that use header and footer only, text in paragraphs spread all across the page, making content hard to read when printed.

On core layouts we limit this to 80%. This doesn’t take into account the printed text size, the size of the paper or the orientation (eg line length still bad in landscape, or very short on envelope sizes)

* Use em so that line length is always appropriate
* Use max-width so it’s never longer than the width of the page
* Apply to the main element to constrain all content

This has some negative affects:
* Printing uses more paper 🌲 
* Tables don't spread full width and complex tables don't print nicely

Looking at this as part of https://trello.com/c/MluRcP1W/. Printed foreign travel advice is currently limited to 80% width, other government-frontend documents aren't.

The most printed pages are mainstream content, which is 80% width. This is the most printed page: https://www.gov.uk/national-minimum-wage-rates

## Screenshots

|Feature|Old|New|
|--|--|--|
|Consultation A4 portrait|![screen shot 2017-02-27 at 11 17 04](https://cloud.githubusercontent.com/assets/319055/23359523/7897e050-fcde-11e6-97ea-c567138b6a0d.png)|![screen shot 2017-02-27 at 11 17 15](https://cloud.githubusercontent.com/assets/319055/23359526/7f1a92ce-fcde-11e6-82c3-62f9658e7c5a.png)|
|HTML publication A4 portrait|![screen shot 2017-02-27 at 11 20 07](https://cloud.githubusercontent.com/assets/319055/23359593/d686bb8c-fcde-11e6-9d6a-33235cfcd85e.png)|![screen shot 2017-02-27 at 11 20 39](https://cloud.githubusercontent.com/assets/319055/23359597/dc39f6d4-fcde-11e6-8486-09b35b6fcf6e.png)
|HTML publication A4 landscape|![screen shot 2017-02-27 at 11 22 31](https://cloud.githubusercontent.com/assets/319055/23359654/1e7c3a02-fcdf-11e6-96ce-a05fa6abb206.png)|![screen shot 2017-02-27 at 11 22 45](https://cloud.githubusercontent.com/assets/319055/23359657/23a52eee-fcdf-11e6-9762-68b8621f0816.png)|
|Case study A5 portrait|![screen shot 2017-02-27 at 11 27 18](https://cloud.githubusercontent.com/assets/319055/23359774/c8efe380-fcdf-11e6-8c08-ce5366941abe.png)|![screen shot 2017-02-27 at 11 27 32](https://cloud.githubusercontent.com/assets/319055/23359784/d5a84ef0-fcdf-11e6-9804-cb581464bfcb.png)|
|[HTML publication with tables (second most printed government document)](https://www.gov.uk/government/publications/tax-and-tax-credit-rates-and-thresholds-for-2017-18/tax-and-tax-credit-rates-and-thresholds-for-2017-18)|![screen shot 2017-02-27 at 11 32 52](https://cloud.githubusercontent.com/assets/319055/23359929/8dba1cbc-fce0-11e6-8dd1-c131681551ea.png)|![screen shot 2017-02-27 at 11 33 12](https://cloud.githubusercontent.com/assets/319055/23359933/9020f2dc-fce0-11e6-8ad7-fab3823e6c1f.png)|

cc @robinwhittleton @nickcolley @markhurrell 