### PR TITLE
Track total number of breadcrumbs in Google Analytics

### DIFF
--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -24,8 +24,10 @@
             track_category: 'breadcrumbClicked',
             track_action: index + 1,
             track_label: path,
-            track_dimension: crumb[:title],
-            track_dimension_index: 29,
+            track_options: {
+              dimension28: breadcrumbs.length,
+              dimension29: crumb[:title]
+            }
           },
           class: css_class,
           aria: {

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -21,12 +21,35 @@ class BreadcrumbsTestCase < ComponentTestCase
   test "renders all data attributes for tracking" do
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 
+    expected_tracking_options = {
+      dimension28: 1,
+      dimension29: "Section"
+    }
+
     assert_select '.govuk-breadcrumbs[data-module="track-click"]', 1
     assert_select 'ol li:first-child a[data-track-action="1"]', 1
     assert_select 'ol li:first-child a[data-track-label="/section"]', 1
-    assert_select 'ol li:first-child a[data-track-dimension="Section"]', 1
     assert_select 'ol li:first-child a[data-track-category="breadcrumbClicked"]', 1
-    assert_select 'ol li:first-child a[data-track-dimension-index="29"]', 1
+    assert_select "ol li:first-child a[data-track-options='#{expected_tracking_options.to_json}']", 1
+  end
+
+  test "tracks the total breadcrumb count on each breadcrumb" do
+    breadcrumbs = [
+      { title: 'Section 1', url: '/section-1' },
+      { title: 'Section 2', url: '/section-2' },
+      { title: 'Section 3', url: '/section-3' },
+    ]
+    render_component(breadcrumbs: breadcrumbs)
+
+    expected_tracking_options = [
+      {dimension28: 3, dimension29: "Section 1"},
+      {dimension28: 3, dimension29: "Section 2"},
+      {dimension28: 3, dimension29: "Section 3"},
+    ]
+
+    assert_select "ol li:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1
+    assert_select "ol li:nth-child(2) a[data-track-options='#{expected_tracking_options[1].to_json}']", 1
+    assert_select "ol li:nth-child(3) a[data-track-options='#{expected_tracking_options[2].to_json}']", 1
   end
 
   test "renders a list of breadcrumbs" do


### PR DESCRIPTION
When a breadcrumb link is clicked, report the full length of the breadcrumb list as well as the existing tracking of title, position, etc.

This will help us understand the tracked breadcrumb position in the context of the full taxon list.

https://trello.com/c/JffDJtJ5/500-track-the-number-of-items-in-accordions-breadcrumbs-and-related-links