### PR TITLE
Fix gap in sidebar links

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -22,11 +22,15 @@
       list-style-type: none;
       line-height: 1.5;
 
-      a:before {
-        content: "•";
-        display: inline-block;
-        width: 15px;
-        margin-left: -15px;
+      a {
+        display: block;
+
+        &:before {
+          content: "•";
+          display: inline-block;
+          width: 15px;
+          margin-left: -15px;
+        }
       }
     }
   }


### PR DESCRIPTION
There was a gap between multiline links in the sidebar that you couldn't click. `display: block` makes these links wrap the entire li element

Trello card: https://trello.com/c/xshqCdju/33-it-s-possible-to-click-in-the-middle-of-related-links-and-not-go-anywhere

## Before

![screen shot 2017-03-09 at 11 37 51](https://cloud.githubusercontent.com/assets/523014/23748772/e8e65b44-04bc-11e7-9c1e-7c768dc99517.png)

## After

![screen shot 2017-03-09 at 11 37 59](https://cloud.githubusercontent.com/assets/523014/23748780/efc8813a-04bc-11e7-9fb6-3b9506da5e06.png)
