### PR TITLE
Remove govukTrackerGifUrl config parameter

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -15,7 +15,6 @@
     universalId: universalId,
     cookieDomain: cookieDomain,
     allowLinker: true,
-    govukTrackerGifUrl: '<%= asset_path "/static/a.gif" %>',
   });
 
   // Make interface public for virtual pageviews and events


### PR DESCRIPTION
Removing the `govukTrackerGifUrl` config parameter will disable analytics tracking,
we need to do this because requests to origin for this asset have increased
with adverse effects.
Some analysis of the impact of this config is needed before re-enabling.