### PR TITLE
Fix Google Analytics warning about using integers rather than strings

### DIFF
--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -25,7 +25,7 @@
             track_action: index + 1,
             track_label: path,
             track_options: {
-              dimension28: breadcrumbs.length,
+              dimension28: breadcrumbs.length.to_s,
               dimension29: crumb[:title]
             }
           },

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -18,7 +18,7 @@
                   track_action: "#{section_index + 1}.#{item_index + 1}",
                   track_label: item[:url],
                   track_options: {
-                    dimension28: section[:items].length,
+                    dimension28: section[:items].length.to_s,
                     dimension29: item[:title],
                   },
                 },
@@ -35,7 +35,7 @@
                   track_action: "#{section_index + 1}.#{section[:items].size + 1}",
                   track_label: section[:url],
                   track_options: {
-                    dimension28: sections.length,
+                    dimension28: sections.length.to_s,
                     dimension29: "More",
                   },
                 },

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -15,7 +15,7 @@
                 track_action: "#{item_index + 1}",
                 track_label: item[:url],
                 track_options: {
-                  dimension28: items.length,
+                  dimension28: items.length.to_s,
                   dimension29: item[:title],
                 },
               },
@@ -41,7 +41,7 @@
                           track_action: "#{item_index + 1}.#{related_content_index + 1}",
                           track_label: related_item[:link],
                           track_options: {
-                            dimension28: item[:related_content].length,
+                            dimension28: item[:related_content].length.to_s,
                             dimension29: related_item[:title],
                           }
                       },

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -22,7 +22,7 @@ class BreadcrumbsTestCase < ComponentTestCase
     render_component(breadcrumbs: [{ title: 'Section', url: '/section' }])
 
     expected_tracking_options = {
-      dimension28: 1,
+      dimension28: "1",
       dimension29: "Section"
     }
 
@@ -42,9 +42,9 @@ class BreadcrumbsTestCase < ComponentTestCase
     render_component(breadcrumbs: breadcrumbs)
 
     expected_tracking_options = [
-      {dimension28: 3, dimension29: "Section 1"},
-      {dimension28: 3, dimension29: "Section 2"},
-      {dimension28: 3, dimension29: "Section 3"},
+      {dimension28: "3", dimension29: "Section 1"},
+      {dimension28: "3", dimension29: "Section 2"},
+      {dimension28: "3", dimension29: "Section 3"},
     ]
 
     assert_select "ol li:nth-child(1) a[data-track-options='#{expected_tracking_options[0].to_json}']", 1

--- a/test/govuk_component/related_items_test.rb
+++ b/test/govuk_component/related_items_test.rb
@@ -155,24 +155,24 @@ class RelatedItemsTestCase < ComponentTestCase
 
     assert_tracking_link(
       "options",
-      { dimension28: total_sections, dimension29: "More" }.to_json,
+      { dimension28: total_sections.to_s, dimension29: "More" }.to_json,
       2)
 
     assert_tracking_link("action", "1.1")
     assert_tracking_link("label", "/item")
     expected_link_1_tracking_options = {
-      dimension28: total_links_in_section_1,
+      dimension28: total_links_in_section_1.to_s,
       dimension29: "Item title",
     }
     assert_tracking_link(
       "options",
-      { dimension28: total_links_in_section_1, dimension29: "Item title" }.to_json)
+      { dimension28: total_links_in_section_1.to_s, dimension29: "Item title" }.to_json)
 
     assert_tracking_link("action", "1.2")
     assert_tracking_link("label", "/other-item")
     assert_tracking_link(
       "options",
-      { dimension28: total_links_in_section_1, dimension29: "Other item title" }.to_json)
+      { dimension28: total_links_in_section_1.to_s, dimension29: "Other item title" }.to_json)
 
     assert_tracking_link("action", "1.3")
     assert_tracking_link("label", "/more-link")
@@ -181,7 +181,7 @@ class RelatedItemsTestCase < ComponentTestCase
     assert_tracking_link("label", "/foo")
     assert_tracking_link(
       "options",
-      { dimension28: total_links_in_section_2, dimension29: "Foo" }.to_json)
+      { dimension28: total_links_in_section_2.to_s, dimension29: "Foo" }.to_json)
 
     assert_tracking_link("action", "2.2")
     assert_tracking_link("label", "/another-more-link")

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -122,24 +122,24 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_tracking_link("category", "relatedLinkClicked", 6)
 
     expected_title_tracking_options = {
-      dimension28: total_sections,
+      dimension28: total_sections.to_s,
       dimension29: "Item title"
     }
     assert_tracking_link(
       "options",
-      { dimension28: total_sections, dimension29: "Item title" }.to_json)
+      { dimension28: total_sections.to_s, dimension29: "Item title" }.to_json)
     assert_tracking_link("action", "1")
     assert_tracking_link("label", "/item")
 
     assert_tracking_link(
       "options",
-      { dimension28: total_links_in_section_1, dimension29: "Related link 1a" }.to_json)
+      { dimension28: total_links_in_section_1.to_s, dimension29: "Related link 1a" }.to_json)
     assert_tracking_link("action", "1.1")
     assert_tracking_link("label", "/related-link-1a")
 
     assert_tracking_link(
       "options",
-      { dimension28: total_links_in_section_1, dimension29: "Related link 1a" }.to_json)
+      { dimension28: total_links_in_section_1.to_s, dimension29: "Related link 1a" }.to_json)
     assert_tracking_link("action", "1.2")
     assert_tracking_link("label", "/related-link-1b")
   end


### PR DESCRIPTION
Update the breadcrumb and related link tracking which tracks the total number of links against dimension 28. Convert the count to a string, which gets rid of the Google Analytics JavaScript warning: `Expected a string value for field: "dimension28". but found: "number"`.

https://trello.com/c/JffDJtJ5/500-track-the-number-of-items-in-accordions-breadcrumbs-and-related-links