### PR TITLE
Track taxon slugs rather than titles

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -35,7 +35,7 @@
   navigation_document_type = content_item_hash[:navigation_document_supertype]
   meta_tags["govuk:navigation-document-type"] = navigation_document_type if navigation_document_type
 
-  def root_taxons(content_item)
+  def root_taxon_slugs(content_item)
     root_taxon_set = Set.new
 
     links = content_item[:links]
@@ -43,18 +43,18 @@
     parent_taxons = links[:parent_taxons] || links[:taxons] unless links.nil?
 
     if parent_taxons.blank?
-      root_taxon_set << content_item[:title] if content_item[:document_type] == 'taxon'
+      root_taxon_set << content_item[:base_path].sub(%r(^/), '') if content_item[:document_type] == 'taxon'
     else
       parent_taxons.each do |parent_taxon|
-        root_taxon_set += root_taxons(parent_taxon)
+        root_taxon_set += root_taxon_slugs(parent_taxon)
       end
     end
 
     root_taxon_set
   end
 
-  themes = root_taxons(content_item_hash)
-  meta_tags["govuk:themes"] = themes.to_a.sort.join('; ') unless themes.empty?
+  themes = root_taxon_slugs(content_item_hash)
+  meta_tags["govuk:themes"] = themes.to_a.sort.join(', ') unless themes.empty?
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -121,12 +121,13 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   test "renders themes metatag for root taxon" do
     taxon = {
       title: 'Root taxon',
+      base_path: '/root-taxon',
       links: {
         parent_taxons: [],
       },
     }
     render_component(content_item: example_document_for('taxon', 'taxon').merge(taxon))
-    assert_meta_tag('govuk:themes', 'Root taxon')
+    assert_meta_tag('govuk:themes', 'root-taxon')
   end
 
   test "renders themes metatag for child taxon" do
@@ -136,13 +137,14 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
         parent_taxons: [
           {
             title: 'Root taxon',
+            base_path: '/root-taxon',
             document_type: 'taxon',
           },
         ],
       },
     }
     render_component(content_item: example_document_for('taxon', 'taxon').merge(taxon))
-    assert_meta_tag('govuk:themes', 'Root taxon')
+    assert_meta_tag('govuk:themes', 'root-taxon')
   end
 
   test "renders themes metatag for content item" do
@@ -156,6 +158,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
               parent_taxons: [
                 {
                   title: 'Root taxon',
+                  base_path: '/root-taxon',
                   document_type: 'taxon',
                 },
               ],
@@ -165,7 +168,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
       },
     }
     render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
-    assert_meta_tag('govuk:themes', 'Root taxon')
+    assert_meta_tag('govuk:themes', 'root-taxon')
   end
 
   test "renders themes metatag for content item with multiple roots" do
@@ -179,6 +182,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
               parent_taxons: [
                 {
                   title: 'Education root taxon',
+                  base_path: '/education-root-taxon',
                   document_type: 'taxon',
                 },
               ],
@@ -195,6 +199,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
                   parent_taxons: [
                     {
                       title: 'Parenting root taxon',
+                      base_path: '/parenting-root-taxon',
                       document_type: 'taxon',
                     }
                   ],
@@ -206,7 +211,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
       },
     }
     render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
-    assert_meta_tag('govuk:themes', 'Education root taxon; Parenting root taxon')
+    assert_meta_tag('govuk:themes', 'education-root-taxon, parenting-root-taxon')
   end
 
   test "does not render themes metatag for content item with no taxon" do


### PR DESCRIPTION
This change will report the taxon slugs rather than their titles, in line with the Trello card.

### Trello

https://trello.com/c/kLfd977R/555-track-the-theme-in-google-analytics