### PR TITLE
Track clicks with arbitrary JSON options

### DIFF
--- a/app/assets/javascripts/modules/track-click.js
+++ b/app/assets/javascripts/modules/track-click.js
@@ -26,7 +26,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
             label = $el.attr('data-track-label'),
             value = $el.attr('data-track-value'),
             dimension = $el.attr('data-track-dimension'),
-            dimensionIndex = $el.attr('data-track-dimension-index');
+            dimensionIndex = $el.attr('data-track-dimension-index'),
+            extraOptions = $el.attr('data-track-options');
 
         if (label) {
           options.label = label;
@@ -38,6 +39,10 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
         if (dimension && dimensionIndex) {
           options['dimension' + dimensionIndex] = dimension;
+        }
+
+        if (extraOptions) {
+          $.extend(options, JSON.parse(extraOptions));
         }
 
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {

--- a/spec/javascripts/modules/track-click.spec.js
+++ b/spec/javascripts/modules/track-click.spec.js
@@ -112,6 +112,28 @@ describe('A click tracker', function() {
     );
   });
 
+  it('tracks clicks with arbitrary JSON', function() {
+    spyOn(GOVUK.analytics, 'trackEvent');
+
+    element = $(
+      "<a data-track-category='category' \
+          data-track-action='1' \
+          data-track-label='/' \
+          data-track-options='{\"dimension28\": \"foo\", \"dimension29\": \"bar\"}' \
+          href='/'>Home</a>"
+    );
+
+    tracker.start(element);
+
+    element.trigger('click');
+
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category',
+      '1',
+      { label: '/', dimension28: 'foo', dimension29: 'bar', transport: 'beacon' }
+    );
+  });
+
   it('tracks all trackable links within a container', function() {
     spyOn(GOVUK.analytics, 'trackEvent');
 


### PR DESCRIPTION
Some clicks require multiple custom dimensions to be set on them. Our current markup only allows one dimension ID and its corresponding value to be set.

In order to submit multiple custom dimensions, this change adds the ability to set arbitrary Google Analytics tracking events in the [`fieldObject`](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) in the form of JSON.

The corresponding change in `collections` is: https://github.com/alphagov/collections/pull/288

### Trello

https://trello.com/c/btaOSNax/426-track-position-of-clicks-in-the-new-taxon-grid-pages
