### PR TITLE
Design updates to taxonomy sidebar component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,46 +1,41 @@
 .govuk-taxonomy-sidebar {
   border-top: 10px solid $mainstream-brand;
-  padding-top: 5px;
-
-  h2 {
-    @include bold-24;
-    margin: 0;
-  }
-
-  p {
-    @include core-19;
-    margin-top: $gutter-one-third / 2;
-    margin-bottom: $gutter-two-thirds;
-  }
-
-  ul {
-    margin: 0;
-    padding: 0;
-  }
+  @include core-16;
 
   .sidebar-taxon {
-    @include core-16;
-    padding-bottom: 1.25em;
+    padding-top: 1.25em;
 
-    .taxon-link {
-      font-size: 19px;
+    h2 {
+      @include bold-24;
+      margin: 0 0 5px;
+
+      a {
+        text-decoration: none;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
     }
-  }
 
-  .related-content {
-    line-height: 1.5;
-
-    .related-content-item {
-      margin-bottom: 0;
+    .taxon-description {
+      font-size: 16px;
+      margin: 0;
     }
 
-    .related-link {
-      text-decoration: none;
+    .related-content {
+      margin: 0 0 0 15px;
+      padding: 0;
+      list-style-type: none;
+      line-height: 1.5;
 
-      &:hover,
-      &:focus {
-        text-decoration: underline;
+      a:before {
+        content: "•";
+        display: inline-block;
+        width: 15px;
+        margin-left: -15px;
       }
     }
   }
+
 }

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -2,19 +2,21 @@
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
     <% items.each_with_index do |item, item_index| %>
 
-      <div class="sidebar-taxon">
-        <h2>More about <%= item[:title] %></h2>
+      <div class='sidebar-taxon'>
+        <h2>
+          <%= link_to item[:title], item[:url], class: 'taxon-link' %>
+        </h2>
 
-        <p>
+        <p class='taxon-description'>
           <%= item[:description] %>
         </p>
 
         <% item[:related_content] ||= [] %>
         <% if item[:related_content].any? %>
           <nav role='navigation'>
-            <ul class="related-content">
+            <ul class='related-content'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>
-                <li class="related-content-item">
+                <li>
                   <%=
                     link_to(
                       related_item[:title],
@@ -34,23 +36,6 @@
             </ul>
           </nav>
         <% end %>
-
-        <p>
-          <%=
-            link_to(
-                "See everything in #{item[:title]}",
-                item[:url],
-                data: {
-                    track_category: 'relatedLinkClicked',
-                    track_action: "#{item_index + 1}.#{item[:related_content].length + 1}",
-                    track_label: item[:url],
-                    track_dimension: item[:title],
-                    track_dimension_index: 29,
-                },
-                class: 'taxon-link',
-            )
-          %>
-        </p>
       </div>
 
     <% end %>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -4,7 +4,20 @@
 
       <div class='sidebar-taxon'>
         <h2>
-          <%= link_to item[:title], item[:url], class: 'taxon-link' %>
+          <%=
+            link_to(
+              item[:title],
+              item[:url],
+              class: 'taxon-link',
+              data: {
+                track_category: 'relatedLinkClicked',
+                track_action: "#{item_index + 1}",
+                track_label: item[:url],
+                track_dimension: item[:title],
+                track_dimension_index: 29,
+              },
+            )
+          %>
         </h2>
 
         <p class='taxon-description'>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:items] && !items.blank? %>
+
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
     <% items.each_with_index do |item, item_index| %>
-
       <div class='sidebar-taxon'>
         <h2>
           <%=
@@ -25,7 +25,7 @@
         </p>
 
         <% item[:related_content] ||= [] %>
-        <% if item[:related_content].any? %>
+        <% if item[:related_content].any? && item_index < 2 %>
           <nav role='navigation'>
             <ul class='related-content'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>
@@ -50,7 +50,7 @@
           </nav>
         <% end %>
       </div>
-
     <% end %>
   </aside>
+
 <% end %>

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -15,62 +15,67 @@ class TaxonomySidebarTestCase < ComponentTestCase
     render_component(
       items: [
         {
-          title: "Item title",
-          url: "/item",
-          description: "An item",
+          title: "Item 1 title",
+          url: "/item-1",
+          description: "item 1",
         },
         {
-          title: "Other item title",
-          url: "/other-item",
-          description: "Another item",
+          title: "Item 2 title",
+          url: "/item-2",
+          description: "item 2",
         },
       ]
     )
 
-    assert_select ".govuk-taxonomy-sidebar > :nth-of-type(1) h2", text: "More about Item title"
-    assert_link_with_text_in(".govuk-taxonomy-sidebar > :nth-of-type(1)", "/item", "See everything in Item title")
-    assert_select(".govuk-taxonomy-sidebar > :nth-of-type(1) p", "An item")
-
-    assert_select ".govuk-taxonomy-sidebar > :nth-of-type(2) h2", text: "More about Other item title"
-    assert_link_with_text_in(".govuk-taxonomy-sidebar > :nth-of-type(2)", "/other-item", "See everything in Other item title")
-    assert_select(".govuk-taxonomy-sidebar > :nth-of-type(2) p", "Another item")
+    taxon_titles = css_select(".sidebar-taxon h2").map { |taxon_title| taxon_title.text.strip }
+    taxon_titles = ["Item 1 title", "Item 2 title"]
   end
 
-  test "renders related content for taxons" do
+  test "renders related content for the first two taxons" do
     render_component(
       items: [
         {
-          title: "Item title",
-          url: "/item",
-          description: "An item",
+          title: "Item 1 title",
+          url: "/item-1",
+          description: "item 1",
           related_content: [
             {
-              title: "Related link 1",
-              link: "/related-link-1",
+              title: "Related link B",
+              link: "/related-link-b",
             },
             {
-              title: "Related link 2",
-              link: "/related-link-2",
+              title: "Related link A",
+              link: "/related-link-a",
             },
           ],
         },
         {
-          title: "Other item title",
-          url: "/other-item",
-          description: "Another item",
+          title: "Item 2 title",
+          url: "/item-2",
+          description: "item 2",
           related_content: [
             {
-              title: "Related link 3",
-              link: "/related-link-3",
+              title: "Related link C",
+              link: "/related-link-c",
             },
           ],
         },
+        {
+          title: "Item 3 title",
+          url: "/item-3",
+          description: "item 3",
+          related_content: [
+            {
+              title: "Related link D",
+              link: "/related-link-d",
+            },
+          ],
+        }
       ],
     )
 
-    assert_link_with_text_in(".related-content-item", "/related-link-1", "Related link 1")
-    assert_link_with_text_in(".related-content-item", "/related-link-2", "Related link 2")
-    assert_link_with_text_in(".related-content-item", "/related-link-3", "Related link 3")
+    related_links = css_select(".related-content a").map { |link| link.text }
+    assert_equal ["Related link B", "Related link A", "Related link C"], related_links
   end
 
   test "renders all data attributes for tracking" do
@@ -98,6 +103,10 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_select "a[data-track-category=\"relatedLinkClicked\"]", 3
     assert_select "a[data-track-dimension-index=\"29\"]", 3
 
+    assert_select "a[data-track-dimension=\"Item title\"]", 1
+    assert_select "a[data-track-action=\"1\"]", 1
+    assert_select "a[data-track-label=\"/item\"]", 1
+
     assert_select "a[data-track-dimension=\"Related link 1\"]", 1
     assert_select "a[data-track-action=\"1.1\"]", 1
     assert_select "a[data-track-label=\"/related-link-1\"]", 1
@@ -105,9 +114,5 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_select "a[data-track-dimension=\"Related link 2\"]", 1
     assert_select "a[data-track-action=\"1.2\"]", 1
     assert_select "a[data-track-label=\"/related-link-2\"]", 1
-
-    assert_select "a[data-track-dimension=\"Item title\"]", 1
-    assert_select "a[data-track-action=\"1.3\"]", 1
-    assert_select "a[data-track-label=\"/item\"]", 1
   end
 end


### PR DESCRIPTION
Apply the latest set of design changes.



## Government frontend

![screen shot 2017-03-06 at 16 40 18](https://cloud.githubusercontent.com/assets/519250/23619588/095ae850-028c-11e7-9ffe-2fad21ed4ebe.png)


## Smart Answers

<img width="1003" alt="screen shot 2017-03-07 at 15 02 17" src="https://cloud.githubusercontent.com/assets/519250/23662324/182f68e0-0347-11e7-8259-13826e1d6ec8.png">


https://trello.com/c/yFhLdgMX/471-style-and-copy-changes-to-the-taxonomy-side-bar