### PR TITLE
Reverts previous commit

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -51,7 +51,7 @@
     smallSurveys: [
       {
         identifier: 'govuk_email_survey_t02',
-        frequency: 10,
+        frequency: 25,
         activeWhen: function() {
           function breadcrumbExclude() {
             var text = $('.govuk-breadcrumbs').text() || "";
@@ -72,8 +72,8 @@
           return !(sectionExclude() || breadcrumbExclude() || organisationExclude());
         },
         surveyType: 'email',
-        startTime: new Date("April 3, 2017 10:30:00").getTime(),
-        endTime: new Date("April 4, 2017 23:59:59").getTime()
+        startTime: new Date("March 22, 2017 00:01:00").getTime(),
+        endTime: new Date("March 24, 2017 23:59:59").getTime()
       },
       {
         url: "https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=" + window.location.pathname + "&utm_source=Hold_gov_to_account&utm_medium=gov.uk%20survey&t=GDS",


### PR DESCRIPTION
This commit will revert: https://github.com/alphagov/static/pull/979/files

Reason: There is currently an error when sending email surveys. It might be related to these changes so I am reverting them and testing the error separately. This is done to unblock static and feedback from being deployed to production.