### PR TITLE
Fix breadcrumbs' layout in Firefox

### DIFF
--- a/app/assets/stylesheets/govuk-component/mixins/_touch-friendly-links.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_touch-friendly-links.scss
@@ -6,5 +6,6 @@
     padding: $padding;
     margin: -1 * $padding;
     outline-color: transparent;
+    display: inline-block;
   }
 }


### PR DESCRIPTION
The negative margin added to the breadcrumb links to improve the
clickable area introduced a bug in firefox, where the link text wraps to
a new line.

By adding `display: inline-block` we make sure the link doesn't wrap to
a new line like in other browsers.

### Before

<img width="1440" alt="screen shot 2017-03-07 at 10 39 45" src="https://cloud.githubusercontent.com/assets/416701/23652983/be0b5c94-0322-11e7-8508-d15f04e5ae3e.png">

### After

<img width="1440" alt="screen shot 2017-03-07 at 10 40 00" src="https://cloud.githubusercontent.com/assets/416701/23652989/c15e5a72-0322-11e7-96ee-f64b1ac00d6e.png">


Trello: https://trello.com/c/QlITug3n/499-firefox-shows-breadcrumbs-wrapped