### PR TITLE
Add a custom GA dimension for content-id meta tag

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -103,6 +103,7 @@
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
     this.setUserJourneyStage(dimensions['user-journey-stage']);
     this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
+    this.setContentIdDimension(dimensions['content-id']);
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
@@ -168,6 +169,10 @@
 
   StaticAnalytics.prototype.setThemesDimension = function(themes) {
     this.setDimension(3, themes || 'other');
+  }
+
+  StaticAnalytics.prototype.setContentIdDimension = function(contentId) {
+    this.setDimension(4, contentId || '00000000-0000-0000-0000-000000000000');
   };
 
   StaticAnalytics.prototype.setResultCountDimension = function(count) {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 9;
+    const expectedDefaultArgumentCount = 10;
 
     var universalSetupArguments;
 
@@ -153,6 +153,12 @@ describe("GOVUK.StaticAnalytics", function() {
           number: 34,
           defaultValue: 'other',
           setupArgumentsIndex: 8
+        },
+        {
+          name: 'content-id',
+          number: 4,
+          defaultValue: '00000000-0000-0000-0000-000000000000',
+          setupArgumentsIndex: 9
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {


### PR DESCRIPTION
Trello: https://trello.com/c/wCb2VvDw/132-custom-dimension-content-unique-id

> We need to have a canonical key for joining GA data to other sources of data about content. The URI is the only thing currently in GA and is not authoritative.

This PR ensures that the `content-id` meta tag is sent as dimension 4.