### PR TITLE
Display related links in taxonomy sidebar

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -4,31 +4,42 @@
 
   h2 {
     @include bold-24;
-    margin-top: 0.3em;
-    margin-bottom: 0.5em;
+    margin: 0;
+  }
+
+  p {
+    @include core-19;
+    margin-top: $gutter-one-third / 2;
+    margin-bottom: $gutter-two-thirds;
   }
 
   ul {
-    // reset the default browser styles
-    padding: 0;
     margin: 0;
+    padding: 0;
+  }
 
+  .sidebar-taxon {
     @include core-16;
-    list-style: none;
-    margin-bottom: 1.25em;
+    padding-bottom: 1.25em;
 
-    li {
-      // reset the default browser styles
-      padding: 0;
+    .taxon-link {
+      font-size: 19px;
+    }
+  }
 
-      margin-bottom: 0.75em;
+  .related-content {
+    line-height: 1.5;
 
-      .taxon-link {
-        font-size: 19px;
-      }
+    .related-content-item {
+      margin-bottom: 0;
+    }
 
-      .taxon-description {
-        margin-top: 0.5em;
+    .related-link {
+      text-decoration: none;
+
+      &:hover,
+      &:focus {
+        text-decoration: underline;
       }
     }
   }

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -1,19 +1,31 @@
 name: "Taxonomy sidebar"
 description: "Sidebar navigation for displaying on pages tagged to the GOV.UK taxonomy."
 body: |
-  Accepts an array of sections. Each section can have a title and a list of
-  items - these items are typically the list of taxons the current content page
-  is tagged to.
+  Accepts an array of items. These items are typically the list of taxons the current
+  content page is tagged to.
 
-  Each item is a hash with a title, url, and description.
+  Each item is a hash with a title, url, description, and list of related content
+  associated with that item.
 fixtures:
   default:
-    sections:
-      - title: "Parent taxons"
-        items:
-          - title: "School curriculum"
-            url: /education/school-curriculum
-          - title: "Tests (key stage 1)"
-            url: /key-stage-1-tests
+    items:
+      - title: "School curriculum"
+        url: /education/school-curriculum
+        description: |
+          Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+          exams and assessments, PSHE and SMSC.
+        related_content:
+          - title: "The national curriculum"
+            link: /national-curriculum
+      - title: "Tests (key stage 1)"
+        url: /key-stage-1-tests
+        description: |
+          Key dates, sample and test materials, administration, moderation,
+          assessing and reporting, statistics, frameworks.
+        related_content:
+          - title: "Key stage 1 teacher assessment"
+            link: /government/collections/key-stage-1-teacher-assessment
+          - title: "Primary assessments: information and resources for 2017"
+            link: /government/publications/primary-assessments-information-and-resources-for-2017
 
 

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,33 +1,58 @@
-<% if local_assigns[:sections] && !sections.blank? %>
+<% if local_assigns[:items] && !items.blank? %>
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
-    <% sections.each_with_index do |section, section_index| %>
+    <% items.each_with_index do |item, item_index| %>
 
-      <h2> <%= section[:title] %> </h2>
+      <div class="sidebar-taxon">
+        <h2>More about <%= item[:title] %></h2>
 
-      <nav role='navigation'>
-        <ul>
-          <% section[:items].each_with_index do |item, item_index| %>
-            <li>
-              <%=
-                link_to(
-                  item[:title],
-                  item[:url],
-                  data: {
+        <p>
+          <%= item[:description] %>
+        </p>
+
+        <% item[:related_content] ||= [] %>
+        <% if item[:related_content].any? %>
+          <nav role='navigation'>
+            <ul class="related-content">
+              <% item[:related_content].each_with_index do |related_item, related_content_index| %>
+                <li class="related-content-item">
+                  <%=
+                    link_to(
+                      related_item[:title],
+                      related_item[:link],
+                      data: {
+                          track_category: 'relatedLinkClicked',
+                          track_action: "#{item_index + 1}.#{related_content_index + 1}",
+                          track_label: related_item[:link],
+                          track_dimension: related_item[:title],
+                          track_dimension_index: 29,
+                      },
+                      class: 'related-link',
+                    )
+                  %>
+                </li>
+              <% end %>
+            </ul>
+          </nav>
+        <% end %>
+
+        <p>
+          <%=
+            link_to(
+                "See everything in #{item[:title]}",
+                item[:url],
+                data: {
                     track_category: 'relatedLinkClicked',
-                    track_action: "#{section_index + 1}.#{item_index + 1}",
+                    track_action: "#{item_index + 1}.#{item[:related_content].length + 1}",
                     track_label: item[:url],
                     track_dimension: item[:title],
                     track_dimension_index: 29,
-                  },
-                  class: 'taxon-link',
-                )
-              %>
+                },
+                class: 'taxon-link',
+            )
+          %>
+        </p>
+      </div>
 
-              <p class='taxon-description'><%= item[:description] %></p>
-            </li>
-          <% end %>
-        </ul>
-      </nav>
     <% end %>
   </aside>
 <% end %>

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -11,55 +11,103 @@ class TaxonomySidebarTestCase < ComponentTestCase
     end
   end
 
-  test "renders a related items block" do
+  test "renders a taxonomy sidebar" do
     render_component(
-      sections: [
+      items: [
         {
-          title: "Section title",
-          items: [
+          title: "Item title",
+          url: "/item",
+          description: "An item",
+        },
+        {
+          title: "Other item title",
+          url: "/other-item",
+          description: "Another item",
+        },
+      ]
+    )
+
+    assert_select ".govuk-taxonomy-sidebar > :nth-of-type(1) h2", text: "More about Item title"
+    assert_link_with_text_in(".govuk-taxonomy-sidebar > :nth-of-type(1)", "/item", "See everything in Item title")
+    assert_select(".govuk-taxonomy-sidebar > :nth-of-type(1) p", "An item")
+
+    assert_select ".govuk-taxonomy-sidebar > :nth-of-type(2) h2", text: "More about Other item title"
+    assert_link_with_text_in(".govuk-taxonomy-sidebar > :nth-of-type(2)", "/other-item", "See everything in Other item title")
+    assert_select(".govuk-taxonomy-sidebar > :nth-of-type(2) p", "Another item")
+  end
+
+  test "renders related content for taxons" do
+    render_component(
+      items: [
+        {
+          title: "Item title",
+          url: "/item",
+          description: "An item",
+          related_content: [
             {
-              title: "Item title",
-              url: "/item",
-              description: "An item",
+              title: "Related link 1",
+              link: "/related-link-1",
             },
             {
-              title: "Other item title",
-              url: "/other-item",
-              description: "Another item",
-            }
-          ]
-        }
+              title: "Related link 2",
+              link: "/related-link-2",
+            },
+          ],
+        },
+        {
+          title: "Other item title",
+          url: "/other-item",
+          description: "Another item",
+          related_content: [
+            {
+              title: "Related link 3",
+              link: "/related-link-3",
+            },
+          ],
+        },
       ],
     )
 
-    assert_select "h2", text: "Section title"
-    assert_link_with_text_in("ul li:first-child", "/item", "Item title")
-    assert_select("ul li:first-child p", "An item")
-    assert_link_with_text_in("ul li:first-child + li", "/other-item", "Other item title")
-    assert_select("ul li:first-child + li p", "Another item")
+    assert_link_with_text_in(".related-content-item", "/related-link-1", "Related link 1")
+    assert_link_with_text_in(".related-content-item", "/related-link-2", "Related link 2")
+    assert_link_with_text_in(".related-content-item", "/related-link-3", "Related link 3")
   end
 
   test "renders all data attributes for tracking" do
     render_component(
-      sections: [
+      items: [
         {
-          title: "Section title",
-          items: [
+          title: "Item title",
+          url: "/item",
+          description: "An item",
+          related_content: [
             {
-              title: "Item title",
-              url: "/item",
-              description: "An item",
+              title: "Related link 1",
+              link: "/related-link-1",
             },
-          ]
-        }
-      ],
+            {
+              title: "Related link 2",
+              link: "/related-link-2",
+            },
+          ],
+        },
+      ]
     )
 
     assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
-    assert_select "a[data-track-category=\"relatedLinkClicked\"]", 1
-    assert_select "a[data-track-dimension=\"Item title\"]", 1
-    assert_select "a[data-track-dimension-index=\"29\"]", 1
+    assert_select "a[data-track-category=\"relatedLinkClicked\"]", 3
+    assert_select "a[data-track-dimension-index=\"29\"]", 3
+
+    assert_select "a[data-track-dimension=\"Related link 1\"]", 1
     assert_select "a[data-track-action=\"1.1\"]", 1
+    assert_select "a[data-track-label=\"/related-link-1\"]", 1
+
+    assert_select "a[data-track-dimension=\"Related link 2\"]", 1
+    assert_select "a[data-track-action=\"1.2\"]", 1
+    assert_select "a[data-track-label=\"/related-link-2\"]", 1
+
+    assert_select "a[data-track-dimension=\"Item title\"]", 1
+    assert_select "a[data-track-action=\"1.3\"]", 1
     assert_select "a[data-track-label=\"/item\"]", 1
   end
 end


### PR DESCRIPTION
This change updates the taxonomy sidebar to accept a list of related content items under each taxon, and updates the styling to match the latest designs.

This is a **breaking change** which will align the API to the slimmed-down version in [this update to `govuk_navigation_helpers`](https://github.com/alphagov/govuk_navigation_helpers/pull/44). Since taxonomy display is still in alpha, and this is a novel component being used only by the navigation team this breakage is assumed to be acceptable.

# Screenshots

## Before

![sidebar-before](https://cloud.githubusercontent.com/assets/12036746/23406678/0ea72fae-fdb8-11e6-9e3a-1ad35ff08576.png)

## After

![sidebar-after](https://cloud.githubusercontent.com/assets/12036746/23406684/1500c234-fdb8-11e6-9b05-cb7b9596d030.png)

# Trello

https://trello.com/c/EJXC60k1/429-add-more-like-this-results-to-side-navigation-in-frontend-apps