### PR TITLE
Track taxons

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -104,6 +104,10 @@
     this.setUserJourneyStage(dimensions['user-journey-stage']);
     this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
     this.setContentIdDimension(dimensions['content-id']);
+    this.setTaxonSlugDimension(dimensions['taxon-slug']);
+    this.setTaxonIdDimension(dimensions['taxon-id']);
+    this.setTaxonSlugsDimension(dimensions['taxon-slugs']);
+    this.setTaxonIdsDimension(dimensions['taxon-ids']);
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
@@ -216,6 +220,22 @@
 
   StaticAnalytics.prototype.setNavigationDocumentTypeDimension = function(documentType) {
     this.setDimension(34, documentType || "other");
+  };
+
+  StaticAnalytics.prototype.setTaxonSlugDimension = function(taxonSlug) {
+    this.setDimension(56, taxonSlug || "other");
+  };
+
+  StaticAnalytics.prototype.setTaxonIdDimension = function(taxonId) {
+    this.setDimension(57, taxonId || "other");
+  };
+
+  StaticAnalytics.prototype.setTaxonSlugsDimension = function(taxonSlugs) {
+    this.setDimension(58, taxonSlugs || "other");
+  };
+
+  StaticAnalytics.prototype.setTaxonIdsDimension = function (taxonIds) {
+    this.setDimension(59, taxonIds || "other");
   };
 
   GOVUK.StaticAnalytics = StaticAnalytics;

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -55,6 +55,27 @@
 
   themes = root_taxon_slugs(content_item_hash)
   meta_tags["govuk:themes"] = themes.to_a.sort.join(', ') unless themes.empty?
+
+  if content_item_hash[:document_type] == 'taxon'
+    taxons = [content_item_hash]
+  else
+    taxons = links_hash[:taxons] || []
+  end
+
+  taxons.sort_by! { |taxon| taxon[:title] }
+  taxon_slugs_without_theme = taxons.map do |taxon|
+    base_path = taxon[:base_path] || ""
+    slug_without_theme = base_path[%r{/[^/]+/(.+)}, 1]
+    # Return the slug without the theme, or in the special case of a root taxon,
+    # just return the full slug (because it doesn't have a slug beneath the theme)
+    slug_without_theme || base_path.sub(%r(^/), '')
+  end
+  taxon_ids = taxons.map { |taxon| taxon[:content_id] }
+
+  meta_tags["govuk:taxon-id"] = taxon_ids.first unless taxon_ids.empty?
+  meta_tags["govuk:taxon-ids"] = taxon_ids.join(',') unless taxon_ids.empty?
+  meta_tags["govuk:taxon-slug"] = taxon_slugs_without_theme.first unless taxon_slugs_without_theme.empty?
+  meta_tags["govuk:taxon-slugs"] = taxon_slugs_without_theme.join(',') unless taxon_slugs_without_theme.empty?
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 10;
+    const expectedDefaultArgumentCount = 14;
 
     var universalSetupArguments;
 
@@ -159,6 +159,30 @@ describe("GOVUK.StaticAnalytics", function() {
           number: 4,
           defaultValue: '00000000-0000-0000-0000-000000000000',
           setupArgumentsIndex: 9
+        },
+        {
+          name: 'taxon-slug',
+          number: 56,
+          defaultValue: 'other',
+          setupArgumentsIndex: 10
+        },
+        {
+          name: 'taxon-id',
+          number: 57,
+          defaultValue: 'other',
+          setupArgumentsIndex: 11
+        },
+        {
+          name: 'taxon-slugs',
+          number: 58,
+          defaultValue: 'other',
+          setupArgumentsIndex: 12
+        },
+        {
+          name: 'taxon-ids',
+          number: 59,
+          defaultValue: 'other',
+          setupArgumentsIndex: 13
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {


### PR DESCRIPTION
Track taxons of content items. We'll be using 4 custom dimensions to track:
- The slug (without the theme) of the first taxon (eg if the taxon has slug `/education/a-taxon`, we track `a-taxon`), when taxons are sorted alphabetically
- The content ID of the first taxon, when taxons are sorted alphabetically
- The list of all slugs without their themes for all taxons tagged to the content
- The list of all content IDs for all taxons tagged to the content

If a page is a taxon, we track the taxon itself.

### Trello

https://trello.com/c/6lLHmlEe/495-track-the-taxon-of-content-items-in-google-analytics