### PR TITLE
Workaround for IE8 bug on related link bullet points

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -22,8 +22,14 @@
       list-style-type: none;
       line-height: 1.5;
 
+      // We use a pseudo element to add bullet points to related links. This
+      // makes the bullets clickable and highlights them on link hover. With
+      // this approach, IE8 erroneously applies the anchor tag's underline to
+      // the pseudo element. Specifying separate text-decoration rules for the
+      // anchor tag and a nested span fixes this.
       a {
         display: block;
+        text-decoration: none;
 
         &:before {
           content: "•";
@@ -32,7 +38,10 @@
           margin-left: -15px;
         }
       }
+
+      a span {
+        text-decoration: underline;
+      }
     }
   }
-
 }

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -32,7 +32,6 @@
                 <li>
                   <%=
                     link_to(
-                      related_item[:title],
                       related_item[:link],
                       data: {
                           track_category: 'relatedLinkClicked',
@@ -42,7 +41,9 @@
                           track_dimension_index: 29,
                       },
                       class: 'related-link',
-                    )
+                    ) do
+                      content_tag(:span, related_item[:title])
+                    end
                   %>
                 </li>
               <% end %>


### PR DESCRIPTION
Fixes an issue where pseudo elements on an anchor tag receive the same
text decoration as the anchor tag.

## IE 8 (before)
 
<img width="1001" alt="screen_shot_2017-03-09_at_15_46_23" src="https://cloud.githubusercontent.com/assets/519250/23758135/a30a2d02-04e0-11e7-9c59-516b4410ad8e.png">


## IE 8 (after)

<img width="1083" alt="screen shot 2017-03-09 at 13 35 22" src="https://cloud.githubusercontent.com/assets/519250/23752546/a75edbea-04cd-11e7-96c4-a6c9907d979f.png">


## Chrome (no change)

<img width="1005" alt="screen shot 2017-03-09 at 13 35 41" src="https://cloud.githubusercontent.com/assets/519250/23752553/b3069866-04cd-11e7-9470-72d6a1497d76.png">
