### PR TITLE
Cross domain tracking

### DIFF
--- a/app/assets/javascripts/analytics/init.js
+++ b/app/assets/javascripts/analytics/init.js
@@ -8,12 +8,19 @@
   // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
   var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
+  var universalId = 'UA-26179049-1'
+
   // Configure profiles, setup custom vars, track initial pageview
   var analytics = new GOVUK.StaticAnalytics({
-    universalId: 'UA-26179049-1',
+    universalId: universalId,
     cookieDomain: cookieDomain
   });
 
   // Make interface public for virtual pageviews and events
+
   GOVUK.analytics = analytics;
+
+  // Enable cross domain tracking to campaign site
+
+  GOVUK.analytics.addLinkedTrackerDomain(universalId, "PlanForBritainCampaign", "planforbritain.gov.uk")
 })();


### PR DESCRIPTION
- Enable Google Analytics Cross Domain Tracking to the campaign site.
- Pass the client id from the session on our domain to the session on the other domain.
- Joins up the user journey tracking.
- More information about Cross Domain Tracking can be found [here](https://support.google.com/analytics/answer/1034342?hl=en).