### PR TITLE
[WIP] Fix clickable related link bullet styling

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -19,28 +19,20 @@
     .related-content {
       margin: 0 0 0 15px;
       padding: 0;
-      list-style-type: none;
-      line-height: 1.5;
 
-      // We use a pseudo element to add bullet points to related links. This
-      // makes the bullets clickable and highlights them on link hover. With
-      // this approach, IE8 erroneously applies the anchor tag's underline to
-      // the pseudo element. Specifying separate text-decoration rules for the
-      // anchor tag and a nested span fixes this.
-      a {
-        display: block;
-        text-decoration: none;
-
-        &:before {
-          content: "•";
-          display: inline-block;
-          width: 15px;
-          margin-left: -15px;
-        }
+      li {
+        font-size: 12px;
       }
 
-      a span {
-        text-decoration: underline;
+      a {
+        display: block;
+        font-size: 16px;
+        line-height: 1.5;
+
+        span {
+          position: relative;
+          top: 1px;
+        }
       }
     }
   }


### PR DESCRIPTION
This fix is for a more robust CSS fix to achieve the following effect in the taxonomy sidebar:

- Listed links have clickable bullet points
- The bullet points are styled to match the colour of the link text (even on hover/focus/visited)
- The bullet points are not underlined

The previous fix used a pseudoelement, which is both:
- a bullet point anti-pattern
- broken on screenreaders (which try to read out the pseudoelement)

This has been tested in Chrome, Firefox and IE8/11.

That all said, I'm not 100% convinced that having bullets that follow the behaviour and styling of a link is particularly typical. My preferred fix for this would be to remove this altogether. However, if that's the design we're sticking with for now this Pull Request should at least achieve the design in a more typical and robust way.

### Trello

https://trello.com/c/37jp8eJQ/514-taxonomy-sidebar-related-links-bullet-points-can-we-make-these-better-for-screenreaders
