### PR TITLE
Update scroll tracker for 2017 budget

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -51,6 +51,16 @@
       ['Heading', 'How Universal Credit makes work pay'],
       ['Heading', 'When you can claim Universal Credit'],
       ['Heading', 'Help and advice']
+    ],
+    '/government/publications/spring-budget-2017-documents/spring-budget-2017': [
+      ['Heading', '1. Executive summary'],
+      ['Heading', '2. Economic context and public finances'],
+      ['Heading', '3. Policy decisions'],
+      ['Heading', '4. Tax'],
+      ['Heading', '5. Productivity'],
+      ['Heading', '6. Public services and markets'],
+      ['Heading', '7. Annex A: Financing'],
+      ['Heading', '8. Annex B: Office for Budget Responsibility\'s Economic and fiscal outlook']
     ]
   };
 


### PR DESCRIPTION
Supersedes https://github.com/alphagov/static/pull/930

HMT have asked for scroll tracking to be added to the 2017 budget publication. They want to track the numbers of users who reach the links in the headings I've added to the code.

This pull request replaces #925 (I've created a new one as the headings' titles have changed and this request reflects the change).