### PR TITLE
Define surveys in html not js

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -244,9 +244,7 @@
 
       $.each(smallSurveys, function(_index, survey) {
         if(userSurveys.currentTime() >= survey.startTime && userSurveys.currentTime() <= survey.endTime) {
-          if(typeof(survey.activeWhen) === 'function') {
-            if(survey.activeWhen()) { activeSurvey = survey; }
-          } else {
+          if (userSurveys.activeWhen(survey)) {
             activeSurvey = survey;
           }
         }
@@ -449,8 +447,82 @@
       return "govuk_" + cookieStub;
     },
 
+    pathMatch: function(paths) {
+      if (paths === undefined) {
+        return false;
+      } else {
+        var pathMatchingExpr = new RegExp(
+          $.map($.makeArray(paths), function(path, _i) {
+            if (/[\^\$]/.test(path)) {
+              return "(?:"+path+")"
+            } else {
+              return "(?:\/"+path+"(?:\/|$))";
+            }
+          }).join("|")
+        );
+        return pathMatchingExpr.test(userSurveys.currentPath());
+      }
+    },
+
+    breadcrumbMatch: function(breadcrumbs) {
+      if (breadcrumbs === undefined) {
+        return false;
+      } else {
+        var breadcrumbMatchingExpr = new RegExp($.makeArray(breadcrumbs).join("|"), 'i');
+        return breadcrumbMatchingExpr.test(userSurveys.currentBreadcrumb());
+      }
+    },
+
+    sectionMatch: function(sections) {
+      if (sections === undefined) {
+        return false;
+      } else {
+        var sectionMatchingExpr = new RegExp($.makeArray(sections).join("|"), 'i');
+        return sectionMatchingExpr.test(userSurveys.currentSection());
+      }
+    },
+
+    organisationMatch: function(organisations) {
+      if (organisations === undefined) {
+        return false;
+      } else {
+        var orgMatchingExpr = new RegExp($.makeArray(organisations).join("|"));
+        return orgMatchingExpr.test(userSurveys.currentOrganisation());
+      }
+    },
+
+    activeWhen: function(survey) {
+      if (survey.hasOwnProperty('activeWhen')) {
+        if (survey.activeWhen.hasOwnProperty('path') ||
+            survey.activeWhen.hasOwnProperty('breadcrumb') ||
+            survey.activeWhen.hasOwnProperty('section') ||
+            survey.activeWhen.hasOwnProperty('organisation')) {
+
+          var matchType = (survey.activeWhen.matchType || 'include'),
+            matchByPath = userSurveys.pathMatch(survey.activeWhen.path),
+            matchByBreadcrumb = userSurveys.breadcrumbMatch(survey.activeWhen.breadcrumb),
+            matchBySection = userSurveys.sectionMatch(survey.activeWhen.section),
+            matchByOrganisation = userSurveys.organisationMatch(survey.activeWhen.organisation),
+            pageMatches = (matchByPath || matchByBreadcrumb || matchBySection || matchByOrganisation);
+
+          if (matchType !== 'exclude') {
+            return pageMatches;
+          } else {
+            return !pageMatches;
+          }
+        } else {
+          return true;
+        }
+      } else {
+        return true;
+      }
+    },
+
     currentTime: function() { return new Date().getTime(); },
-    currentPath: function() { return window.location.pathname; }
+    currentPath: function() { return window.location.pathname; },
+    currentBreadcrumb: function() { return $('.govuk-breadcrumbs').text() || ""; },
+    currentSection: function() { return $('meta[name="govuk:section"]').attr('content') || ""; },
+    currentOrganisation: function() { return $('meta[name="govuk:analytics:organisations"]').attr('content') || ""; }
   };
 
   root.GOVUK.userSurveys = userSurveys;

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -305,47 +305,39 @@
     },
 
     pathMatch: function(paths) {
-      if (paths === undefined) {
-        return false;
-      } else {
-        var pathMatchingExpr = new RegExp(
-          $.map($.makeArray(paths), function(path, _i) {
-            if (/[\^\$]/.test(path)) {
-              return "(?:"+path+")"
-            } else {
-              return "(?:\/"+path+"(?:\/|$))";
-            }
-          }).join("|")
-        );
-        return pathMatchingExpr.test(userSurveys.currentPath());
-      }
+      if (paths === undefined) { return false; }
+
+      var pathMatchingExpr = new RegExp(
+        $.map($.makeArray(paths), function(path, _i) {
+          if (/[\^\$]/.test(path)) {
+            return "(?:"+path+")"
+          } else {
+            return "(?:\/"+path+"(?:\/|$))";
+          }
+        }).join("|")
+      );
+      return pathMatchingExpr.test(userSurveys.currentPath());
     },
 
     breadcrumbMatch: function(breadcrumbs) {
-      if (breadcrumbs === undefined) {
-        return false;
-      } else {
-        var breadcrumbMatchingExpr = new RegExp($.makeArray(breadcrumbs).join("|"), 'i');
-        return breadcrumbMatchingExpr.test(userSurveys.currentBreadcrumb());
-      }
+      if (breadcrumbs === undefined) { return false; }
+
+      var breadcrumbMatchingExpr = new RegExp($.makeArray(breadcrumbs).join("|"), 'i');
+      return breadcrumbMatchingExpr.test(userSurveys.currentBreadcrumb());
     },
 
     sectionMatch: function(sections) {
-      if (sections === undefined) {
-        return false;
-      } else {
-        var sectionMatchingExpr = new RegExp($.makeArray(sections).join("|"), 'i');
-        return sectionMatchingExpr.test(userSurveys.currentSection());
-      }
+      if (sections === undefined) { return false; }
+
+      var sectionMatchingExpr = new RegExp($.makeArray(sections).join("|"), 'i');
+      return sectionMatchingExpr.test(userSurveys.currentSection());
     },
 
     organisationMatch: function(organisations) {
-      if (organisations === undefined) {
-        return false;
-      } else {
-        var orgMatchingExpr = new RegExp($.makeArray(organisations).join("|"));
-        return orgMatchingExpr.test(userSurveys.currentOrganisation());
-      }
+      if (organisations === undefined) { return false; }
+
+      var orgMatchingExpr = new RegExp($.makeArray(organisations).join("|"));
+      return orgMatchingExpr.test(userSurveys.currentOrganisation());
     },
 
     surveyIsAllowedToRunBasedOnTimes: function(survey) {
@@ -357,26 +349,24 @@
     },
 
     surveyIsAllowedToRunBasedOnActiveWhen: function(survey) {
-      if (survey.hasOwnProperty('activeWhen')) {
-        if (survey.activeWhen.hasOwnProperty('path') ||
-            survey.activeWhen.hasOwnProperty('breadcrumb') ||
-            survey.activeWhen.hasOwnProperty('section') ||
-            survey.activeWhen.hasOwnProperty('organisation')) {
+      if (!survey.hasOwnProperty('activeWhen')) { return true; }
 
-          var matchType = (survey.activeWhen.matchType || 'include'),
-            matchByPath = userSurveys.pathMatch(survey.activeWhen.path),
-            matchByBreadcrumb = userSurveys.breadcrumbMatch(survey.activeWhen.breadcrumb),
-            matchBySection = userSurveys.sectionMatch(survey.activeWhen.section),
-            matchByOrganisation = userSurveys.organisationMatch(survey.activeWhen.organisation),
-            pageMatches = (matchByPath || matchByBreadcrumb || matchBySection || matchByOrganisation);
+      if (survey.activeWhen.hasOwnProperty('path') ||
+          survey.activeWhen.hasOwnProperty('breadcrumb') ||
+          survey.activeWhen.hasOwnProperty('section') ||
+          survey.activeWhen.hasOwnProperty('organisation')) {
 
-          if (matchType !== 'exclude') {
-            return pageMatches;
-          } else {
-            return !pageMatches;
-          }
+        var matchType = (survey.activeWhen.matchType || 'include'),
+          matchByPath = userSurveys.pathMatch(survey.activeWhen.path),
+          matchByBreadcrumb = userSurveys.breadcrumbMatch(survey.activeWhen.breadcrumb),
+          matchBySection = userSurveys.sectionMatch(survey.activeWhen.section),
+          matchByOrganisation = userSurveys.organisationMatch(survey.activeWhen.organisation),
+          pageMatches = (matchByPath || matchByBreadcrumb || matchBySection || matchByOrganisation);
+
+        if (matchType !== 'exclude') {
+          return pageMatches;
         } else {
-          return true;
+          return !pageMatches;
         }
       } else {
         return true;

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -24,13 +24,7 @@
         surveyCtaPostscript: $urlSurveyTemplate.data('defaultSurveyCtaPostscript'),
         render: function(survey, surveyUrl) {
           var templateArgs = (survey.templateArguments || {}),
-            surveyUrl = survey.url;
-
-          // Survey monkey can record the URL of the survey link if passed
-          // through as a query param
-          if ((/surveymonkey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
-            surveyUrl += "?c=" + userSurveys.currentPath();
-          }
+            surveyUrl = survey.url.replace(/\{\{currentPath\}\}/g, userSurveys.currentPath());
 
           return this.template.
             replace(/\{\{title\}\}/g, templateArgs.title || this.title).

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -243,10 +243,8 @@
       var activeSurvey = defaultSurvey;
 
       $.each(smallSurveys, function(_index, survey) {
-        if(userSurveys.currentTime() >= survey.startTime && userSurveys.currentTime() <= survey.endTime) {
-          if (userSurveys.activeWhen(survey)) {
-            activeSurvey = survey;
-          }
+        if (userSurveys.surveyIsAllowedToRunBasedOnTimes(survey) && userSurveys.activeWhen(survey)) {
+          activeSurvey = survey;
         }
       });
 
@@ -489,6 +487,14 @@
         var orgMatchingExpr = new RegExp($.makeArray(organisations).join("|"));
         return orgMatchingExpr.test(userSurveys.currentOrganisation());
       }
+    },
+
+    surveyIsAllowedToRunBasedOnTimes: function(survey) {
+      var startTime = new Date(survey.startTime).getTime(),
+        endTime = new Date(survey.endTime).getTime(),
+        now = userSurveys.currentTime();
+
+      return now >= startTime && now <= endTime;
     },
 
     activeWhen: function(survey) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -243,7 +243,7 @@
       var activeSurvey = defaultSurvey;
 
       $.each(smallSurveys, function(_index, survey) {
-        if (userSurveys.surveyIsAllowedToRunBasedOnTimes(survey) && userSurveys.activeWhen(survey)) {
+        if (userSurveys.surveyIsAllowedToRunBasedOnTimes(survey) && userSurveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)) {
           activeSurvey = survey;
         }
       });
@@ -497,7 +497,7 @@
       return now >= startTime && now <= endTime;
     },
 
-    activeWhen: function(survey) {
+    surveyIsAllowedToRunBasedOnActiveWhen: function(survey) {
       if (survey.hasOwnProperty('activeWhen')) {
         if (survey.activeWhen.hasOwnProperty('path') ||
             survey.activeWhen.hasOwnProperty('breadcrumb') ||

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -5,174 +5,9 @@
       $ = root.jQuery;
   if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
 
-  /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
-    defaultSurvey: {
-      url: 'https://www.smartsurvey.co.uk/s/gov-uk',
-      identifier: 'user_satisfaction_survey',
-      frequency: 50,
-      surveyType: 'url',
-    },
-    smallSurveys: [
-      {
-        identifier: 'govuk_email_survey_t02',
-        frequency: 10,
-        activeWhen: function() {
-          function breadcrumbExclude() {
-            var text = $('.govuk-breadcrumbs').text() || "";
-            return (/Education/i.test(text) || /Childcare/i.test(text) || /Schools/i.test(text));
-          }
-
-          function sectionExclude() {
-            var sectionName = $('meta[name="govuk:section"]').attr('content');
-            return (/education/i.test(sectionName) || /childcare/i.test(sectionName) || /schools/i.test(sectionName));
-          }
-
-          function organisationExclude() {
-            var orgMatchingExpr = /<D6>|<D106>|<D109>|<EA243>|<EA86>|<EA242>|<EA541>/;
-            var metaText = $('meta[name="govuk:analytics:organisations"]').attr('content') || "";
-            return orgMatchingExpr.test(metaText);
-          }
-
-          return !(sectionExclude() || breadcrumbExclude() || organisationExclude());
-        },
-        surveyType: 'email',
-        startTime: new Date("April 3, 2017 10:00:00").getTime(),
-        endTime: new Date("April 4, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=" + window.location.pathname + "&utm_source=Hold_gov_to_account&utm_medium=gov.uk%20survey&t=GDS",
-        identifier: 'mar_ur_panel',
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = new RegExp('/(?:'
-                + /government\/policies/.source
-                + /|government\/how-government-works/.source
-                + /|make-a-freedom-of-information-request/.source
-                + /|government\/collections\/open-government/.source
-                + /|government\/publications\/uk-open-government-national-action-plan-2016-18\/uk-open-government-national-action-plan-2016-18/.source
-                + /|government\/policies\/government-transparency-and-accountability/.source
-                + /|topic\/local-government\/transparency/.source
-                + ')'
-            );
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 20, 2017").getTime(),
-        endTime: new Date("April 21, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=" + window.location.pathname + "&utm_source=Improve_platform_basics&utm_medium=gov.uk%20survey&t=GDS",
-        identifier: 'mar_ur_panel',
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = new RegExp('/(?:'
-                + /government\/world/.source
-                + /|government\/world\/australia/.source
-                + /|government\/world\/china/.source
-                + /|government\/world\/india/.source
-                + /|government\/world\/pakistan/.source
-                + /|government\/world\/usa/.source
-                + ')'
-            );
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 20, 2017").getTime(),
-        endTime: new Date("April 21, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=Anti_Money_Laundering&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = /\/government\/publications\/money-laundering-regulations-application-for-registration-mlr100/;
-
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 22, 2017").getTime(),
-        endTime: new Date("April 20, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=P800&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = /\/claim-tax-refund/;
-
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 22, 2017").getTime(),
-        endTime: new Date("April 20, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=IHT&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = /\/government\/publications\/inheritance-tax-inheritance-tax-account-iht400/;
-
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 22, 2017").getTime(),
-        endTime: new Date("April 20, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=TAV_C&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = /\/guidance\/venture-capital-schemes-apply-for-the-enterprise-investment-scheme/;
-
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 22, 2017").getTime(),
-        endTime: new Date("April 20, 2017 23:59:59").getTime()
-      },
-      {
-        url: "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=capital_gains&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
-        frequency: 5,
-        activeWhen: function() {
-          function pathMatches() {
-            var pathMatchingExpr = /\/capital-gains-tax/;
-
-            return pathMatchingExpr.test(userSurveys.currentPath());
-          }
-
-          return (pathMatches());
-        },
-        surveyType: 'url',
-        startTime: new Date("March 22, 2017").getTime(),
-        endTime: new Date("April 20, 2017 23:59:59").getTime()
-      }
-    ],
-
-    init: function() {
-      var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys);
+  init: function() {
+      var activeSurvey = userSurveys.getActiveSurvey();
       if (userSurveys.isSurveyToBeDisplayed(activeSurvey)) {
         $('#global-bar').hide(); // Hide global bar if one is showing
         userSurveys.displaySurvey(activeSurvey);
@@ -239,19 +74,41 @@
       };
     },
 
-    getActiveSurvey: function(defaultSurvey, smallSurveys) {
-      var activeSurvey = defaultSurvey;
+    getActiveSurvey: function() {
+      var activeSurvey = userSurveys.getDefaultSurvey();
 
-      $.each(smallSurveys, function(_index, survey) {
-        if (userSurveys.surveyIsAllowedToRunBasedOnTimes(survey) && userSurveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)) {
-          activeSurvey = survey;
+      $.each(userSurveys.getOtherSurveys(), function(_index, survey) {
+        if (survey !== undefined) {
+          if (userSurveys.surveyIsAllowedToRunBasedOnTimes(survey) && userSurveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)) {
+            activeSurvey = survey;
+          }
         }
       });
 
       return activeSurvey;
     },
 
+    getDefaultSurvey: function() {
+      try {
+        return JSON.parse($('#user-satisfaction-survey-container [data-survey-default]').text());
+      } catch (e) {
+        return undefined;
+      }
+    },
+
+    getOtherSurveys: function() {
+      return $('#user-satisfaction-survey-container [data-survey]').map(function(_idx, surveyDefinition) {
+        try {
+          return JSON.parse(surveyDefinition.text);
+        } catch (e) {
+          return undefined;
+        }
+      });
+    },
+
     displaySurvey: function(survey) {
+      if (survey === undefined) { return; }
+
       var surveyContainer = $("#user-satisfaction-survey-container");
       if (survey.surveyType === 'email') {
         userSurveys.displayEmailSurvey(survey, surveyContainer);
@@ -365,6 +222,8 @@
     },
 
     isSurveyToBeDisplayed: function(survey) {
+      if (survey === undefined) { return; }
+
       if (userSurveys.pathInBlacklist()) {
         return false;
       } else if (userSurveys.otherNotificationVisible() ||

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -5,41 +5,6 @@
       $ = root.jQuery;
   if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
 
-  var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-                            '  <div class="wrapper">' +
-                            '    <h1>Help improve GOV.UK</h1>' +
-                            '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
-                            '    <p><a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">Answer some questions about yourself to join the research community</a> This link opens in a new tab.</p>' +
-                            '  </div>' +
-                            '</section>',
-    EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-                            '  <div id="email-survey-pre" class="wrapper">' +
-                            '    <h1>Tell us what you think of GOV.UK</h1>' +
-                            '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
-                            '    <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer">Your feedback will help us improve this website</a></p>' +
-                            '  </div>' +
-                            '  <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <div id="feedback-prototype-form">'+
-                            '      <h1>We\'d like to hear from you</h1>'+
-                            '      <p class="right"><a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a></p>' +
-                            '      <label for="email">Tell us your email address and we\'ll send you a link to a quick feedback form.</label>' +
-                            '      <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
-                            '      <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-                            '      <input name="email_survey_signup[email_address]" type="text" placeholder="Your email address">' +
-                            '      <div class="actions">' +
-                            '        <button type="submit">Send</button>' +
-                            '        <p class="button-info">We won\'t store your email address or share it with anyone</span>' +
-                            '      </div>' +
-                            '    </div>' +
-                            '  </form>' +
-                            '  <div id="email-survey-post-success" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <p>Thanks, we\'ve sent you an email with a link to the survey.</p>' +
-                            '  </div>' +
-                            '  <div id="email-survey-post-failure" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <p>Sorry, we’re unable to send you an email right now.  Please try again later.</h2>' +
-                            '  </div>' +
-                            '</section>';
-
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
     defaultSurvey: {
@@ -214,6 +179,66 @@
       }
     },
 
+    getUrlSurveyTemplate: function() {
+      var $urlSurveyTemplate = $('#url-survey-template');
+      return {
+        template: $urlSurveyTemplate.text(),
+        title: $urlSurveyTemplate.data('defaultTitle'),
+        noThanks: $urlSurveyTemplate.data('defaultNoThanks'),
+        surveyCta: $urlSurveyTemplate.data('defaultSurveyCta'),
+        surveyCtaPostscript: $urlSurveyTemplate.data('defaultSurveyCtaPostscript'),
+        render: function(survey, surveyUrl) {
+          var templateArgs = (survey.templateArguments || {}),
+            surveyUrl = survey.url;
+
+          // Survey monkey can record the URL of the survey link if passed
+          // through as a query param
+          if ((/surveymonkey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
+            surveyUrl += "?c=" + userSurveys.currentPath();
+          }
+
+          return this.template.
+            replace(/\{\{title\}\}/g, templateArgs.title || this.title).
+            replace(/\{\{noThanks\}\}/g, templateArgs.noThanks || this.noThanks).
+            replace(/\{\{surveyCta\}\}/g, templateArgs.surveyCta || this.surveyCta).
+            replace(/\{\{surveyCtaPostscript\}\}/g, templateArgs.surveyCtaPostscript || this.surveyCtaPostscript).
+            replace(/\{\{surveyUrl\}\}/g, surveyUrl);
+        }
+      };
+    },
+
+    getEmailSurveyTemplate: function() {
+      var $emailSurveyTemplate = $('#email-survey-template');
+      return {
+        template: $emailSurveyTemplate.text(),
+        title: $emailSurveyTemplate.data('defaultTitle'),
+        noThanks: $emailSurveyTemplate.data('defaultNoThanks'),
+        surveyCta: $emailSurveyTemplate.data('defaultSurveyCta'),
+        surveyFormTitle: $emailSurveyTemplate.data('defaultSurveyFormTitle'),
+        surveyFormEmailLabel:$emailSurveyTemplate.data('defaultSurveyFormEmailLabel'),
+        surveyFormCta: $emailSurveyTemplate.data('defaultSurveyFormCta'),
+        surveyFormCtaPostscript: $emailSurveyTemplate.data('defaultSurveyFormCtaPostscript'),
+        surveySuccess: $emailSurveyTemplate.data('defaultSurveySuccess'),
+        surveyFailure: $emailSurveyTemplate.data('defaultSurveyFailure'),
+        render: function(survey) {
+          var templateArguments = (survey.templateArguments || {});
+
+          return this.template.
+            replace(/\{\{title\}\}/g, templateArguments.title || this.title).
+            replace(/\{\{noThanks\}\}/g, templateArguments.noThanks || this.noThanks).
+            replace(/\{\{surveyCta\}\}/g, templateArguments.surveyCta || this.surveyCta).
+            replace(/\{\{surveyFormTitle\}\}/g, templateArguments.surveyFormTitle || this.surveyFormTitle).
+            replace(/\{\{surveyFormEmailLabel\}\}/g, templateArguments.surveyFormEmailLabel || this.surveyFormEmailLabel).
+            replace(/\{\{surveyFormCta\}\}/g, templateArguments.surveyFormCta || this.surveyFormCta).
+            replace(/\{\{surveyFormCtaPostscript\}\}/g, templateArguments.surveyFormCtaPostscript || this.surveyFormCtaPostscript).
+            replace(/\{\{surveySuccess\}\}/g, templateArguments.surveySuccess || this.surveySuccess).
+            replace(/\{\{surveyFailure\}\}/g, templateArguments.surveyFailure || this.surveyFailure).
+            replace(/\{\{surveyId\}\}/g, survey.identifier).
+            replace(/\{\{surveySource\}\}/g, userSurveys.currentPath());
+        }
+      };
+    },
+
     getActiveSurvey: function(defaultSurvey, smallSurveys) {
       var activeSurvey = defaultSurvey;
 
@@ -243,29 +268,17 @@
     },
 
     displayURLSurvey: function(survey, surveyContainer) {
-      surveyContainer.append(survey.template || URL_SURVEY_TEMPLATE);
+      var urlSurveyTemplate = userSurveys.getUrlSurveyTemplate();
 
-      var $surveyLink = $('#take-survey');
-      var surveyUrl = survey.url;
-
-      // Survey monkey can record the URL of the survey link if passed through as a query param
-      if ((/surveymonkey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
-        surveyUrl += "?c=" + userSurveys.currentPath();
-      }
-
-      $surveyLink.attr('href', surveyUrl);
+      surveyContainer.append(urlSurveyTemplate.render(survey));
 
       userSurveys.setURLSurveyEventHandlers(survey);
     },
 
     displayEmailSurvey: function(survey, surveyContainer) {
-      surveyContainer.append(survey.template || EMAIL_SURVEY_TEMPLATE);
+      var emailSurveyTemplate = userSurveys.getEmailSurveyTemplate();
 
-      var $surveyId = $('#email-survey-form input[name="email_survey_signup[survey_id]"]'),
-        $surveySource = $('#email-survey-form input[name="email_survey_signup[survey_source]"]');
-
-      $surveyId.val(survey.identifier);
-      $surveySource.val(userSurveys.currentPath());
+      surveyContainer.append(emailSurveyTemplate.render(survey));
 
       userSurveys.setEmailSurveyEventHandlers(survey);
     },

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -26,7 +26,9 @@
 <% end %>
 
 <% content_for :after_header do %>
-  <div id="user-satisfaction-survey-container"></div>
+  <div id="user-satisfaction-survey-container">
+    <%= render :partial => 'surveys' %>
+  </div>
   <% if @banner_notification.present? %>
     <%= @banner_notification %>
   <% end %>

--- a/app/views/root/_surveys.html.erb
+++ b/app/views/root/_surveys.html.erb
@@ -1,2 +1,3 @@
 <%= render :partial => 'surveys/url_survey_template' %>
 <%= render :partial => 'surveys/email_survey_template' %>
+<%= render :partial => 'surveys/survey_definitions' %>

--- a/app/views/root/_surveys.html.erb
+++ b/app/views/root/_surveys.html.erb
@@ -1,0 +1,2 @@
+<%= render :partial => 'surveys/url_survey_template' %>
+<%= render :partial => 'surveys/email_survey_template' %>

--- a/app/views/surveys/_email_survey_template.html.erb
+++ b/app/views/surveys/_email_survey_template.html.erb
@@ -1,0 +1,39 @@
+<script type="text/html+template"
+        id="email-survey-template"
+        data-default-title="Tell us what you think of GOV.UK"
+        data-default-no-thanks="No thanks"
+        data-default-survey-cta="Your feedback will help us improve this website"
+        data-default-survey-form-title="We’d like to hear from you"
+        data-default-survey-form-email-label="Tell us your email address and we’ll send you a link to a quick feedback form."
+        data-default-survey-form-cta="Send"
+        data-default-survey-form-cta-postscript="We won’t store your email address or share it with anyone"
+        data-default-survey-success="Thanks, we’ve sent you an email with a link to the survey."
+        data-default-survey-failure="Sorry, we’re unable to send you an email right now.  Please try again later.">
+  <section id="user-satisfaction-survey" class="visible" aria-hidden="false">
+    <div id="email-survey-pre" class="wrapper">
+      <h1>{{title}}</h1>
+      <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">{{noThanks}}</a></p>
+      <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer">{{surveyCta}}</a></p>
+    </div>
+    <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="wrapper js-hidden" aria-hidden="true">
+      <div id="feedback-prototype-form">
+        <h1>{{surveyFormTitle}}</h1>
+        <p class="right"><a href="#email-survey-cancel" id="email-survey-cancel">{{noThanks}}</a></p>
+        <label for="email">{{surveyFormEmailLabel}}</label>
+        <input name="email_survey_signup[survey_id]" type="hidden" value="{{surveyId}}">
+        <input name="email_survey_signup[survey_source]" type="hidden" value="{{surveySource}}">
+        <input name="email_survey_signup[email_address]" type="text" placeholder="Your email address">
+        <div class="actions">
+          <button type="submit">{{surveyFormCta}}</button>
+          <p class="button-info">{{surveyFormCtaPostscript}}</p>
+        </div>
+      </div>
+    </form>
+    <div id="email-survey-post-success" class="wrapper js-hidden" aria-hidden="true">
+      <p>{{surveySuccess}}</p>
+    </div>
+    <div id="email-survey-post-failure" class="wrapper js-hidden" aria-hidden="true">
+      <p>{{surveyFailure}}</p>
+    </div>
+  </section>
+</script>

--- a/app/views/surveys/_survey_definitions.html.erb
+++ b/app/views/surveys/_survey_definitions.html.erb
@@ -1,6 +1,6 @@
 <script type="application/json" data-survey-default>
   {
-    "url": "https://www.surveymonkey.com/s/2MRDLTW?c={{currentPath}}",
+    "url": "https://www.smartsurvey.co.uk/s/gov-uk",
     "identifier": "user_satisfaction_survey",
     "frequency": 50,
     "surveyType": "url",
@@ -8,47 +8,134 @@
 </script>
 <script type="application/json" data-survey>
   {
-    "url:" "https://www.smartsurvey.co.uk/s/6YYKX/",
-    "identifier": "ons_survey",
-    "templateArguments": {
-      "surveyCta": "Give us your feedback on government statistical data"
-    },
-    "frequency": 1,
+    "identifier": "govuk_email_survey_t02",
+    "frequency": 10,
     "activeWhen": {
-      "path": ["^\/government\/statistics\/?$"]
+      "breadcrumb": ["Education", "Childcare", "Schools"],
+      "section": ["education", "childcare", "schools"],
+      "organisation": ["<D6>", "<D106>", "<D109>", "<EA243>", "<EA86>", "<EA242>", "<EA541>"],
+      "matchType": "exclude"
     },
-    "surveyType": "url",
-    "startTime": "January 25, 2017",
-    "endTime": "February 27, 2017 23:59:59"
+    "surveyType": "email",
+    "startTime": "April 3, 2017 10:00:00",
+    "endTime": "April 4, 2017 23:59:59"
   },
 </script>
 <script type="application/json" data-survey>
   {
-    "identifier": "govuk_email_survey_t01",
-    "frequency": 1,
+    "url": "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign={{currentPath}}&utm_source=Hold_gov_to_account&utm_medium=gov.uk%20survey&t=GDS",
+    "identifier": "mar_ur_panel",
+    "frequency": 5,
     "activeWhen": {
-      "breadcrumb": ["Education", "Childcare", "Schools"],
-      "section": ["education", "childcare", "schools"],
-      "organisation": ["<D6>", "<D106>", "<D109>", "<EA243>", "<EA86>", "<EA242>", "<EA541>"],
-      "matchType": "exclude"
+      "path": [
+        "government/policies",
+        "government/how-government-works",
+        "make-a-freedom-of-information-request",
+        "government/collections/open-government",
+        "government/publications/uk-open-government-national-action-plan-2016-18/uk-open-government-national-action-plan-2016-18",
+        "government/policies/government-transparency-and-accountability",
+        "topic/local-government/transparency"
+      ],
+      "matchType": "include"
     },
-    "surveyType": "email",
-    "startTime": "March 08, 2017",
-    "endTime": "March 10, 2017 12:59:59"
+    "surveyType": "url",
+    "startTime": "March 20, 2017 00:00:00",
+    "endTime": "April 21, 2017 23:59:59"
   }
 </script>
 <script type="application/json" data-survey>
   {
-    "identifier": "govuk_email_survey_t02",
-    "frequency": 2,
+    "url": "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign={{currentPath}}&utm_source=Improve_platform_basics&utm_medium=gov.uk%20survey&t=GDS",
+    "identifier": "mar_ur_panel",
+    "frequency": 5,
     "activeWhen": {
-      "breadcrumb": ["Education", "Childcare", "Schools"],
-      "section": ["education", "childcare", "schools"],
-      "organisation": ["<D6>", "<D106>", "<D109>", "<EA243>", "<EA86>", "<EA242>", "<EA541>"],
-      "matchType": "exclude"
+      "path": [
+        "government/world",
+        "government/world/australia",
+        "government/world/china",
+        "government/world/india",
+        "government/world/pakistan",
+        "government/world/usa"
+      ],
+      "matchType": "include"
     },
-    "surveyType": "email",
-    "startTime": "March 10, 2017 13:00:00",
-    "endTime": "March 13, 2017 23:59:59"
+    "surveyType": "url",
+    "startTime": "March 20, 2017 00:00:00",
+    "endTime": "April 21, 2017 23:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=Anti_Money_Laundering&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "frequency": 5,
+    "activeWhen": {
+      "path": [
+        "government/publications/money-laundering-regulations-application-for-registration-mlr100"
+      ],
+      "matchType": "include"
+    },
+    "surveyType": "url",
+    "startTime": "March 22, 2017 00:00:00",
+    "endTime": "April 20, 2017 23:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=P800&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "frequency": 5,
+    "activeWhen": {
+      "path": [
+        "claim-tax-refund"
+      ],
+      "matchType": "include"
+    },
+    "surveyType": "url",
+    "startTime": "March 22, 2017 00:00:00",
+    "endTime": "April 20, 2017 23:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=IHT&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "frequency": 5,
+    "activeWhen": {
+      "path": [
+        "government/publications/inheritance-tax-inheritance-tax-account-iht400"
+      ],
+      "matchType": "include"
+    },
+    "surveyType": "url",
+    "startTime": "March 22, 2017 00:00:00",
+    "endTime": "April 20, 2017 23:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=TAV_C&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "frequency": 5,
+    "activeWhen": {
+      "path": [
+        "guidance/venture-capital-schemes-apply-for-the-enterprise-investment-scheme"
+      ],
+      "matchType": "include"
+    },
+    "surveyType": "url",
+    "startTime": "March 22, 2017 00:00:00",
+    "endTime": "April 20, 2017 23:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=capital_gains&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "frequency": 5,
+    "activeWhen": {
+      "path": [
+        "capital-gains-tax"
+      ],
+      "matchType": "include"
+    },
+    "surveyType": "url",
+    "startTime": "March 22, 2017 00:00:00",
+    "endTime": "April 20, 2017 23:59:59"
   }
 </script>

--- a/app/views/surveys/_survey_definitions.html.erb
+++ b/app/views/surveys/_survey_definitions.html.erb
@@ -1,6 +1,6 @@
 <script type="application/json" data-survey-default>
   {
-    "url": "https://www.surveymonkey.com/s/2MRDLTW",
+    "url": "https://www.surveymonkey.com/s/2MRDLTW?c={{currentPath}}",
     "identifier": "user_satisfaction_survey",
     "frequency": 50,
     "surveyType": "url",

--- a/app/views/surveys/_survey_definitions.html.erb
+++ b/app/views/surveys/_survey_definitions.html.erb
@@ -67,6 +67,7 @@
 <script type="application/json" data-survey>
   {
     "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=Anti_Money_Laundering&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "identifier": "user_research_panel",
     "frequency": 5,
     "activeWhen": {
       "path": [
@@ -82,6 +83,7 @@
 <script type="application/json" data-survey>
   {
     "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=P800&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "identifier": "user_research_panel",
     "frequency": 5,
     "activeWhen": {
       "path": [
@@ -97,6 +99,7 @@
 <script type="application/json" data-survey>
   {
     "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=IHT&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "identifier": "user_research_panel",
     "frequency": 5,
     "activeWhen": {
       "path": [
@@ -112,6 +115,7 @@
 <script type="application/json" data-survey>
   {
     "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=TAV_C&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "identifier": "user_research_panel",
     "frequency": 5,
     "activeWhen": {
       "path": [
@@ -127,6 +131,7 @@
 <script type="application/json" data-survey>
   {
     "url": "https://signup.take-part-in-research.service.gov.uk/?utm_campaign=capital_gains&utm_source=govukother&utm_medium=gov.uk%20survey&t=HMRC",
+    "identifier": "user_research_panel",
     "frequency": 5,
     "activeWhen": {
       "path": [

--- a/app/views/surveys/_survey_definitions.html.erb
+++ b/app/views/surveys/_survey_definitions.html.erb
@@ -1,0 +1,54 @@
+<script type="application/json" data-survey-default>
+  {
+    "url": "https://www.surveymonkey.com/s/2MRDLTW",
+    "identifier": "user_satisfaction_survey",
+    "frequency": 50,
+    "surveyType": "url",
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "url:" "https://www.smartsurvey.co.uk/s/6YYKX/",
+    "identifier": "ons_survey",
+    "templateArguments": {
+      "surveyCta": "Give us your feedback on government statistical data"
+    },
+    "frequency": 1,
+    "activeWhen": {
+      "path": ["^\/government\/statistics\/?$"]
+    },
+    "surveyType": "url",
+    "startTime": "January 25, 2017",
+    "endTime": "February 27, 2017 23:59:59"
+  },
+</script>
+<script type="application/json" data-survey>
+  {
+    "identifier": "govuk_email_survey_t01",
+    "frequency": 1,
+    "activeWhen": {
+      "breadcrumb": ["Education", "Childcare", "Schools"],
+      "section": ["education", "childcare", "schools"],
+      "organisation": ["<D6>", "<D106>", "<D109>", "<EA243>", "<EA86>", "<EA242>", "<EA541>"],
+      "matchType": "exclude"
+    },
+    "surveyType": "email",
+    "startTime": "March 08, 2017",
+    "endTime": "March 10, 2017 12:59:59"
+  }
+</script>
+<script type="application/json" data-survey>
+  {
+    "identifier": "govuk_email_survey_t02",
+    "frequency": 2,
+    "activeWhen": {
+      "breadcrumb": ["Education", "Childcare", "Schools"],
+      "section": ["education", "childcare", "schools"],
+      "organisation": ["<D6>", "<D106>", "<D109>", "<EA243>", "<EA86>", "<EA242>", "<EA541>"],
+      "matchType": "exclude"
+    },
+    "surveyType": "email",
+    "startTime": "March 10, 2017 13:00:00",
+    "endTime": "March 13, 2017 23:59:59"
+  }
+</script>

--- a/app/views/surveys/_url_survey_template.html.erb
+++ b/app/views/surveys/_url_survey_template.html.erb
@@ -1,0 +1,14 @@
+<script type="text/html+template"
+        id="url-survey-template"
+        data-default-title="Tell us what you think of GOV.UK"
+        data-default-no-thanks="No thanks"
+        data-default-survey-cta="Take the 3 minute survey"
+        data-default-survey-cta-postscript="This will open a short survey on another website">
+  <section id="user-satisfaction-survey" class="visible" aria-hidden="false">
+    <div class="wrapper">
+      <h1>{{title}}</h1>
+      <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">{{noThanks}}</a></p>
+      <p><a href="{{surveyUrl}}" id="take-survey" target="_blank" rel="noopener noreferrer">{{surveyCta}}</a> {{surveyCtaPostscript}}</p>
+    </div>
+  </section>
+</script>

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -25,8 +25,8 @@ There are sections of the site that should not show any surveys and these can be
     organisation: ['<D106>'],
     matchType: 'include'
   },
-  startTime: new Date("July 25, 2016").getTime(),
-  endTime: new Date("August 3, 2016 23:59:50").getTime()
+  startTime: "July 25, 2016",
+  endTime: "August 3, 2016 23:59:50"
 }
 ```
 
@@ -148,4 +148,4 @@ In the example above, the survey will only be considered "active" on pages with 
 Not providing any `activeWhen` parameters, or providing an empty `activeWhen` parameter will apply the survey to all pages on GOV.UK between `startTime` and `endTime`, so take care when doing this.
 
 ### `startTime` and `endTime`
-The survey will only be considered "active" between these dates and times. Where an explicit time is not provided (e.g. startTime) note that JavaScript will assume 00:00:00.000 i.e. just after midnight.
+The survey will only be considered "active" between these dates and times. These strings are passed into `new Date(...)` to parse them into real times, so note that where an explicit time is not provided (e.g. startTime) this will assume 00:00:00.000 i.e. just after midnight.

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -47,8 +47,11 @@ What type of survey is this.  Currently either `url` or `email` is supported.  `
 
 Note that for `email` surveys the users email is submitted back to the [feedback](https://github.com/alphagov/feedback) app which actually sends the email.  The email address is sent with the `identifier` of the survey and this identifier must match with the `id` of a survey defined in [`app/models/email_survey.rb`](https://github.com/alphagov/feedback/blob/85e07b0c572a91be02b64af1d551df313f2695f9/app/models/email_survey.rb#L24).  Make sure you define the survey in both `static` and `feedback`.
 
-### `url` - required for `url` surveys
-This should link to a surveymonkey -- or other survey page -- that allows the visitor to take the survey.
+### `url` - required for `url` surveys, ignored for `email` surveys
+This should link to a surveymonkey -- or other survey page -- that allows the visitor to take the survey.  If the url contains the template param `{{currentPath}}` this will be replaced with the current page path.  For example if the `url` param is:
+
+* `https://www.surveymonkey.com/s/2AAAAAA/` - it will be left alone and inserted in the template as-is.
+* `https://www.surveymonkey.com/s/2AAAAAA/?c={{currentPath}}` - will be transformed into `https://www.surveymonkey.com/s/2AAAAAA/?c=/government/publications/the-temple-of-the-jedi-order` (assuming the page the survey was shown on was https://www.gov.uk/government/publications/the-temple-of-the-jedi-order).
 
 ### `templateArguments` - OPTIONAL
 This allows you to customise the text in the survey.  The available options for customisation are based on the `surveyType`

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -1,34 +1,38 @@
 # Running test surveys on GOV.UK
 
-Across GOV.UK, a "survey" will pop up for one in 50 visitors, asking them what they thought of GOV.UK. This is known as the "user satisfaction survey".
+Across GOV.UK, a "survey" will pop up for one in 50 visitors, asking them what they thought of GOV.UK. This is known as the "user satisfaction survey", or "default survey".
 
-Sometimes, a "small survey" or "test survey" needs to be run across GOV.UK for a short time to evaluate content changes or taxonomy changes.
+Sometimes, we want to run some other survey across a different set of pages across GOV.UK for a short time to evaluate content changes or taxonomy changes.
 
-This can easily be done by adding an entry to `GOVUK.userSurveys.smallSurveys` in `app/assets/javascripts/surveys.js`.
+This can easily be done by adding an entry to `app/views/surveys/_survey_definitions.html.erb`.
 
 There are sections of the site that should not show any surveys and these can be controlled via the `GOVUK.userSurveys.pathInBlacklist` function in `app/assets/javascripts/surveys.js`.  They are also never shown on "done" pages which can be controlled via the `GOVUK.userSurveys.userCompletedTransaction` function in the same file.
 
 ## Example
 
-```javascript
-{
-  url: 'https://www.surveymonkey.com/s/2AAAAAA/',
-  identifier: 'education_only_survey',
-  frequency: 50,
-  templateArguments: {
-    title: "Help us improve GOV.UK",
-  },
-  activeWhen: {
-    section: ['education and learning'],
-    path: ['guidance/social-care-common-inspection-framework-sccif-boarding-schools'],
-    breadcrumbs: ['Schools'],
-    organisation: ['<D106>'],
-    matchType: 'include'
-  },
-  startTime: "July 25, 2016",
-  endTime: "August 3, 2016 23:59:50"
-}
+```html
+<script type="application/json" data-survey>
+  {
+    "url": "https://www.surveymonkey.com/s/2AAAAAA/",
+    "identifier": "education_only_survey",
+    "frequency": 50,
+    "templateArguments": {
+      "title": "Help us improve GOV.UK",
+    },
+    "activeWhen": {
+      "section": ["education and learning"],
+      "path": ["guidance/social-care-common-inspection-framework-sccif-boarding-schools"],
+      "breadcrumbs": ["Schools"],
+      "organisation": ["<D106>"],
+      "matchType": "include"
+    },
+    "startTime": "July 25, 2016",
+    "endTime": "August 3, 2016 23:59:50"
+  }
+</script>
 ```
+
+Any script tag with the `data-survey` attribute will be read in as a potential survey to run, the default survey has the `data-survey-default` attribute on its script tag instead of `data-survey`.
 
 ## About the data structure
 

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -18,13 +18,12 @@ There are sections of the site that should not show any surveys and these can be
   templateArguments: {
     title: "Help us improve GOV.UK",
   },
-  activeWhen: function() {
-    function sectionMatches() {
-      return $('meta[property="govuk:section"]').attr('content') === 'education and learning';
-    }
-    function pageClassMatches() { return $('#page').hasClass('magic-content'); }
-
-    return (sectionMatches() || pageClassMatches());
+  activeWhen: {
+    section: ['education and learning'],
+    path: ['guidance/social-care-common-inspection-framework-sccif-boarding-schools'],
+    breadcrumbs: ['Schools'],
+    organisation: ['<D106>'],
+    matchType: 'include'
   },
   startTime: new Date("July 25, 2016").getTime(),
   endTime: new Date("August 3, 2016 23:59:50").getTime()
@@ -129,26 +128,24 @@ The following are not customisable via `templateArguments`, but are calculated:
 * surveySource - this is filled in with the current path
 
 ### `activeWhen` - OPTIONAL
-A callback function returning true or false allowing further scoping of when the survey is considered "active".
+By default a survey will run on all pages on GOV.UK.  If you specify parameters in the `activeWhen` we limit which pages the survey will appear on.  There are five params, all are optional:
 
-In the example above, the survey will only be considered "active" on pages with a section of "education and learning", and will not display on pages where this function evaluates to false.
+* `matchType` - (optional) the default is "include".  This tells us how to interpret the other params.  For "include" we treat the params as limiting the survey to only display on those pages that match one or more of the params.  For "exclude" we treat the params as limiting the survey to only display on those pages that do not match any of the params.  If the value is other than "include" or "exclude" it is assumed to be "include".
+* `path` - (optional).  If present this is used to match complete path segments in the path of the page.  Each entry is turned into a regexp as follows: `statistcis` becomes `/\/statistics(\/|$)/` and this means that a value of "statistics" would match a path like "/government/statistics/a-very-large-report", but not a path like "/guidance/how-to-download-statistics-and-announcements".  If you use regex special characters `^` or `$` then the string is not changed before being turned into a regexp to match paths.
+* `breadcrumb` - (optional).  If present this is used to match against the text in the `.govuk-breadcrumb` element on the page.  The text match is case-insensitive and does not attempt to match complete words so `hats` would match `Hats` and `Chats`.
+* `section` - (optional).  If present this is used to match against the value of the content attribute of the `govuk:section` meta tag on the page.  The text match is case-insensitive and does not attempt to match complete words so `hats` would match `Hats` and `Chats`.
+* `organisation` - (optional).  If present this is used to match against the value of the content attribute of the `govuk:analytics:organisations` meta tag on the page.  The text match is case-sensitive and does not attempt to match complete words so `hats` would match `hats` and `Chats`, but not `Hats`.
 
-Additional examples of functions which control when a survey should be active based on the current path and organisation:
+Other than `matchType`, all params are specified as arrays, allowing multiple possible values.  All values are OR'd together so that only one of them has to match, not all of them.
 
-```javascript
-function pathMatches() {
-  var pathMatchingExpr = /\/foreign-travel-advice|\/government\/world/;
-  return pathMatchingExpr.test(currentPath());
-}
+In the example above, the survey will only be considered "active" on pages with any of:
 
-function organisationMatches() {
-  var orgMatchingExpr = /<D13>|<OT554>|<D8>|<D1196>/;
-  var metaText = $('meta[name="govuk:analytics:organisations"]').attr('content') || "";
-  return orgMatchingExpr.test(metaText);
-}
-```
+1. a govuk:section meta tag with "education and learning",
+2. a path that includes `guidance/social-care-common-inspection-framework-sccif-boarding-schools`
+3. a govuk:analytics:organisation that includes `<D106>`
+4. the word `Schools` appearing in the text of the `.govuk-breadcrumb` element on the page
 
-Not providing the `activeWhen` argument has the same effect as setting it to `return true`. The survey will therefore apply to all pages on GOV.UK between `startTime` and `endTime`.
+Not providing any `activeWhen` parameters, or providing an empty `activeWhen` parameter will apply the survey to all pages on GOV.UK between `startTime` and `endTime`, so take care when doing this.
 
 ### `startTime` and `endTime`
 The survey will only be considered "active" between these dates and times. Where an explicit time is not provided (e.g. startTime) note that JavaScript will assume 00:00:00.000 i.e. just after midnight.

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -487,13 +487,13 @@ describe("Surveys", function() {
     // we make sure that slash-terminated and slash-unterminated versions
     // of these paths work
     it("returns true if the path is /service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/service-manual', '/service-manual/');
+      spyOn(surveys, 'currentPath').and.returnValues('/service-manual', '/service-manual/');
       expect(surveys.pathInBlacklist()).toBeTruthy();
       expect(surveys.pathInBlacklist()).toBeTruthy();
     });
 
     it("returns true if the path is a sub-folder under /service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/service-manual/some-other-page', '/service-manual/some-other-page/');
+      spyOn(surveys, 'currentPath').and.returnValues('/service-manual/some-other-page', '/service-manual/some-other-page/');
       expect(surveys.pathInBlacklist()).toBeTruthy();
       expect(surveys.pathInBlacklist()).toBeTruthy();
     });
@@ -505,7 +505,7 @@ describe("Surveys", function() {
     });
 
     it("returns false if the path is /some-other-parent-of/service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/some-other-parent-of/service-manual', '/some-other-parent-of/service-manual/');
+      spyOn(surveys, 'currentPath').and.returnValues('/some-other-parent-of/service-manual', '/some-other-parent-of/service-manual/');
       expect(surveys.pathInBlacklist()).toBeFalsy();
       expect(surveys.pathInBlacklist()).toBeFalsy();
     });

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -258,24 +258,22 @@ describe("Surveys", function() {
     });
 
     describe("for a 'url' survey", function() {
-      it("links to the url for a surveymonkey survey and adds the current path as a `c` param", function () {
+      it("inserts the survey url in the template", function () {
         surveys.displaySurvey(urlSurvey);
 
-        expect($('#take-survey').attr('href')).toContain(urlSurvey.url);
-        expect($('#take-survey').attr('href')).toContain("?c=" + window.location.pathname);
+        expect($('#take-survey').attr('href')).toEqual(urlSurvey.url);
       });
 
-      it("links to the url for a non-surveymonkey survey without adding the current path as a `c` param", function () {
+      it("injects the current path if the survey url contains a {{currentPath}} tempalte parameter", function() {
         var nonSurveyMonkeyUrlSurvey = {
           surveyType: 'url',
-          url: 'surveygorilla.com/default',
+          url: 'surveygorilla.com/default?c={{currentPath}}',
           identifier: 'url-survey',
         }
         surveys.displaySurvey(nonSurveyMonkeyUrlSurvey);
 
-        expect($('#take-survey').attr('href')).toContain(nonSurveyMonkeyUrlSurvey.url);
-        expect($('#take-survey').attr('href')).not.toContain("?c=" + window.location.pathname);
-      });
+        expect($('#take-survey').attr('href')).toEqual('surveygorilla.com/default?c=' + window.location.pathname);
+      })
 
       it("records an event when showing the survey", function() {
         spyOn(surveys, 'trackEvent');

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -122,11 +122,23 @@ describe("Surveys", function() {
     });
 
     describe("for a 'url' survey", function() {
-      it("links to the url for a surveymonkey survey with a completion redirect query parameter", function () {
+      it("links to the url for a surveymonkey survey and adds the current path as a `c` param", function () {
         surveys.displaySurvey(urlSurvey);
 
         expect($('#take-survey').attr('href')).toContain(urlSurvey.url);
         expect($('#take-survey').attr('href')).toContain("?c=" + window.location.pathname);
+      });
+
+      it("links to the url for a non-surveymonkey survey without adding the current path as a `c` param", function () {
+        var nonSurveyMonkeyUrlSurvey = {
+          surveyType: 'url',
+          url: 'surveygorilla.com/default',
+          identifier: 'url-survey',
+        }
+        surveys.displaySurvey(nonSurveyMonkeyUrlSurvey);
+
+        expect($('#take-survey').attr('href')).toContain(nonSurveyMonkeyUrlSurvey.url);
+        expect($('#take-survey').attr('href')).not.toContain("?c=" + window.location.pathname);
       });
 
       it("records an event when showing the survey", function() {

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -733,15 +733,15 @@ describe("Surveys", function() {
     });
   });
 
-  describe("activeWhen", function() {
+  describe("surveyIsAllowedToRunBasedOnActiveWhen", function() {
     it("returns true if the survey has empty activeWhen definitions", function() {
       var survey = {
         identifier: 'a_survey'
       };
-      expect(surveys.activeWhen(survey)).toBe(true);
+      expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
 
       survey.activeWhen = {};
-      expect(surveys.activeWhen(survey)).toBe(true);
+      expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
     });
 
     describe("for 'include' matchType", function() {
@@ -754,9 +754,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/foo/bar', '/bar/foo');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("allows path separators in the path definition, returning true if they match a complete set of path segments in the currentPath", function() {
@@ -767,10 +767,10 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/foo/bar', '/bar/foo', '/baz/foo/bar/qux');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if the path definition does not match the currentPath at all", function() {
@@ -781,7 +781,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValue('/bar');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns false if the path definition matches an incomplete path segment of the currentPath", function() {
@@ -792,9 +792,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo-bar', '/bar-foo', '/i/like/food/');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if any of the path definitions matches a complete path segment in the currentPath", function() {
@@ -805,9 +805,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/food/bar', '/bard/baz/food');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("treats the path definition as a complete match, rather than a path segment match if it includes '^' or '$'", function() {
@@ -818,11 +818,11 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/food', 'foo/', '/foo/bar', '/bar/foo');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
       });
 
@@ -835,7 +835,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if the breadcrumb definition does not match the breadcrumb text at all", function() {
@@ -846,7 +846,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if any of the breadcrumb definitions matches the breadcrumb text", function() {
@@ -857,8 +857,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValues('Home  Education and learning  Schools', 'Home  Childcare and parenting  Maternity leave');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if none of the breadcrumb definitions matches the breadcrumb text", function() {
@@ -869,7 +869,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Benefits  Benfits for families');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
       });
@@ -883,7 +883,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Education');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if the section definition does not match the section meta tag at all", function() {
@@ -894,7 +894,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Education');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if any of the section definitions matches the section meta tag", function() {
@@ -905,8 +905,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValues('Education', 'Childcare');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if none of the section definitions matches the section meta tag", function() {
@@ -917,7 +917,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Schools');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
       });
 
@@ -930,7 +930,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if the organisation definition does not match one of the ids in the organisation meta tag", function() {
@@ -941,7 +941,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if any of the organisation definitions matches an id in the organisation meta tag", function() {
@@ -952,8 +952,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValues('<D10><E1345>', '<D20><E1555>');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if none of the organisation definitions matches the organisation meta tag", function() {
@@ -964,7 +964,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
       });
 
@@ -984,11 +984,11 @@ describe("Surveys", function() {
         spyOn(surveys, 'currentSection').and.returnValues('education', '', 'schools', 'benefits', 'homepage');
         spyOn(surveys, 'currentOrganisation').and.returnValues('<E1555><F12>', '<D20>', '<E1234>', '<D20><F10>', '<D10><E134>');
 
-        expect(surveys.activeWhen(survey)).toBe(true); // because of the breadcrumb
-        expect(surveys.activeWhen(survey)).toBe(true); // because of the path
-        expect(surveys.activeWhen(survey)).toBe(true); // because of the section
-        expect(surveys.activeWhen(survey)).toBe(false); // because nothing matches
-        expect(surveys.activeWhen(survey)).toBe(true); // because of the organisation
+        expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true); // because of the breadcrumb
+        expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true); // because of the path
+        expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true); // because of the section
+        expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false); // because nothing matches
+        expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true); // because of the organisation
       });
     });
 
@@ -1003,9 +1003,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/foo/bar', '/bar/foo');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("allows path separators in the path definition, returning false if they match a complete set of path segments in the currentPath", function() {
@@ -1017,10 +1017,10 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/foo/bar', '/bar/foo', '/baz/foo/bar/qux');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if the excludes path definition does not match the currentPath at all", function() {
@@ -1032,7 +1032,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValue('/bar');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns true if the excludes path definition matches an incomplete path segment of the currentPath", function() {
@@ -1044,9 +1044,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo-bar', '/bar-foo', '/i/like/food/');
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if any of the path definitions matches a complete path segment in the currentPath", function() {
@@ -1058,9 +1058,9 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/food/bar', '/bard/baz/food');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("treats the path definition as a complete match, rather than a path segment match if it includes '^' or '$'", function() {
@@ -1072,11 +1072,11 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentPath').and.returnValues('/foo', '/food', 'foo/', '/foo/bar', '/bar/foo');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
       });
 
@@ -1090,7 +1090,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if the breadcrumb definition does not match the breadcrumb text at all", function() {
@@ -1102,7 +1102,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if any of the breadcrumb definitions matches the breadcrumb text", function() {
@@ -1114,8 +1114,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValues('Home  Education and learning  Schools', 'Home  Childcare and parenting  Maternity leave');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if none of the breadcrumb definitions matches a complete path segment in the currentPath", function() {
@@ -1127,7 +1127,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Benefits  Benfits for families');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
       });
 
@@ -1141,7 +1141,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Education');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if the section definition does not match the section meta tag at all", function() {
@@ -1153,7 +1153,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Education');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if any of the section definitions matches the section meta tag", function() {
@@ -1165,8 +1165,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValues('Education', 'Childcare');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if none of the section definitions matches the section meta tag", function() {
@@ -1178,7 +1178,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentSection').and.returnValue('Schools');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
       });
 
@@ -1192,7 +1192,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if the organisation definition does not match one of the ids in the organisation meta tag", function() {
@@ -1204,7 +1204,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
 
         it("returns false if any of the organisation definitions matches an id in the organisation meta tag", function() {
@@ -1216,8 +1216,8 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValues('<D10><E1345>', '<D20><E1555>');
-          expect(surveys.activeWhen(survey)).toBe(false);
-          expect(surveys.activeWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(false);
         });
 
         it("returns true if none of the organisation definitions matches the organisation meta tag", function() {
@@ -1229,7 +1229,7 @@ describe("Surveys", function() {
             }
           }
           spyOn(surveys, 'currentOrganisation').and.returnValue('<D10><E1345>');
-          expect(surveys.activeWhen(survey)).toBe(true);
+          expect(surveys.surveyIsAllowedToRunBasedOnActiveWhen(survey)).toBe(true);
         });
       });
     });
@@ -1261,7 +1261,7 @@ describe("Surveys", function() {
     describe("when a survey is allowed to run because of the current time", function() {
       it("picks the survey from small surveys if the activeWhen function returns true for it", function() {
         spyOn(surveys, 'currentTime').and.returnValue(new Date("July 9, 2016 10:00:00").getTime());
-        spyOn(surveys, 'activeWhen').and.returnValue(true);
+        spyOn(surveys, 'surveyIsAllowedToRunBasedOnActiveWhen').and.returnValue(true);
 
         var testSurvey = {
           startTime: "July 5, 2016",
@@ -1275,7 +1275,7 @@ describe("Surveys", function() {
 
       it("picks the default survey if the activeWhen function returns false for all the small surveys", function() {
         spyOn(surveys, 'currentTime').and.returnValue(new Date("July 9, 2016 10:00:00").getTime());
-        spyOn(surveys, 'activeWhen').and.returnValue(false);
+        spyOn(surveys, 'surveyIsAllowedToRunBasedOnActiveWhen').and.returnValue(false);
 
         var testSurvey = {
           startTime: "July 5, 2016",


### PR DESCRIPTION
For: https://trello.com/c/8YSfHXc2/110-reduce-need-to-change-static-js-when-deploying-surveys

Inspiration (if not any code) taken from @NeilvB's WIP here: https://github.com/alphagov/static/tree/survey-template-in-html which in turn was based on a conversation with @nickcolley.

The goal here is to define the surveys outside the JS bundle, so that we don't break the caching benefits for frequent visitors.  The approach here is to define the templates and surveys in `script` tags (using html for the template, and json for the surveys) in the HTML and to read the contents of those in the surveys JS implementation.

All of the dynamic parts of the definition have been moved into the survey implementation so that the survey definitions can be expressed in pure JSON, rather than the Javascript Object form they were in when they lived in the JS file.  This may or may not require more thought to check for security concerns.

This is best reviewed commit-by-commit I think as there's a lot of change involved in taking the dynamic parts out and making them into parameterised strings.  Particularly turning the "do what you want" `activeWhen: function () { ... }` into a simple object of parameters like `activeWhen: { path: ['government/publications'], organisations: ['<D10>'] }`.
