### PR TITLE
Add `user-journey-stage` analytics meta tag

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -29,6 +29,9 @@
     meta_tags["govuk:publishing-government"] = details_hash[:government][:slug]
   end
 
+  user_journey_stage = content_item_hash[:user_journey_document_supertype]
+  meta_tags["govuk:user-journey-stage"] = user_journey_stage if user_journey_stage
+
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -84,6 +84,11 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     assert_empty render_component(content_item: { details: { political: true } })
   end
 
+  test "renders user journey stage when user journey supertype is included" do
+    render_component(content_item: { user_journey_document_supertype: 'some-stage-of-journey' })
+    assert_meta_tag('govuk:user-journey-stage', 'some-stage-of-journey')
+  end
+
   test "renders 'political' political status when political content and government is current" do
     current = true
     political = true


### PR DESCRIPTION
Add meta tag which identifies the page as being primarily concerned with content or navigation. This will be converted to an analytics dimension by the analytics JavaScript, and will help us analyse users' journeys through the site.

Trello: https://trello.com/c/SCsj2A9D/425-add-custom-dimension-to-page-view-tracking-on-new-navigation-pages