### PR TITLE
Update gds-api-adapters gem to get the latest special route publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,4 +47,4 @@ if ENV['GOVUK_TEMPLATE_DEV']
 else
   gem 'govuk_template', '0.19.0'
 end
-gem 'gds-api-adapters', '38.1.0'
+gem 'gds-api-adapters', '41.2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,13 +65,13 @@ GEM
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
-    domain_name (0.5.20161129)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.6.0)
     exifr (1.2.3.1)
     fspath (2.1.1)
-    gds-api-adapters (38.1.0)
+    gds-api-adapters (41.2.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -151,7 +151,7 @@ GEM
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.5)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -183,7 +183,7 @@ GEM
     rainbow (2.1.0)
     raindrops (0.15.0)
     rake (10.5.0)
-    rest-client (2.0.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -253,7 +253,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   capybara (~> 2.5.0)
-  gds-api-adapters (= 38.1.0)
+  gds-api-adapters (= 41.2.0)
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.6.0)
   govuk_frontend_toolkit (~> 5.1.3)
@@ -279,4 +279,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   1.13.7
+   1.14.5


### PR DESCRIPTION
Update the API adapter gem so that special route publishing contains the new fields added to the `special_route` schema.

https://trello.com/c/u1H1rgDA/525-some-finding-pages-are-still-being-tracked-as-thing