### PR TITLE
Use Redis to show emergency banner in static

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'airbrake', '~> 4.3.1'
 
 gem 'nokogiri', "~> 1.6.6.4"
 gem 'sprockets-rails', "2.3.3" #FIXME: This is temporary, will allow to upgrade rails to 4.2.5.1 to address security fixes without breaking tests http://weblog.rubyonrails.org/2016/1/25/Rails-5-0-0-beta1-1-4-2-5-1-4-1-14-1-3-2-22-1-and-rails-html-sanitizer-1-0-3-have-been-released/
+gem 'redis', "~> 3.3.3"
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
     rainbow (2.1.0)
     raindrops (0.15.0)
     rake (10.5.0)
+    redis (3.3.3)
     rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
@@ -270,6 +271,7 @@ DEPENDENCIES
   quiet_assets (= 1.1.0)
   rack_strip_client_ip (= 0.0.1)
   rails (= 4.2.7.1)
+  redis (~> 3.3.3)
   sass-rails (= 5.0.6)
   shoulda
   sprockets-rails (= 2.3.3)

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -16,6 +16,7 @@
 @import "helpers/footer";
 @import "helpers/header";
 @import "helpers/emergency-publishing-notifications";
+@import "helpers/emergency-banner-notifications";
 @import "helpers/report-a-problem";
 @import "govuk-component/component";
 @import "modules/*";

--- a/app/assets/stylesheets/helpers/_emergency-banner-notifications.scss
+++ b/app/assets/stylesheets/helpers/_emergency-banner-notifications.scss
@@ -1,0 +1,55 @@
+#emergency-banner-notification {
+  background-color: $panel-colour;
+  border-top: 2px solid white;
+  padding: 0.5em 1em;
+
+  @include media(tablet) {
+    padding: 0;
+  }
+
+  div {
+    @include core-19;
+    color: #fff;
+    margin: 0 auto;
+    padding:0.5em 0;
+    max-width: 1020px;
+    overflow: hidden;
+
+    @include ie-lte(7) {
+      width: 956px;
+    }
+  }
+
+  p {
+    padding: 0;
+    margin: 0;
+
+    @include media(tablet) {
+      padding: 0 30px 0 30px;
+    }
+  }
+
+  a {
+    color: #fff;
+
+    &.more-information {
+      display: block;
+
+      @include media(tablet) {
+        padding: 0 30px;
+      }
+    }
+  }
+
+  &.green {
+    background: #28a197;
+  }
+
+  &.red {
+    background: #b10e1e;
+  }
+
+  &.black {
+    background: #000000;
+  }
+}

--- a/app/helpers/notification_helper.rb
+++ b/app/helpers/notification_helper.rb
@@ -1,4 +1,5 @@
 require "notification_file_lookup"
+require "emergency_banner"
 
 module NotificationHelper
   include ActionView::Helpers::TagHelper
@@ -10,5 +11,10 @@ module NotificationHelper
     else
       ''
     end
+  end
+
+  def emergency_banner_notification
+    emergency_banner = EmergencyBanner.new
+    return emergency_banner if emergency_banner.enabled?
   end
 end

--- a/app/views/notifications/_emergency_banner.erb
+++ b/app/views/notifications/_emergency_banner.erb
@@ -1,5 +1,9 @@
 <section id="emergency-banner-notification" class="<%= banner.campaign_class %>">
   <div>
-    <p><%= banner.heading %></p>
+    <p><%= banner.heading %><br>
+    <%= banner.short_description %></p>
+    <% if banner.link %>
+      <a href="<%= banner.link %>" class="more-information">More information</a>
+    <% end %>
   </div>
 </section>

--- a/app/views/notifications/_emergency_banner.erb
+++ b/app/views/notifications/_emergency_banner.erb
@@ -1,0 +1,2 @@
+<section id="emergency-banner-notification">
+</section>

--- a/app/views/notifications/_emergency_banner.erb
+++ b/app/views/notifications/_emergency_banner.erb
@@ -1,2 +1,5 @@
-<section id="emergency-banner-notification">
+<section id="emergency-banner-notification" class="<%= banner.campaign_class %>">
+  <div>
+    <p><%= banner.heading %></p>
+  </div>
 </section>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -33,7 +33,7 @@
   <% end %>
 
   <% if @emergency_banner %>
-    <%= render partial: "notifications/emergency_banner" %>
+    <%= render "notifications/emergency_banner", banner: @emergency_banner %>
   <% end %>
 <% end %>
 

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -38,8 +38,10 @@
 <% end %>
 
 <% content_for :content do %>
-  <% show_global_bar = @banner_notification.blank? && !local_assigns[:hide_banner_notification] %>
-  <%= render partial: "promo_banner" if show_global_bar %>
+  <% unless @emergency_banner %>
+    <% show_global_bar = @banner_notification.blank? && !local_assigns[:hide_banner_notification] && !@emergency_banner %>
+    <%= render partial: "promo_banner" if show_global_bar %>
+  <% end %>
 
   <div id="wrapper" class="group">
     <%= yield :wrapper_content %>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -1,6 +1,7 @@
 <% content_for :homepage_url, Plek.new.website_root %>
 <% content_for :page_title, content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %>
 <% @banner_notification = banner_notification unless local_assigns[:hide_banner_notification] %>
+<% @emergency_banner = emergency_banner_notification unless local_assigns[:hide_banner_notification] %>
 
 <% if ENV["DRAFT_ENVIRONMENT"].present? %>
   <% content_for :body_classes, "draft" %>
@@ -29,6 +30,10 @@
   <div id="user-satisfaction-survey-container"></div>
   <% if @banner_notification.present? %>
     <%= @banner_notification %>
+  <% end %>
+
+  <% if @emergency_banner %>
+    <%= render partial: "notifications/emergency_banner" %>
   <% end %>
 <% end %>
 

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -1,6 +1,17 @@
 class EmergencyBanner
+  def initialize
+    @redis = Redis.new
+  end
+
   def enabled?
-    redis = Redis.new
-    redis.get("emergency_banner:enabled")
+    content && has_campaign_class?
+  end
+
+  def has_campaign_class?
+    content.has_key?(:campaign_class) && content.fetch(:campaign_class).present?
+  end
+
+  def content
+    @redis.hgetall("emergency_banner")
   end
 end

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -11,7 +11,10 @@ class EmergencyBanner
     content.has_key?(:campaign_class) && content.fetch(:campaign_class).present?
   end
 
+private
+
   def content
-    @redis.hgetall("emergency_banner")
+    @data ||= @redis.hgetall("emergency_banner")
+    @data.symbolize_keys if @data
   end
 end

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -7,18 +7,26 @@ class EmergencyBanner
     content && campaign_class && heading
   end
 
-private
-
-  def content
-    @data ||= @redis.hgetall("emergency_banner")
-    @data.symbolize_keys if @data
-  end
-
   def campaign_class
     content[:campaign_class] if content[:campaign_class].present?
   end
 
   def heading
     content[:heading] if content[:heading].present?
+  end
+
+  def short_description
+    content[:short_description] if content[:short_description].present?
+  end
+
+  def link
+    content[:link] if content[:link].present?
+  end
+
+private
+
+  def content
+    @data ||= @redis.hgetall("emergency_banner")
+    @data.symbolize_keys if @data
   end
 end

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -4,11 +4,7 @@ class EmergencyBanner
   end
 
   def enabled?
-    content && has_campaign_class?
-  end
-
-  def has_campaign_class?
-    content.has_key?(:campaign_class) && content.fetch(:campaign_class).present?
+    content && campaign_class
   end
 
 private
@@ -16,5 +12,9 @@ private
   def content
     @data ||= @redis.hgetall("emergency_banner")
     @data.symbolize_keys if @data
+  end
+
+  def campaign_class
+    content[:campaign_class] if content[:campaign_class].present?
   end
 end

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -1,0 +1,6 @@
+class EmergencyBanner
+  def enabled?
+    redis = Redis.new
+    redis.get("emergency_banner:enabled")
+  end
+end

--- a/lib/emergency_banner.rb
+++ b/lib/emergency_banner.rb
@@ -4,7 +4,7 @@ class EmergencyBanner
   end
 
   def enabled?
-    content && campaign_class
+    content && campaign_class && heading
   end
 
 private
@@ -16,5 +16,9 @@ private
 
   def campaign_class
     content[:campaign_class] if content[:campaign_class].present?
+  end
+
+  def heading
+    content[:heading] if content[:heading].present?
   end
 end

--- a/test/functional/root_controller_test.rb
+++ b/test/functional/root_controller_test.rb
@@ -4,6 +4,7 @@ class RootControllerTest < ActionController::TestCase
   context "a template using the base partial" do
     setup do
       stub_template "root/dummy.html.erb" => "<%= render partial: 'base' %>"
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
     end
 
     context "with a blank promo banner partial" do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -82,6 +82,22 @@ class NotificationsTest < ActionDispatch::IntegrationTest
     end
   end
 
+  context "promo banner" do
+    should "not display if the Emergency Banner is enabled" do
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(true)
+      visit "/templates/wrapper.html.erb"
+
+      refute page.has_selector? ".global-bar-message"
+    end
+
+    should "display if the Emergency Banner is not enabled" do
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
+      visit "/templates/wrapper.html.erb"
+
+      assert page.has_selector? ".global-bar-message"
+    end
+  end
+
   context "banner files" do
     should "have a green file" do
       assert File.exist? "#{Rails.root}/app/views/notifications/banner_green.erb"

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -16,16 +16,26 @@ class NotificationsTest < ActionDispatch::IntegrationTest
   end
 
   context "emergency banner notifications" do
-    should "render a banner" do
+    should "not render a banner if one does not exist" do
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
+      visit "/templates/wrapper.html.erb"
+      refute page.has_selector? "#emergency-banner-notification"
+    end
+
+    should "render a banner if one does exist" do
       EmergencyBanner.any_instance.stubs(:enabled?).returns(true)
       visit "/templates/wrapper.html.erb"
       assert page.has_selector? "#emergency-banner-notification"
     end
 
-    should "not render a banner if one does not exist" do
-      EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
+    should "render a banner with a heading and campaign colour" do
+      EmergencyBanner.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner.any_instance.stubs(:campaign_class).returns("black")
+
       visit "/templates/wrapper.html.erb"
-      refute page.has_selector? "#emergency-banner-notification"
+
+      assert page.has_selector? "#emergency-banner-notification.black"
+      assert_match 'Alas poor Yorick', page.body
     end
   end
 

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -37,6 +37,49 @@ class NotificationsTest < ActionDispatch::IntegrationTest
       assert page.has_selector? "#emergency-banner-notification.black"
       assert_match 'Alas poor Yorick', page.body
     end
+
+    should "render the more information link" do
+      EmergencyBanner.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner.any_instance.stubs(:campaign_class).returns("black")
+      EmergencyBanner.any_instance.stubs(:link).returns("https://yoricks.gov")
+
+      visit "/templates/wrapper.html.erb"
+
+      assert page.has_selector? ".more-information"
+      assert_match "More information", page.body
+      assert_match /yoricks\.gov/, page.body
+    end
+
+    should "not render the more information link if it does not exist" do
+      EmergencyBanner.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner.any_instance.stubs(:campaign_class).returns("black")
+      EmergencyBanner.any_instance.stubs(:link).returns(nil)
+
+      visit "/templates/wrapper.html.erb"
+
+      refute page.has_selector? ".more-information"
+      refute_match /yoricks\.gov/, page.body
+    end
+
+    should "render the extra information" do
+      EmergencyBanner.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner.any_instance.stubs(:campaign_class).returns("black")
+      EmergencyBanner.any_instance.stubs(:short_description).returns("I knew him well")
+
+      visit "/templates/wrapper.html.erb"
+
+      assert_match "I knew him well", page.body
+    end
+
+    should "does not render the extra information if it does not exist" do
+      EmergencyBanner.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner.any_instance.stubs(:campaign_class).returns("black")
+      EmergencyBanner.any_instance.stubs(:short_description).returns(nil)
+
+      visit "/templates/wrapper.html.erb"
+
+      refute_match "I knew him well", page.body
+    end
   end
 
   context "banner files" do

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -9,6 +9,26 @@ class NotificationsTest < ActionDispatch::IntegrationTest
     Static.banner = @original_banner
   end
 
+  context "emergency banner file" do
+    should "have an emergency banner file" do
+      assert File.exist? "#{Rails.root}/app/views/notifications/_emergency_banner.erb"
+    end
+  end
+
+  context "emergency banner notifications" do
+    should "render a banner" do
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(true)
+      visit "/templates/wrapper.html.erb"
+      assert page.has_selector? "#emergency-banner-notification"
+    end
+
+    should "not render a banner if one does not exist" do
+      EmergencyBanner.any_instance.stubs(:enabled?).returns(false)
+      visit "/templates/wrapper.html.erb"
+      refute page.has_selector? "#emergency-banner-notification"
+    end
+  end
+
   context "banner files" do
     should "have a green file" do
       assert File.exist? "#{Rails.root}/app/views/notifications/banner_green.erb"

--- a/test/unit/emergency_banner_test.rb
+++ b/test/unit/emergency_banner_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+require_relative '../../lib/emergency_banner'
+
+describe "Emergency Banner" do
+  should "return enabled is true when enabled key is true in Redis" do
+    banner = EmergencyBanner.new
+    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(true)
+
+    assert banner.enabled?
+  end
+
+  should "return enabled is false when enabled key is false in Redis" do
+    banner = EmergencyBanner.new
+    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(false)
+
+    refute banner.enabled?
+  end
+
+  should "return enabled is false when enabled key does not exist in Redis" do
+    banner = EmergencyBanner.new
+    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(nil)
+
+    refute banner.enabled?
+  end
+end

--- a/test/unit/emergency_banner_test.rb
+++ b/test/unit/emergency_banner_test.rb
@@ -70,4 +70,61 @@ describe "Emergency Banner" do
       refute @banner.enabled?
     end
   end
+
+  context "content" do
+    should "return the heading as An Emergency" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        heading: "An Emergency"
+      })
+
+      assert_equal "An Emergency", @banner.heading
+    end
+
+    should "return the campaign class as green" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        campaign_class: "green"
+      })
+
+      assert_equal "green", @banner.campaign_class
+    end
+
+    should "return the short description if it is present" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        short_description: "the short description"
+      })
+
+      assert_equal "the short description", @banner.short_description
+    end
+
+    should "return nil for the short description if it is empty" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        short_description: ""
+      })
+
+      assert_nil @banner.short_description
+    end
+
+    should "return the link if it is present" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        link: "https://gov.uk"
+      })
+
+      assert_equal "https://gov.uk", @banner.link
+    end
+
+    should "return nil for the link if it is empty" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        link: ""
+      })
+
+      assert_nil @banner.link
+    end
+
+    should "return nil for the short description and the link if they are not present" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({})
+
+      assert_nil @banner.short_description
+      assert_nil @banner.link
+    end
+  end
 end

--- a/test/unit/emergency_banner_test.rb
+++ b/test/unit/emergency_banner_test.rb
@@ -2,24 +2,37 @@ require 'test_helper'
 require_relative '../../lib/emergency_banner'
 
 describe "Emergency Banner" do
-  should "return enabled is true when enabled key is true in Redis" do
-    banner = EmergencyBanner.new
-    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(true)
-
-    assert banner.enabled?
+  before do
+    @banner = EmergencyBanner.new
   end
 
-  should "return enabled is false when enabled key is false in Redis" do
-    banner = EmergencyBanner.new
-    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(false)
+  context "#enabled?" do
+    should "return enabled is true when all content for the emergency banner is set in Redis" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+          campaign_class: "black",
+        })
 
-    refute banner.enabled?
-  end
+      assert @banner.enabled?
+    end
 
-  should "return enabled is false when enabled key does not exist in Redis" do
-    banner = EmergencyBanner.new
-    Redis.any_instance.stubs(:get).with("emergency_banner:enabled").returns(nil)
+    should "return enabled is false when the content for the emergency_banner is missing in Redis" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        campaign_class: ""
+        })
 
-    refute banner.enabled?
+      refute @banner.enabled?
+    end
+
+    should "return enabled is false when the emergency_banner is empty in Redis" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({})
+
+      refute @banner.enabled?
+    end
+
+    should "return enabled is false when the emergency_banner does not exist in Redis" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(nil)
+
+      refute @banner.enabled?
+    end
   end
 end

--- a/test/unit/emergency_banner_test.rb
+++ b/test/unit/emergency_banner_test.rb
@@ -9,22 +9,57 @@ describe "Emergency Banner" do
   context "#enabled?" do
     should "return enabled is true when all content for the emergency banner is set in Redis" do
       Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
-          campaign_class: "black",
+        heading: "Emergency!",
+        campaign_class: "black",
         })
 
       assert @banner.enabled?
     end
 
-    should "return enabled is false when the content for the emergency_banner is missing in Redis" do
+    should "return enabled is false when the heading is not present" do
       Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
-        campaign_class: ""
+        campaign_class: "a colour",
+        heading: "",
         })
 
       refute @banner.enabled?
     end
 
+    should "return enabled is false when the campaign_class for the emergency_banner is missing in Redis" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        campaign_class: "",
+        heading: "a heading",
+        })
+
+      refute @banner.enabled?
+    end
+
+    should "return enabled is false when the campaign_class and the heading are empty" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        campaign_class: "",
+        heading: "",
+        })
+
+      refute @banner.enabled?
+    end
     should "return enabled is false when the emergency_banner is empty in Redis" do
       Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({})
+
+      refute @banner.enabled?
+    end
+
+    should "return enabled is false when the heading is present but campaign class is not" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        heading: "a heading",
+      })
+
+      refute @banner.enabled?
+    end
+
+    should "return enabled is false when the campaign_class is present but heading class is not" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({
+        campaign_class: "a heading",
+      })
 
       refute @banner.enabled?
     end


### PR DESCRIPTION
Trello card: https://trello.com/c/EPTEOgHJ

Depends on

## Motivation

The current emergency banner doesn't allow static to be deployed while the banner is up.
This PR uses values in Redis to determine whether:
* The banner should be displayed
* What the contents of the banner should be, i.e. the heading and banner colour etc.

## Note

The functionality for the old emergency banner has not been removed yet to allow comparison testing of the old and new emergency banners.