### PR TITLE
Add a default value for the `user-journey-stage` dimension

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -93,6 +93,7 @@
       dimensions[key] = value;
     });
 
+    this.setUserJourneyStage(dimensions['user-journey-stage']);
     this.setSectionDimension(dimensions['section']);
     this.setFormatDimension(dimensions['format']);
     this.setResultCountDimension(dimensions['search-result-count']);
@@ -102,7 +103,6 @@
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
-    this.setUserJourneyStage(dimensions['user-journey-stage']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -187,8 +187,11 @@
     this.setDimension(32, pageType);
   };
 
-  StaticAnalytics.prototype.setUserJourneyStage = function(pageType) {
-    this.setDimension(33, pageType);
+  StaticAnalytics.prototype.setUserJourneyStage = function(journeyStage) {
+    // Track the stage of a user's journey through GOV.UK. If the page does not
+    // set a page type in a meta tag, default to "thing", which identifes a page
+    // as containing content rather than some kind of navigation.
+    this.setDimension(33, journeyStage || "thing");
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -44,6 +44,9 @@ describe("GOVUK.StaticAnalytics", function() {
     });
 
     describe('when there are govuk: meta tags', function() {
+      // The number of setup arguments which are set before the dimensions
+      const expectedDefaultArgumentCount = 5;
+
       beforeEach(function() {
         window.ga.calls.reset();
       });
@@ -67,27 +70,27 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
+        setupArguments = dimensionSetupArguments();
 
-        expect(universalSetupArguments[5]).toEqual(['set', 'dimension1', 'section']);
-        expect(universalSetupArguments[6]).toEqual(['set', 'dimension2', 'format']);
-        expect(universalSetupArguments[7]).toEqual(['set', 'dimension5', '1000']);
-        expect(universalSetupArguments[8]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
-        expect(universalSetupArguments[9]).toEqual(['set', 'dimension7', 'historic']);
-        expect(universalSetupArguments[10]).toEqual(['set', 'dimension9', '<D10>']);
-        expect(universalSetupArguments[11]).toEqual(['set', 'dimension10', '<W1>']);
-        expect(universalSetupArguments[12]).toEqual(['set', 'dimension32', 'accordion']);
-        expect(universalSetupArguments[13]).toEqual(['set', 'dimension33', 'navigation']);
+        expect(setupArguments[0]).toEqual(['set', 'dimension1', 'section']);
+        expect(setupArguments[1]).toEqual(['set', 'dimension2', 'format']);
+        expect(setupArguments[2]).toEqual(['set', 'dimension5', '1000']);
+        expect(setupArguments[3]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
+        expect(setupArguments[4]).toEqual(['set', 'dimension7', 'historic']);
+        expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
+        expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(setupArguments[7]).toEqual(['set', 'dimension32', 'accordion']);
+        expect(setupArguments[8]).toEqual(['set', 'dimension33', 'navigation']);
       });
 
       it('ignores meta tags not set', function() {
         $('head').append('<meta name="govuk:section" content="section">');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
+        setupArguments = dimensionSetupArguments();
 
-        expect(universalSetupArguments[5]).toEqual(['set', 'dimension1', 'section']);
-        assertClosingArgumentIsAtIndex(universalSetupArguments, 6);
+        expect(setupArguments.length).toEqual(1);
+        expect(setupArguments[0]).toEqual(['set', 'dimension1', 'section']);
       });
 
       it('sets A/B meta tags as dimensions', function() {
@@ -97,10 +100,10 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
+        setupArguments = dimensionSetupArguments();
 
-        expect(universalSetupArguments[5]).toEqual(['set', 'dimension42', 'name-of-test:name-of-ab-bucket']);
-        expect(universalSetupArguments[6]).toEqual(['set', 'dimension48', 'name-of-other-test:name-of-other-ab-bucket']);
+        expect(setupArguments[0]).toEqual(['set', 'dimension42', 'name-of-test:name-of-ab-bucket']);
+        expect(setupArguments[1]).toEqual(['set', 'dimension48', 'name-of-other-test:name-of-other-ab-bucket']);
       });
 
       it('ignores dimensions outside of the A/B test range', function () {
@@ -112,11 +115,11 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
+        setupArguments = dimensionSetupArguments();
 
-        expect(universalSetupArguments[5]).toEqual(['set', 'dimension40', 'name-of-valid-test:some-bucket']);
-        expect(universalSetupArguments[6]).toEqual(['set', 'dimension49', 'name-of-other-valid-test:some-bucket']);
-        assertClosingArgumentIsAtIndex(universalSetupArguments, 7);
+        expect(setupArguments.length).toEqual(2);
+        expect(setupArguments[0]).toEqual(['set', 'dimension40', 'name-of-valid-test:some-bucket']);
+        expect(setupArguments[1]).toEqual(['set', 'dimension49', 'name-of-other-valid-test:some-bucket']);
       });
 
       it('ignores A/B meta tags with invalid dimensions', function () {
@@ -126,13 +129,14 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        universalSetupArguments = window.ga.calls.allArgs();
+        setupArguments = dimensionSetupArguments();
 
-        assertClosingArgumentIsAtIndex(universalSetupArguments, 5);
+        expect(setupArguments.length).toEqual(0);
       });
 
-      function assertClosingArgumentIsAtIndex(setupArgs, argIndex) {
-        expect(setupArgs[argIndex]).toEqual(['send', 'pageview']);
+      function dimensionSetupArguments() {
+        // Remove the default calls to the analytics object
+        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1);
       }
     });
   });

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -32,7 +32,7 @@ describe("GOVUK.StaticAnalytics", function() {
     });
 
     it('tracks a pageview in universal', function() {
-      expect(universalSetupArguments[5]).toEqual(['send', 'pageview']);
+      expect(universalSetupArguments[6]).toEqual(['send', 'pageview']);
     });
 
     it('begins print tracking', function() {
@@ -45,7 +45,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
     describe('when there are govuk: meta tags', function() {
       // The number of setup arguments which are set before the dimensions
-      const expectedDefaultArgumentCount = 5;
+      const expectedDefaultArgumentCount = 6;
 
       beforeEach(function() {
         window.ga.calls.reset();
@@ -56,7 +56,6 @@ describe("GOVUK.StaticAnalytics", function() {
       });
 
       it('sets them as dimensions', function() {
-
         $('head').append('\
           <meta name="govuk:section" content="section">\
           <meta name="govuk:format" content="format">\
@@ -66,7 +65,6 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
           <meta name="govuk:navigation-page-type" content="accordion">\
-          <meta name="govuk:user-journey-stage" content="navigation">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -80,7 +78,6 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
         expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
         expect(setupArguments[7]).toEqual(['set', 'dimension32', 'accordion']);
-        expect(setupArguments[8]).toEqual(['set', 'dimension33', 'navigation']);
       });
 
       it('ignores meta tags not set', function() {
@@ -132,6 +129,25 @@ describe("GOVUK.StaticAnalytics", function() {
         setupArguments = dimensionSetupArguments();
 
         expect(setupArguments.length).toEqual(0);
+      });
+
+      it('sets the user journey stage dimension from a meta tag if present', function () {
+        $('head').append('\
+          <meta name="govuk:user-journey-stage" content="some-user-journey-stage">\
+        ');
+
+        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+        setupArguments = window.ga.calls.allArgs();
+
+        expect(setupArguments[5]).toEqual(['set', 'dimension33', 'some-user-journey-stage']);
+      });
+
+      it('sets the default dimension if no user journey stage meta tag is present', function () {
+        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+        setupArguments = window.ga.calls.allArgs();
+        var defaultUserJourneyStage = 'thing';
+
+        expect(setupArguments[5]).toEqual(['set', 'dimension33', defaultUserJourneyStage]);
       });
 
       function dimensionSetupArguments() {


### PR DESCRIPTION
Probably easiest to review as individual commits:

- Refactor test of analytics dimensions.
- Add a default value for the `user-journey-stage` dimension. Pages which show navigation rather than content will add the meta tag for this dimension. All other pages should be tracked as 'thing', which identifies pages as containing content rather than navigation.

Marked as DO NOT MERGE until the meta tag has been added to all the navigation page types. Full list in Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages