### PR TITLE
Fix regression: Don't style strong text as bold unless using rich govspeak

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -19,10 +19,4 @@
     direction: rtl;
     text-align: start;
   }
-
-  &.rich-govspeak {
-    strong {
-      font-weight: bold;
-    }
-  }
 }

--- a/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
@@ -186,6 +186,18 @@
 
   // Text styles
 
+  strong {
+    font-weight: 400;
+  }
+
+  // rich-govspeak is a modifier for the govspeak component
+  // that allows bold text. Used by the highway code manual.
+  &.rich-govspeak {
+    strong {
+      font-weight: bold;
+    }
+  }
+
   em,
   i {
     font-style: normal;

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -237,10 +237,13 @@ fixtures:
         <li>تابعنا باللغة العربية عبر</li>
         <li>تابعنا باللغة العربية عبر تويتر </li>
       </ul>
+  with_bold_unstyled:
+    content: |
+      <p>This content has <strong>text in strong tags</strong>, but they are not styled as bold</p>
   with_rich_govspeak:
     rich_govspeak: true
     content: |
-      <p>This content has some <strong>rich govspeak</strong></p>
+      <p>This content uses rich govspeak and has <strong>text in strong tags</strong> that are styled as bold</p>
   with_youtube_embed:
     content: |
       <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>


### PR DESCRIPTION
We don’t style bold text in markdown except for specific places where rich-govspeak is enabled (eg the highway code manual), see https://github.com/alphagov/static/pull/657

If an app uses `core-layout` then it uses a reset that styles strong as bold. See: https://github.com/alphagov/static/pull/483. Any app using core-layout and the govspeak component would render the `strong` text in bold. This is a regression that has gradually affected a greater proportion of content as we have migrated.

Whitehall did not set `strong` styles, so bold was not used in content.

[Our style guide says](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bold):
> __bold__
> Don’t use bold. It can distract the user and it makes the text longer and more confusing for users of screen readers. Use headings or bullets instead if you want to emphasise particular words or sections.

This PR means we are:
* being explicit about strong being rendered as normal text
* continuing to whitelist rich-govspeak use
* letting these rules work with whatever flavour of reset an app has

Other reading on our approach to bold:
https://gdsengagement.blog.gov.uk/2016/11/28/how-to-make-blog-posts-accessible/
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#bold
https://www.gov.uk/design-principles/accessiblepdfs#use-headings

We correctly omit bold from our markdown guidance here:
https://www.gov.uk/guidance/how-to-publish-on-gov-uk/markdown

![screen shot 2017-03-02 at 12 00 07](https://cloud.githubusercontent.com/assets/319055/23506410/0b9a89e4-ff40-11e6-987f-a66e762958b2.png)

cc @markhurrell