### PR TITLE
Move the tracking of ReportAProblem confirmation

### DIFF
--- a/app/assets/javascripts/report-a-problem-form.js
+++ b/app/assets/javascripts/report-a-problem-form.js
@@ -65,7 +65,6 @@
   ReportAProblemForm.prototype.submit = function(evt) {
     this.hidePrompt();
     this.setUrl();
-    this.trackEvent('GOVUK Send Feedback');
     this.disableSubmitButton();
     this.postFormViaAjax();
 

--- a/app/assets/javascripts/report-a-problem.js
+++ b/app/assets/javascripts/report-a-problem.js
@@ -37,6 +37,8 @@
   };
 
   ReportAProblem.prototype.showConfirmation = function(evt, data) {
+    this.trackEvent('GOVUK Send Feedback');
+
     this.$container.find('.report-a-problem-content').html(data.message);
   };
 

--- a/spec/javascripts/report-a-problem-form-spec.js
+++ b/spec/javascripts/report-a-problem-form-spec.js
@@ -36,15 +36,6 @@ describe("form submission for reporting a problem", function () {
       args = $.ajax.calls.mostRecent().args;
       expect(args[0].url).toBe('ajax-endpoint');
     });
-
-    it("should track the event", function() {
-      spyOn(GOVUK.analytics, "trackEvent");
-      $form.triggerHandler('submit');
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
-        'Onsite Feedback', 'GOVUK Send Feedback', jasmine.any(Object)
-      );
-    });
   });
 
   describe("if the request succeeds", function() {

--- a/spec/javascripts/report-a-problem-spec.js
+++ b/spec/javascripts/report-a-problem-spec.js
@@ -46,6 +46,16 @@ describe("form submission for reporting a problem", function () {
       expect($form).toBeHidden();
       expect($('.report-a-problem-content').html()).toEqual('great success!');
     });
+
+    it("should track the event", function() {
+      spyOn(GOVUK.analytics, "trackEvent");
+
+      $form.trigger('reportAProblemForm.success', {});
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+        'Onsite Feedback', 'GOVUK Send Feedback', jasmine.any(Object)
+      );
+    });
   });
 
   describe("if the request has failed", function() {
@@ -55,6 +65,16 @@ describe("form submission for reporting a problem", function () {
 
       expect($form).not.toBeVisible();
       expect($('.report-a-problem-content').html()).toContain("Sorry, we’re unable to receive your message");
+    });
+
+    it("should not track the event", function() {
+      spyOn(GOVUK.analytics, "trackEvent");
+
+      $form.trigger('reportAProblemForm.error');
+
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith(
+        'Onsite Feedback', 'GOVUK Send Feedback', jasmine.any(Object)
+      );
     });
   });
 });


### PR DESCRIPTION
Trello: https://trello.com/c/ICN4oEAt/136-move-ga-event-when-submitting-the-report-a-problem-form

Moves the tracking of the Report a Problem form to only be sent upon successful submission.