### PR TITLE
Explicitly include button styles for the email survey submit button

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -27,7 +27,7 @@
                             '      <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
                             '      <input name="email_survey_signup[email_address]" type="text" placeholder="Your email address">' +
                             '      <div class="actions">' +
-                            '        <button class="button">Send</button>' +
+                            '        <button type="submit">Send</button>' +
                             '        <p class="button-info">We won\'t store your email address or share it with anyone</span>' +
                             '      </div>' +
                             '    </div>' +

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -307,6 +307,7 @@
       margin: 0.5em 0 0.5em 20px;
 
       button {
+        @include button;
         display: inline-block;
       }
 


### PR DESCRIPTION
The send button in the email survey UI used the ".button" class to get the
styling defined in `helpers/_buttons`.  Unfortunately this styling is not
included in all layouts that an app might request from static.  For example
it is included in the static layout, but not the header_and_footer_only or
core_layout.  This means that only some frontend rendering apps will style
the button correctly.

Instead we explicitly include the button styling mixin in the css for a
button in the user-satisfaction-survey in `helpers/_header`.  This helper
is included in all layouts so all frontend rendering apps will style the
button correctly.

For: https://trello.com/c/dfSufy85/114-develop-a-new-survey-delivery-method