### PR TITLE
Track the navigation document type in Google analytics

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -112,6 +112,7 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
+    this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -201,6 +202,10 @@
     // set a page type in a meta tag, default to "thing", which identifes a page
     // as containing content rather than some kind of navigation.
     this.setDimension(33, journeyStage || "thing");
+  };
+
+  StaticAnalytics.prototype.setNavigationDocumentTypeDimension = function(documentType) {
+    this.setDimension(34, documentType);
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -32,6 +32,8 @@
   user_journey_stage = content_item_hash[:user_journey_document_supertype]
   meta_tags["govuk:user-journey-stage"] = user_journey_stage if user_journey_stage
 
+  navigation_document_type = content_item_hash[:navigation_document_supertype]
+  meta_tags["govuk:navigation-document-type"] = navigation_document_type if navigation_document_type
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -64,6 +64,7 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
+          <meta name="govuk:navigation-document-type" content="guidance">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -76,6 +77,7 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(setupArguments[4]).toEqual(['set', 'dimension7', 'historic']);
         expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
         expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(setupArguments[7]).toEqual(['set', 'dimension34', 'guidance']);
       });
 
       it('ignores meta tags not set', function() {

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -89,6 +89,11 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     assert_meta_tag('govuk:user-journey-stage', 'some-stage-of-journey')
   end
 
+  test "renders navigation document type when content item has navigation document supertype" do
+    render_component(content_item: { navigation_document_supertype: 'guidance' })
+    assert_meta_tag('govuk:navigation-document-type', 'guidance')
+  end
+
   test "renders 'political' political status when political content and government is current" do
     current = true
     political = true


### PR DESCRIPTION
Track the type of page using dimension 34. Pages are currently classified as 'guidance' or 'other', but more page types may be added in future.

This will help us understand user journeys through the new navigation, because only guidance content appears on the new taxonomy pages.

https://trello.com/c/Tkn0P6Fm/532-track-guidance-navigation-supertype-in-google-analytics