### PR TITLE
Add DiT organisation

### DIFF
--- a/app/assets/stylesheets/govuk-component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk-component/_organisation-logo.scss
@@ -95,6 +95,10 @@
     }
   }
 
+  .crest-dit {
+    @include crest('dit_crest');
+  }
+
   .crest-bis {
     @include crest('bis_crest');
   }

--- a/app/views/govuk_component/docs/organisation_logo.yml
+++ b/app/views/govuk_component/docs/organisation_logo.yml
@@ -27,6 +27,12 @@ fixtures:
       url: '/government/organisations/department-for-business-innovation-skills'
       brand: 'department-for-business-innovation-skills'
       crest: 'bis'
+  department_for_international_trade:
+    organisation:
+      name: 'Department for<br>International Trade'
+      url: '/government/organisations/department-for-international-trade'
+      brand: 'department-for-international-trade'
+      crest: 'dit'
   executive_office:
     organisation:
       name: Prime Minister's Office, 10 Downing Street


### PR DESCRIPTION
- Adds the support for the dit crest
- Adds fixture to show the example in the Component Guide

To test:

1. Check this branch out
2. Run `./startup.sh`
3. Check https://github.com/alphagov/govuk-component-guide out
4. Run `PLEK_SERVICE_STATIC_URI=http://static.dev.gov.uk ./startup.sh`
5. Visit `http://x.x.x.x:3113/components/organisation_logo/fixtures/department_for_international_trade` where `x.x.x.x` is replaced with your VM or local machines' IP address
6. Check https://github.com/alphagov/government-frontend out
7. Run `PLEK_SERVICE_CONTENT_STORE_URI=https://www.gov.uk/api PLEK_SERVICE_STATIC_URI=http://static.dev.gov.uk ./startup.sh`
8. Visit `http://government-frontend.dev.gov.uk/government/publications/why-overseas-companies-should-set-up-in-the-uk/why-overseas-companies-should-set-up-in-the-uk`

Before:

![screen shot 2017-02-27 at 13 56 21](https://cloud.githubusercontent.com/assets/2445413/23363885/aeb4499c-fcf4-11e6-99a5-23594aa5520a.png)

After:

![screen shot 2017-02-27 at 13 57 14](https://cloud.githubusercontent.com/assets/2445413/23363886/aeb47192-fcf4-11e6-9d5b-d170a5a7da6b.png)

![screen shot 2017-02-27 at 13 56 17](https://cloud.githubusercontent.com/assets/2445413/23363884/aeb41a6c-fcf4-11e6-9312-cef3ac9f1e5a.png)

---

I've noticed our organisation logos are rendering very blurry, at least on my machine. I think this is due to our use of `background-size` being a pixel off, so will raise a separate issue for that.