### PR TITLE
Change link text in banners to be more accessible

### DIFF
--- a/app/views/govuk_component/alpha_label.raw.html.erb
+++ b/app/views/govuk_component/alpha_label.raw.html.erb
@@ -5,7 +5,7 @@
       <% if local_assigns.include?(:message) %>
         <%= raw message %>
       <% else %>
-        This part of GOV.UK is being built &ndash; <a href="/service-manual/phases/ideal-alphas">find out what this means</a>
+        This part of GOV.UK is being built &ndash; <a href="/service-manual/phases/ideal-alphas">find out what alpha means</a>
       <% end %>
     </span>
   </p>

--- a/app/views/govuk_component/beta_label.raw.html.erb
+++ b/app/views/govuk_component/beta_label.raw.html.erb
@@ -5,7 +5,7 @@
       <% if local_assigns.include?(:message) %>
         <%= raw message %>
       <% else %>
-        This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what this means</a>
+        This part of GOV.UK is being rebuilt &ndash; <a href="/help/beta">find out what beta means</a>
       <% end %>
     </span>
   </p>


### PR DESCRIPTION
When reading out of context, for example when using a screen reader, "find out what this means" is not very clear.