### PR TITLE
[DO NOT MERGE] Show all related links provided in the data

### DIFF
--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -28,7 +28,7 @@
         </p>
 
         <% item[:related_content] ||= [] %>
-        <% if item[:related_content].any? && item_index < 2 %>
+        <% if item[:related_content].any? %>
           <nav role='navigation'>
             <ul class='related-content'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -46,6 +46,7 @@
                           }
                       },
                       class: 'related-link',
+                      rel: related_item[:rel],
                     ) do
                       content_tag(:span, related_item[:title])
                     end

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -31,53 +31,6 @@ class TaxonomySidebarTestCase < ComponentTestCase
     taxon_titles = ["Item 1 title", "Item 2 title"]
   end
 
-  test "renders related content for the first two taxons" do
-    render_component(
-      items: [
-        {
-          title: "Item 1 title",
-          url: "/item-1",
-          description: "item 1",
-          related_content: [
-            {
-              title: "Related link B",
-              link: "/related-link-b",
-            },
-            {
-              title: "Related link A",
-              link: "/related-link-a",
-            },
-          ],
-        },
-        {
-          title: "Item 2 title",
-          url: "/item-2",
-          description: "item 2",
-          related_content: [
-            {
-              title: "Related link C",
-              link: "/related-link-c",
-            },
-          ],
-        },
-        {
-          title: "Item 3 title",
-          url: "/item-3",
-          description: "item 3",
-          related_content: [
-            {
-              title: "Related link D",
-              link: "/related-link-d",
-            },
-          ],
-        }
-      ],
-    )
-
-    related_links = css_select(".related-content a").map { |link| link.text }
-    assert_equal ["Related link B", "Related link A", "Related link C"], related_links
-  end
-
   test "renders all data attributes for tracking" do
     render_component(
       items: [

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -121,4 +121,36 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_select 'h2', "Without an url"
     assert_select 'h2 a', false
   end
+
+  test "includes the rel attribute when given" do
+    render_component(
+      items: [
+        {
+          title: "Without an url",
+          description: "An item",
+          related_content: [
+            {
+              title: "External link",
+              link: "/external-link-1",
+              rel: 'external'
+            }
+          ],
+        },
+      ]
+    )
+
+    related_links = css_select(".sidebar-taxon .related-content li a")
+    assert_equal(
+      1,
+      related_links.count,
+      "Expecting only one external link"
+    )
+
+    link = related_links.first
+    assert_equal(
+      "external",
+      link[:rel],
+      "The external link is missing a :rel attribute"
+    )
+  end
 end


### PR DESCRIPTION
Note: this is now being done in govuk_navigation_helpers:
https://github.com/alphagov/govuk_navigation_helpers/pull/62

The reasons for that are described in that pull request. Basically, we
need flexibility in the way we present related links. The previous rule
here was to only display related links for the first 2 sections of the
side bar. That's the correct behaviour, but we now need to display links
for sections such as "Elsewhere on GOV.UK", which appear below the
taxonomy sections. That means in certain circumstances, we might not
be showing them because of the index of those sections.

The logic of what should presented should be provided by navigation
helpers in order to give us that flexibility.

Before this can be merged, we need to:
- [x] merge https://github.com/alphagov/govuk_navigation_helpers/pull/62
- [ ] update all frontend apps to use the new navigation helpers

Trello: https://trello.com/c/vM6Kaw9B/546-ias-and-content-designers-can-curate-related-links-for-any-content-type