### PR TITLE
Taxon names should be underlined in sidebar

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -8,14 +8,6 @@
     h2 {
       @include bold-24;
       margin: 0 0 5px;
-
-      a {
-        text-decoration: none;
-
-        &:hover {
-          text-decoration: underline;
-        }
-      }
     }
 
     .taxon-description {


### PR DESCRIPTION
Trello: https://trello.com/c/koyo5MKj/48-topic-titles-in-sidebar-should-be-underlined

@alextea is this what you expect?

<img width="1132" alt="screen shot 2017-03-08 at 17 43 21" src="https://cloud.githubusercontent.com/assets/416701/23716069/c096c0c0-0426-11e7-8db5-f921e5c94b5c.png">
