### PR TITLE
Track total number of related links in Google Analytics

### DIFF
--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -17,8 +17,10 @@
                   track_category: 'relatedLinkClicked',
                   track_action: "#{section_index + 1}.#{item_index + 1}",
                   track_label: item[:url],
-                  track_dimension: item[:title],
-                  track_dimension_index: 29,
+                  track_options: {
+                    dimension28: section[:items].length,
+                    dimension29: item[:title],
+                  },
                 },
                 rel: item[:rel],
               ) %>
@@ -32,8 +34,10 @@
                   track_category: 'relatedLinkClicked',
                   track_action: "#{section_index + 1}.#{section[:items].size + 1}",
                   track_label: section[:url],
-                  track_dimension: 'More',
-                  track_dimension_index: 29,
+                  track_options: {
+                    dimension28: sections.length,
+                    dimension29: "More",
+                  },
                 },
               ) do %>
                 <%= t("govuk_component.related_items.more", default: "More") %>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -13,8 +13,10 @@
                 track_category: 'relatedLinkClicked',
                 track_action: "#{item_index + 1}",
                 track_label: item[:url],
-                track_dimension: item[:title],
-                track_dimension_index: 29,
+                track_options: {
+                  dimension28: items.length,
+                  dimension29: item[:title],
+                },
               },
             )
           %>
@@ -37,8 +39,10 @@
                           track_category: 'relatedLinkClicked',
                           track_action: "#{item_index + 1}.#{related_content_index + 1}",
                           track_label: related_item[:link],
-                          track_dimension: related_item[:title],
-                          track_dimension_index: 29,
+                          track_options: {
+                            dimension28: item[:related_content].length,
+                            dimension29: related_item[:title],
+                          }
                       },
                       class: 'related-link',
                     ) do

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -144,26 +144,26 @@ class RelatedItemsTestCase < ComponentTestCase
 
     assert_select '.govuk-related-items[data-module="track-click"]', 1
 
-    assert_select "a[data-track-category=\"relatedLinkClicked\"]", 5
-    assert_select "a[data-track-dimension-index=\"29\"]", 5
-    assert_select "a[data-track-dimension=\"More\"]", 2
+    assert_tracking_link("category", "relatedLinkClicked", 5)
+    assert_tracking_link("dimension-index", "29", 5)
+    assert_tracking_link("dimension", "More", 2)
 
-    assert_select "a[data-track-action=\"1.1\"]", 1
-    assert_select "a[data-track-label=\"/item\"]", 1
-    assert_select "a[data-track-dimension=\"Item title\"]", 1
+    assert_tracking_link("action", "1.1")
+    assert_tracking_link("label", "/item")
+    assert_tracking_link("dimension", "Item title")
 
-    assert_select "a[data-track-action=\"1.2\"]", 1
-    assert_select "a[data-track-label=\"/other-item\"]", 1
-    assert_select "a[data-track-dimension=\"Other item title\"]", 1
+    assert_tracking_link("action", "1.2")
+    assert_tracking_link("label", "/other-item")
+    assert_tracking_link("dimension", "Other item title")
 
-    assert_select "a[data-track-action=\"1.3\"]", 1
-    assert_select "a[data-track-label=\"/more-link\"]", 1
+    assert_tracking_link("action", "1.3")
+    assert_tracking_link("label", "/more-link")
 
-    assert_select "a[data-track-action=\"2.1\"]", 1
-    assert_select "a[data-track-label=\"/foo\"]", 1
-    assert_select "a[data-track-dimension=\"Foo\"]", 1
+    assert_tracking_link("action", "2.1")
+    assert_tracking_link("label", "/foo")
+    assert_tracking_link("dimension", "Foo")
 
-    assert_select "a[data-track-action=\"2.2\"]", 1
-    assert_select "a[data-track-label=\"/another-more-link\"]", 1
+    assert_tracking_link("action", "2.2")
+    assert_tracking_link("label", "/another-more-link")
   end
 end

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -127,6 +127,10 @@ class RelatedItemsTestCase < ComponentTestCase
               title: "Other item title",
               url: "/other-item"
             },
+            {
+              title: "Another item title",
+              url: "/another-item"
+            },
           ]
         },
         {
@@ -142,26 +146,42 @@ class RelatedItemsTestCase < ComponentTestCase
       ],
     )
 
-    assert_select '.govuk-related-items[data-module="track-click"]', 1
+    total_sections = 2
+    total_links_in_section_1 = 3
+    total_links_in_section_2 = 1
 
-    assert_tracking_link("category", "relatedLinkClicked", 5)
-    assert_tracking_link("dimension-index", "29", 5)
-    assert_tracking_link("dimension", "More", 2)
+    assert_select '.govuk-related-items[data-module="track-click"]', 1
+    assert_tracking_link("category", "relatedLinkClicked", 6)
+
+    assert_tracking_link(
+      "options",
+      { dimension28: total_sections, dimension29: "More" }.to_json,
+      2)
 
     assert_tracking_link("action", "1.1")
     assert_tracking_link("label", "/item")
-    assert_tracking_link("dimension", "Item title")
+    expected_link_1_tracking_options = {
+      dimension28: total_links_in_section_1,
+      dimension29: "Item title",
+    }
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_1, dimension29: "Item title" }.to_json)
 
     assert_tracking_link("action", "1.2")
     assert_tracking_link("label", "/other-item")
-    assert_tracking_link("dimension", "Other item title")
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_1, dimension29: "Other item title" }.to_json)
 
     assert_tracking_link("action", "1.3")
     assert_tracking_link("label", "/more-link")
 
     assert_tracking_link("action", "2.1")
     assert_tracking_link("label", "/foo")
-    assert_tracking_link("dimension", "Foo")
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_2, dimension29: "Foo" }.to_json)
 
     assert_tracking_link("action", "2.2")
     assert_tracking_link("label", "/another-more-link")

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -100,19 +100,19 @@ class TaxonomySidebarTestCase < ComponentTestCase
     )
 
     assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
-    assert_select "a[data-track-category=\"relatedLinkClicked\"]", 3
-    assert_select "a[data-track-dimension-index=\"29\"]", 3
+    assert_tracking_link("category", "relatedLinkClicked", 3)
+    assert_tracking_link("dimension-index", "29", 3)
 
-    assert_select "a[data-track-dimension=\"Item title\"]", 1
-    assert_select "a[data-track-action=\"1\"]", 1
-    assert_select "a[data-track-label=\"/item\"]", 1
+    assert_tracking_link("dimension", "Item title")
+    assert_tracking_link("action", "1")
+    assert_tracking_link("label", "/item")
 
-    assert_select "a[data-track-dimension=\"Related link 1\"]", 1
-    assert_select "a[data-track-action=\"1.1\"]", 1
-    assert_select "a[data-track-label=\"/related-link-1\"]", 1
+    assert_tracking_link("dimension", "Related link 1")
+    assert_tracking_link("action", "1.1")
+    assert_tracking_link("label", "/related-link-1")
 
-    assert_select "a[data-track-dimension=\"Related link 2\"]", 1
-    assert_select "a[data-track-action=\"1.2\"]", 1
-    assert_select "a[data-track-label=\"/related-link-2\"]", 1
+    assert_tracking_link("dimension", "Related link 2")
+    assert_tracking_link("action", "1.2")
+    assert_tracking_link("label", "/related-link-2")
   end
 end

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -87,32 +87,59 @@ class TaxonomySidebarTestCase < ComponentTestCase
           description: "An item",
           related_content: [
             {
-              title: "Related link 1",
-              link: "/related-link-1",
+              title: "Related link 1a",
+              link: "/related-link-1a",
             },
             {
-              title: "Related link 2",
-              link: "/related-link-2",
+              title: "Related link 1b",
+              link: "/related-link-1b",
+            },
+            {
+              title: "Related link 1c",
+              link: "/related-link-1c",
+            },
+          ],
+        },
+        {
+          title: "Second item title",
+          url: "/item-2",
+          description: "Another item",
+          related_content: [
+            {
+              title: "Related link 2a",
+              link: "/related-link-2a",
             },
           ],
         },
       ]
     )
 
-    assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
-    assert_tracking_link("category", "relatedLinkClicked", 3)
-    assert_tracking_link("dimension-index", "29", 3)
+    total_sections = 2
+    total_links_in_section_1 = 3
 
-    assert_tracking_link("dimension", "Item title")
+    assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
+    assert_tracking_link("category", "relatedLinkClicked", 6)
+
+    expected_title_tracking_options = {
+      dimension28: total_sections,
+      dimension29: "Item title"
+    }
+    assert_tracking_link(
+      "options",
+      { dimension28: total_sections, dimension29: "Item title" }.to_json)
     assert_tracking_link("action", "1")
     assert_tracking_link("label", "/item")
 
-    assert_tracking_link("dimension", "Related link 1")
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_1, dimension29: "Related link 1a" }.to_json)
     assert_tracking_link("action", "1.1")
-    assert_tracking_link("label", "/related-link-1")
+    assert_tracking_link("label", "/related-link-1a")
 
-    assert_tracking_link("dimension", "Related link 2")
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_1, dimension29: "Related link 1a" }.to_json)
     assert_tracking_link("action", "1.2")
-    assert_tracking_link("label", "/related-link-2")
+    assert_tracking_link("label", "/related-link-1b")
   end
 end

--- a/test/govuk_component_test_helper.rb
+++ b/test/govuk_component_test_helper.rb
@@ -35,4 +35,8 @@ class ComponentTestCase < ActionView::TestCase
   def assert_timestamp_in(selector, timestamp, text)
     assert_select "#{selector} time[datetime=\"#{timestamp}\"]", text: text
   end
+
+  def assert_tracking_link(name, value, total = 1)
+    assert_select "a[data-track-#{name}=\"#{value}\"]", total
+  end
 end

--- a/test/govuk_component_test_helper.rb
+++ b/test/govuk_component_test_helper.rb
@@ -37,6 +37,6 @@ class ComponentTestCase < ActionView::TestCase
   end
 
   def assert_tracking_link(name, value, total = 1)
-    assert_select "a[data-track-#{name}=\"#{value}\"]", total
+    assert_select "a[data-track-#{name}='#{value}']", total
   end
 end


### PR DESCRIPTION
When a related link in the sidebar is clicked, track the size of the list that it is in:
 - If a taxon name or a 'more' link is clicked, track the number of sections
 - If a related link within a section is clicked, track the number of links in the section

This will help us analyse whether users are finding useful content in those lists.

https://trello.com/c/JffDJtJ5/500-track-the-number-of-items-in-accordions-breadcrumbs-and-related-links