### PR TITLE
Set default navigation page type tracking dimension

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -93,7 +93,17 @@
       dimensions[key] = value;
     });
 
+    // Set defaults first, so that we get a stable ordering in tests
+    this.setDimensionsThatHaveDefaultValues(dimensions);
+    this.setDimensionsThatDoNotHaveDefaultValues(dimensions);
+  };
+
+  StaticAnalytics.prototype.setDimensionsThatHaveDefaultValues = function(dimensions) {
+    this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
     this.setUserJourneyStage(dimensions['user-journey-stage']);
+  };
+
+  StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
     this.setSectionDimension(dimensions['section']);
     this.setFormatDimension(dimensions['format']);
     this.setResultCountDimension(dimensions['search-result-count']);
@@ -102,7 +112,6 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
-    this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -184,7 +193,7 @@
   };
 
   StaticAnalytics.prototype.setNavigationPageTypeDimension = function(pageType) {
-    this.setDimension(32, pageType);
+    this.setDimension(32, pageType || 'none');
   };
 
   StaticAnalytics.prototype.setUserJourneyStage = function(journeyStage) {


### PR DESCRIPTION
This change closely follows https://github.com/alphagov/static/pull/921

Here, we set a default value of `none` for the `navigation-page-type` custom dimension. This is to ease the processing of Google Analytics results, since fields missing this custom dimension are omitted in some reports.

### Trello

https://trello.com/c/Eui3OmTB/491-track-navigation-page-type-for-non-taxon-pages
