### PR TITLE
Track the navigation document type for all pages

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -102,6 +102,7 @@
     this.setThemesDimension(dimensions['themes']);
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
     this.setUserJourneyStage(dimensions['user-journey-stage']);
+    this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
@@ -113,7 +114,6 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
-    this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -210,7 +210,7 @@
   };
 
   StaticAnalytics.prototype.setNavigationDocumentTypeDimension = function(documentType) {
-    this.setDimension(34, documentType);
+    this.setDimension(34, documentType || "other");
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 8;
+    const expectedDefaultArgumentCount = 9;
 
     var universalSetupArguments;
 
@@ -64,7 +64,6 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
-          <meta name="govuk:navigation-document-type" content="guidance">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -77,7 +76,6 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(setupArguments[4]).toEqual(['set', 'dimension7', 'historic']);
         expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
         expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
-        expect(setupArguments[7]).toEqual(['set', 'dimension34', 'guidance']);
       });
 
       it('ignores meta tags not set', function() {
@@ -149,6 +147,12 @@ describe("GOVUK.StaticAnalytics", function() {
           number: 33,
           defaultValue: 'thing',
           setupArgumentsIndex: 7
+        },
+        {
+          name: 'navigation-document-type',
+          number: 34,
+          defaultValue: 'other',
+          setupArgumentsIndex: 8
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {


### PR DESCRIPTION
Add a default value for the navigation document type, so that all pages (which include the JS from static) track the page as 'other' rather than a specific navigation type like 'guidance'.

https://trello.com/c/Tkn0P6Fm/532-track-guidance-navigation-supertype-in-google-analytics

Marked as DO NOT MERGE until we've checked that this dimension is giving us the expected results for pages which explicitly add the `meta` tag for navigation document types.