### PR TITLE
Add padding bottom to taxonomy sidebar

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,5 +1,6 @@
 .govuk-taxonomy-sidebar {
   border-top: 10px solid $mainstream-brand;
+  padding-bottom: $gutter * 2;
   @include core-16;
 
   .sidebar-taxon {


### PR DESCRIPTION
This makes sure we allow enough spacing in between the sidebar and the
content underneath it in mobile viewports.

Trello: https://trello.com/c/tTLH10ht/50-mobile-layout-margins-below-related-component-too-tight

### Before

<img width="836" alt="screen shot 2017-03-08 at 20 21 42" src="https://cloud.githubusercontent.com/assets/416701/23722418/391c7bdc-043d-11e7-8810-57d1ad47ae60.png">

### After

<img width="682" alt="screen shot 2017-03-08 at 20 22 12" src="https://cloud.githubusercontent.com/assets/416701/23722423/3d3424e0-043d-11e7-82d8-95f37c474680.png">
