### PR TITLE
Don't open print links in a new window

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -1,6 +1,4 @@
 $(document).ready(function() {
-  $('.print-link a').attr('target', '_blank');
-
   var $searchFocus = $('.js-search-focus');
   $searchFocus.each(function(i, el){
     if($(el).val() !== ''){


### PR DESCRIPTION
Print links should use target attribute not JS if they want to open in a new window

* Target _blank has a vulnerability:
https://mathiasbynens.github.io/rel-noopener/ and
https://github.com/alphagov/whitehall/issues/2942
* Links don’t need to be in a new window