### PR TITLE
Update breadcrumb component to allow optional collapsed display

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -15,4 +15,22 @@
     color: $secondary-text-colour;
     text-decoration: none;
   }
+
+  @include media-down(mobile) {
+    &.collapse-on-mobile li {
+      display: none;
+
+      &.parent-breadcrumb {
+        background-image: none;
+        display: block;
+        margin-left: 0;
+        padding-left: 14px;
+        position: relative;
+
+        &:before {
+          @include back-arrow;
+        }
+      }
+    }
+  }
 }

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -4,6 +4,7 @@
 @import "design-patterns/alpha-beta";
 
 // Component mixins
+@import "mixins/back-arrow";
 @import "mixins/margins";
 @import "mixins/touch-friendly-links";
 

--- a/app/assets/stylesheets/govuk-component/mixins/_back-arrow.scss
+++ b/app/assets/stylesheets/govuk-component/mixins/_back-arrow.scss
@@ -1,0 +1,13 @@
+// An arrow to represent a "back" link
+
+@mixin back-arrow {
+  border-bottom: 5px solid transparent;
+  border-right: 6px solid;
+  border-top: 5px solid transparent;
+  content: '';
+  display: block;
+  left: 0;
+  margin-top: -6px;
+  position: absolute;
+  top: 50%;
+}

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,18 +1,22 @@
 <%
   breadcrumbs ||= []
+  collapse_on_mobile ||= false
 %>
-<div class="govuk-breadcrumbs" data-module="track-click">
+
+<div
+  class="govuk-breadcrumbs <%= "collapse-on-mobile" if collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } %>"
+  data-module="track-click">
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
-    <li>
-      <%
-        is_link = crumb[:url].present? || crumb[:is_current_page]
-        path = crumb[:is_current_page] ? '#content' : crumb[:url]
-        aria_current = crumb[:is_current_page] ? 'page' : 'false'
-        css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+    <%
+      is_link = crumb[:url].present? || crumb[:is_current_page]
+      path = crumb[:is_current_page] ? '#content' : crumb[:url]
+      aria_current = crumb[:is_current_page] ? 'page' : 'false'
+      css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+    %>
 
-        if is_link
-      %>
+    <li class='<%= "parent-breadcrumb" if crumb[:is_page_parent] %>'>
+      <% if is_link %>
         <%= link_to(
           crumb[:title],
           path,


### PR DESCRIPTION
When viewing the new taxonomy navigation on mobile, we want to show the parent taxon only rather than the full breadcrumb.

This commit allows a 'collapse_on_mobile' flag to be passed in by any app rendering the component, changing the applied CSS accordingly.

https://trello.com/c/Y7OirowB/472-mobile-version-of-breadcrumbs-should-only-show-previous-link

This is a continuation of @mobaig's PR #944 - I can't reopen it because I force-pushed the branch first. TIL.

I've added my changes to Mo's original PR as a separate commit so you can see the diff. I'll squash before merging to master.

This will need a corresponding change in govuk_navigation_helpers to add the flag: https://github.com/alphagov/govuk_navigation_helpers/compare/master...breadcrumb-parents?expand=1