### PR TITLE
Replaces default survey url

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -43,7 +43,7 @@
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
     defaultSurvey: {
-      url: 'https://www.surveymonkey.com/s/2MRDLTW',
+      url: 'https://www.smartsurvey.co.uk/s/gov-uk',
       identifier: 'user_satisfaction_survey',
       frequency: 50,
       surveyType: 'url',


### PR DESCRIPTION
[Trello card](https://trello.com/c/4gNFt4un/138-replace-url-for-default-survey-when-no-tests-are-running) 

This will replace the current default url survey with a new one. It will run at the same frequence: 1 in 50.