### PR TITLE
Track themes

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -99,6 +99,7 @@
   };
 
   StaticAnalytics.prototype.setDimensionsThatHaveDefaultValues = function(dimensions) {
+    this.setThemesDimension(dimensions['themes']);
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
     this.setUserJourneyStage(dimensions['user-journey-stage']);
   };
@@ -163,6 +164,10 @@
 
   StaticAnalytics.prototype.setFormatDimension = function(format) {
     this.setDimension(2, format);
+  };
+
+  StaticAnalytics.prototype.setThemesDimension = function(themes) {
+    this.setDimension(3, themes || 'other');
   };
 
   StaticAnalytics.prototype.setResultCountDimension = function(count) {

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -34,6 +34,27 @@
 
   navigation_document_type = content_item_hash[:navigation_document_supertype]
   meta_tags["govuk:navigation-document-type"] = navigation_document_type if navigation_document_type
+
+  def root_taxons(content_item)
+    root_taxon_set = Set.new
+
+    links = content_item[:links]
+    # Taxons will have :parent_taxons, but content items will have :taxons
+    parent_taxons = links[:parent_taxons] || links[:taxons] unless links.nil?
+
+    if parent_taxons.blank?
+      root_taxon_set << content_item[:title] if content_item[:document_type] == 'taxon'
+    else
+      parent_taxons.each do |parent_taxon|
+        root_taxon_set += root_taxons(parent_taxon)
+      end
+    end
+
+    root_taxon_set
+  end
+
+  themes = root_taxons(content_item_hash)
+  meta_tags["govuk:themes"] = themes.to_a.sort.join('; ') unless themes.empty?
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 7;
+    const expectedDefaultArgumentCount = 8;
 
     var universalSetupArguments;
 
@@ -133,16 +133,22 @@ describe("GOVUK.StaticAnalytics", function() {
 
       [
         {
+          name: 'themes',
+          number: 3,
+          defaultValue: 'other',
+          setupArgumentsIndex: 5
+        },
+        {
           name: 'navigation-page-type',
           number: 32,
           defaultValue: 'none',
-          setupArgumentsIndex: 5
+          setupArgumentsIndex: 6
         },
         {
           name: 'user-journey-stage',
           number: 33,
           defaultValue: 'thing',
-          setupArgumentsIndex: 6
+          setupArgumentsIndex: 7
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -118,6 +118,105 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     assert_political_status_for(political, current, 'non-political')
   end
 
+  test "renders themes metatag for root taxon" do
+    taxon = {
+      title: 'Root taxon',
+      links: {
+        parent_taxons: [],
+      },
+    }
+    render_component(content_item: example_document_for('taxon', 'taxon').merge(taxon))
+    assert_meta_tag('govuk:themes', 'Root taxon')
+  end
+
+  test "renders themes metatag for child taxon" do
+    taxon = {
+      title: 'Child taxon',
+      links: {
+        parent_taxons: [
+          {
+            title: 'Root taxon',
+            document_type: 'taxon',
+          },
+        ],
+      },
+    }
+    render_component(content_item: example_document_for('taxon', 'taxon').merge(taxon))
+    assert_meta_tag('govuk:themes', 'Root taxon')
+  end
+
+  test "renders themes metatag for content item" do
+    content_item = {
+      links: {
+        taxons: [
+          {
+            title: 'Child taxon',
+            document_type: 'taxon',
+            links: {
+              parent_taxons: [
+                {
+                  title: 'Root taxon',
+                  document_type: 'taxon',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
+    assert_meta_tag('govuk:themes', 'Root taxon')
+  end
+
+  test "renders themes metatag for content item with multiple roots" do
+    content_item = {
+      links: {
+        taxons: [
+          {
+            title: 'Education child taxon',
+            document_type: 'taxon',
+            links: {
+              parent_taxons: [
+                {
+                  title: 'Education root taxon',
+                  document_type: 'taxon',
+                },
+              ],
+            },
+          },
+          {
+            title: 'Parenting grandchild taxon',
+            document_type: 'taxon',
+            links: {
+              parent_taxons: [
+                title: 'Parenting child taxon',
+                document_type: 'taxon',
+                links: {
+                  parent_taxons: [
+                    {
+                      title: 'Parenting root taxon',
+                      document_type: 'taxon',
+                    }
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    }
+    render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
+    assert_meta_tag('govuk:themes', 'Education root taxon; Parenting root taxon')
+  end
+
+  test "does not render themes metatag for content item with no taxon" do
+    content_item = {
+      links: {},
+    }
+    render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
+    assert_select "meta[name='govuk:themes']", 0
+  end
+
   def assert_political_status_for(political, current, expected_political_status)
     render_component(content_item: { details: { political: political, government: { current: current, slug: 'government' } } })
     assert_meta_tag('govuk:political-status', expected_political_status)


### PR DESCRIPTION
This change adds a tracking `meta` tag for tracking the "theme" of a document. Its theme is defined as its root taxon, and is tracked for both taxons and content items. The tracked themes should contain all possible themes (ie if a content item or taxon has multiple root taxons), and should be set as `other` if no themes are present.

Note that the implementation here involves defining a method in a `.erb` template, which feels un-idiomatic. However, given that this (complex) logic can't be moved into a helper method because of the way templates are distributed and rendered, it seemed like the neatest way to implement this solution in this way.

Alternative solutions may include:

- Storing the theme directly in the content store, although this would involve changes to publishing and content schemas as well as having to re-present all content items.
- Moving the logic to something akin to the `govuk_navigation_helpers` gem where we could do the complex logic, but given that this [may be moved into `static`](https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+71%3A+Return+rendered+components+from+static?focusedCommentId=130740364#comment-130740364) anyway, it seemed unwise to move in the opposite direction.

### Trello

https://trello.com/c/kLfd977R/555-track-the-theme-in-google-analytics
