### PR TITLE
Revert "Cross domain tracking"

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -8,7 +8,7 @@
   // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
   var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
-  var universalId = 'UA-26179049-1'
+  var universalId = 'UA-26179049-1';
 
   // Configure profiles, setup custom vars, track initial pageview
   var analytics = new GOVUK.StaticAnalytics({
@@ -18,10 +18,5 @@
   });
 
   // Make interface public for virtual pageviews and events
-
   GOVUK.analytics = analytics;
-
-  // Enable cross domain tracking to campaign site
-
-  GOVUK.analytics.addLinkedTrackerDomain(universalId, "PlanForBritainCampaign", "planforbritain.gov.uk")
 })();


### PR DESCRIPTION
This reverts commit 8a7bd892c8ec1f7fb9f8d5b08968b19675a22725.

This is a revert of #961, which can't be reverted automatically due to conflicts.