### PR TITLE
Add linked domain tracking to Plan For Britain campaign

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -1,4 +1,4 @@
-(function() {
+(function(global) {
   "use strict";
 
   // Load Google Analytics libraries
@@ -14,9 +14,16 @@
   var analytics = new GOVUK.StaticAnalytics({
     universalId: universalId,
     cookieDomain: cookieDomain,
+    allowLinker: true,
     govukTrackerGifUrl: '<%= asset_path "/static/a.gif" %>',
   });
 
   // Make interface public for virtual pageviews and events
   GOVUK.analytics = analytics;
-})();
+
+  if (global.ga) {
+    var ga = global.ga;
+    ga('require', 'linker');
+    ga('linker:autoLink', ['planforbritain.gov.uk']);
+  }
+})(window);


### PR DESCRIPTION
Adds linked tracking without creating a new tracker, as per
https://developers.google.com/analytics/devguides/collection/analyticsjs/linker. 
As this is a temporary measure, we’re calling `ga` directly
rather than adding the functionality to
`GOVUK.GoogleAnalyticsUniversalTracker` in `govuk_frontend_toolkit`.