### PR TITLE
Update scroll tracker for 2017 budget

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -52,6 +52,16 @@
       ['Heading', 'When you can claim Universal Credit'],
       ['Heading', 'Help and advice']
     ]
+    '/government/publications/spring-budget-2017-documents/spring-budget-2017': [
+      ['Heading', 'Executive summary'],
+      ['Heading', 'Economy and public finances'],
+      ['Heading', 'Policy decisions']
+      ['Heading', 'Tax']
+      ['Heading', 'Productivity']
+      ['Heading', 'Public services and markets']
+      ['Heading', 'Annex A: Financing']
+      ['Heading', 'Annex B: Office for Budget Responsibility\'s Economic and fiscal outlook']
+    ]
   };
 
   function ScrollTracker(sitewideConfig) {


### PR DESCRIPTION
@pmanrubia @fofr @ikennaokpala  HMT have asked for scroll tracking to be added to the 2017 budget publication. They want to track the numbers of users who reach the links in the headings I've added to the code.

This pull request replaces #925 (I've created a new one as the headings' titles have changed and this request reflects the change).