### PR TITLE
Use shared `buildProject` task in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,83 +6,18 @@ node {
   // Deployed by Puppet's Govuk_jenkins::Pipeline manifest
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
-  properties([
-    buildDiscarder(
-      logRotator(
-        numToKeepStr: '50')
-      ),
-    [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false],
-    [$class: 'ThrottleJobProperty',
-      categories: [],
-      limitOneJobWithMatchingParams: true,
-      maxConcurrentPerNode: 1,
-      maxConcurrentTotal: 0,
-      paramsToUseForLimit: REPOSITORY,
-      throttleEnabled: true,
-      throttleOption: 'category'],
-    [$class: 'ParametersDefinitionProperty',
-      parameterDefinitions: [
-        [$class: 'BooleanParameterDefinition',
-          name: 'IS_SCHEMA_TEST',
-          defaultValue: false,
-          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
-        [$class: 'StringParameterDefinition',
-          name: 'SCHEMA_BRANCH',
-          defaultValue: 'deployed-to-production',
-          description: 'The branch of govuk-content-schemas to test against']]],
-  ])
-
-  try {
-    govuk.setEnvar('GOVUK_APP_DOMAIN', 'dev.gov.uk')
-    govuk.initializeParameters([
-      'IS_SCHEMA_TEST': 'false',
-      'SCHEMA_BRANCH': 'deployed-to-production',
-    ])
-
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
-    }
-
-    stage('Build') {
-      checkout scm
-
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-
-      govuk.bundleApp()
-
-      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-    }
-
-    stage('Lint') {
-      govuk.rubyLinter()
-      govuk.sassLinter('app/assets/stylesheets/govuk-component')
-    }
-
-    stage('Test') {
-      govuk.setEnvar('RAILS_ENV', 'test')
-
-      govuk.runTests('test')
-      govuk.runTests('spec:javascript')
-    }
-
-    stage('Validate assets') {
-      govuk.setEnvar('RAILS_ENV', 'production')
-      govuk.runRakeTask('assets:precompile')
-    }
-
-    stage('Deploy') {
-      // pushTag and deployIntegration are no-ops unless on master branch
-      govuk.pushTag(REPOSITORY, env.BRANCH_NAME, 'release_' + env.BUILD_NUMBER)
-      govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, 'release', 'deploy')
-    }
-
-  } catch (e) {
-    currentBuild.result = 'FAILED'
-    step([$class: 'Mailer',
-          notifyEveryUnstableBuild: true,
-          recipients: 'govuk-ci-notifications@digital.cabinet-office.gov.uk',
-          sendToIndividuals: true])
-    throw e
-  }
+  govuk.buildProject(
+    sassLint: false,
+    beforeTest: {
+      stage("Lint component sass") {
+        govuk.sassLinter("app/assets/stylesheets/govuk-component")
+      }
+    },
+    overrideTestTask: {
+      stage("Test") {
+        govuk.runTests("test")
+        govuk.runTests("spec:javascript")
+      }
+    },
+  )
 }


### PR DESCRIPTION
Use the common jenkinslib build task to build the project. This improves performance by fixing job throttling, and means that static will share any future build improvements.

Override the test task so that the Ruby and JS tests are run separately. Running them in same default rake task causes confusing test errors: http://stackoverflow.com/questions/26235828/actionviewtemplateerror-wrong-number-of-arguments-3-for-1-2