### PR TITLE
Use the correct cookie name for the TLS version cookie set by the CDN

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -36,7 +36,7 @@
     }
 
     function setTLSVersionDimension() {
-      var tls_version = GOVUK.cookie('TLSVersion') || 'unknown';
+      var tls_version = GOVUK.cookie('TLSversion') || 'unknown';
       analytics.setDimension(16, tls_version);
     }
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -137,9 +137,9 @@ describe("GOVUK.StaticAnalytics", function() {
     });
   });
 
-  describe('when there is a TLSVersion cookie', function() {
+  describe('when there is a TLSversion cookie', function() {
     beforeEach(function() {
-      GOVUK.cookie('TLSVersion', '2');
+      GOVUK.cookie('TLSversion', '2');
       window.ga.calls.reset();
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
       universalSetupArguments = window.ga.calls.allArgs();
@@ -149,9 +149,9 @@ describe("GOVUK.StaticAnalytics", function() {
     });
   });
 
-  describe('when there is no TLSVersion cookie', function() {
+  describe('when there is no TLSversion cookie', function() {
     beforeEach(function() {
-      GOVUK.cookie('TLSVersion', null);
+      GOVUK.cookie('TLSversion', null);
       window.ga.calls.reset();
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
       universalSetupArguments = window.ga.calls.allArgs();


### PR DESCRIPTION
The CDN sets [a cookie called `TLSversion`](https://github.com/alphagov/govuk-cdn-config/blob/f42d9db9f361dd434dfb782c0377ec55fc48495c/vcl_templates/www.vcl.erb#L331) not `TLSVersion`. :man_facepalming: 

Only found this out after deploying to staging to test on an environment that has a CDN.