### PR TITLE
Fix tracking of "More" link in mainstream related links

### DIFF
--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -8,6 +8,7 @@
       </h2>
       <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
         <ul>
+          <% total_links_in_section = section[:items].length + (section[:url] ? 1 : 0)  %>
           <% section[:items].each_with_index do |item, item_index| %>
             <li>
               <%= link_to(
@@ -18,7 +19,7 @@
                   track_action: "#{section_index + 1}.#{item_index + 1}",
                   track_label: item[:url],
                   track_options: {
-                    dimension28: section[:items].length.to_s,
+                    dimension28: total_links_in_section.to_s,
                     dimension29: item[:title],
                   },
                 },
@@ -35,7 +36,7 @@
                   track_action: "#{section_index + 1}.#{section[:items].size + 1}",
                   track_label: section[:url],
                   track_options: {
-                    dimension28: sections.length.to_s,
+                    dimension28: total_links_in_section.to_s,
                     dimension29: "More",
                   },
                 },

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -146,17 +146,16 @@ class RelatedItemsTestCase < ComponentTestCase
       ],
     )
 
-    total_sections = 2
-    total_links_in_section_1 = 3
-    total_links_in_section_2 = 1
+    # These counts include the "More" link
+    total_links_in_section_1 = 4
+    total_links_in_section_2 = 2
 
     assert_select '.govuk-related-items[data-module="track-click"]', 1
     assert_tracking_link("category", "relatedLinkClicked", 6)
 
     assert_tracking_link(
       "options",
-      { dimension28: total_sections.to_s, dimension29: "More" }.to_json,
-      2)
+      { dimension28: total_links_in_section_1.to_s, dimension29: "More" }.to_json)
 
     assert_tracking_link("action", "1.1")
     assert_tracking_link("label", "/item")
@@ -185,5 +184,32 @@ class RelatedItemsTestCase < ComponentTestCase
 
     assert_tracking_link("action", "2.2")
     assert_tracking_link("label", "/another-more-link")
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section_2.to_s, dimension29: "More" }.to_json)
+  end
+
+  test "does not render a 'More' link if the section has no url" do
+    render_component(
+      sections: [
+        {
+          title: "Section title",
+          items: [
+            {
+              title: "Item title",
+              url: "/item"
+            },
+          ]
+        },
+      ],
+    )
+
+    assert_select "ul li", text: /More/, count: 0
+
+    # Expected total links does not include More link if More link is not rendered
+    total_links_in_section = 1
+    assert_tracking_link(
+      "options",
+      { dimension28: total_links_in_section.to_s, dimension29: "Item title" }.to_json)
   end
 end


### PR DESCRIPTION
Google Analytics dimension 28 is used to track the length of a list of links. Update this value for mainstream related links so that it tracks the full length of the list including the "More" links, and update the "More" link itself to track the link list length within a section rather than the number of sections.

This makes dimension 28 consistent with dimension 29 which tracks the position in the list and already includes the "More" link in that list.

https://trello.com/c/JffDJtJ5/500-track-the-number-of-items-in-accordions-breadcrumbs-and-related-links