### PR TITLE
Add a taxonomy survey notification ID to surveys.js

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -268,7 +268,13 @@
     },
 
     otherNotificationVisible: function() {
-      return $('#banner-notification:visible, #global-cookie-message:visible, #global-browser-prompt:visible').length > 0;
+      var notificationIds = [
+        '#banner-notification:visible',
+        '#global-cookie-message:visible',
+        '#global-browser-prompt:visible',
+        '#taxonomy-survey:visible'
+      ]
+      return $(notificationIds.join(', ')).length > 0;
     },
 
     surveyTakenCookieName: function(survey) {


### PR DESCRIPTION
If we're showing the new taxonomy navigation survey, we don't want to
show other banners.