### PR TITLE
Render govspeak contact details inline for legibility

### DIFF
--- a/app/assets/stylesheets/govuk-component/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_contact.scss
@@ -29,20 +29,7 @@
         margin-bottom: 5px;
       }
 
-      .adr,
-      .email-url-number,
-      .comments {
-        @include media(tablet) {
-          width: $half;
-          float: left;
-        }
-      }
-
       .email-url-number {
-        p {
-          margin: 0;
-        }
-
         .email {
           word-wrap: break-word;
         }


### PR DESCRIPTION
* Port fix from https://github.com/alphagov/whitehall/pull/2367
* Also remove custom paragraph rule, Whitehall had padding so these items were slightly spaced
* Addresses https://govuk.zendesk.com/agent/tickets/1918092

Fix was made to Whitehall after styles were cut for govspeak component.

## Old Whitehall
http://webarchive.nationalarchives.gov.uk/+/https://www.gov.uk/government/news/future-life-expectancy-to-be-considered-in-first-state-pension-age-review

![screen shot 2017-03-07 at 13 34 05](https://cloud.githubusercontent.com/assets/319055/23658505/c5a28776-033a-11e7-9672-e72c6547a8fd.png)

## Component
![screen shot 2017-03-07 at 13 28 35](https://cloud.githubusercontent.com/assets/319055/23658409/5eb0d540-033a-11e7-9294-a02e21d18a3c.png)

## Component after fix
![screen shot 2017-03-07 at 13 28 16](https://cloud.githubusercontent.com/assets/319055/23658410/5ec9dd92-033a-11e7-9109-30d6013f5dda.png)