### PR TITLE
Update breadcrumb component to allow optional collapsed display

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -15,4 +15,32 @@
     color: $secondary-text-colour;
     text-decoration: none;
   }
+
+  @include media-down(mobile) {
+    &.collapse-on-mobile li {
+      display: none;
+
+      &.parent-taxon {
+        background-image: none;
+        display: block;
+        margin-left: 0;
+        padding-left: 14px;
+        position: relative;
+
+        &:before {
+          border-bottom: 5px solid transparent;
+          border-right: 6px solid #0b0c0c;
+          border-top: 5px solid transparent;
+          content: '';
+          display: block;
+          height: 0;
+          left: 0;
+          margin-top: -6px;
+          position: absolute;
+          top: 50%;
+          width: 0;
+        }
+      }
+    }
+  }
 }

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,18 +1,21 @@
 <%
   breadcrumbs ||= []
+  collapse_on_mobile ||= false
 %>
-<div class="govuk-breadcrumbs" data-module="track-click">
+
+<div class="govuk-breadcrumbs <%= "collapse-on-mobile" if collapse_on_mobile %>" data-module="track-click">
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
-    <li>
-      <%
-        is_link = crumb[:url].present? || crumb[:is_current_page]
-        path = crumb[:is_current_page] ? '#content' : crumb[:url]
-        aria_current = crumb[:is_current_page] ? 'page' : 'false'
-        css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+    <%
+      is_link = crumb[:url].present? || crumb[:is_current_page]
+      is_parent = index == breadcrumbs.length - 2
+      path = crumb[:is_current_page] ? '#content' : crumb[:url]
+      aria_current = crumb[:is_current_page] ? 'page' : 'false'
+      css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+    %>
 
-        if is_link
-      %>
+    <li class='<%= "parent-taxon" if is_parent %>'>
+      <% if is_link %>
         <%= link_to(
           crumb[:title],
           path,


### PR DESCRIPTION
When viewing the new taxonomy navigation on mobile, we want to show the
parent taxon only rather than the full breadcrumb.

This commit allows a 'collapse_on_mobile' flag to be passed in by any
app rendering the component, changing the applied CSS accordingly.

# Examples

## Government frontend
<img width="558" alt="screen shot 2017-03-10 at 16 37 05" src="https://cloud.githubusercontent.com/assets/519250/23803871/db981056-05af-11e7-9714-e3451d61ff60.png">

## Collections
<img width="545" alt="screen shot 2017-03-10 at 16 41 30" src="https://cloud.githubusercontent.com/assets/519250/23804038/7567526e-05b0-11e7-97c8-7c32b7df2bc4.png">


https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link