### PR TITLE
Track total number of sections and section links

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -108,6 +108,8 @@
     this.setTaxonIdDimension(dimensions['taxon-id']);
     this.setTaxonSlugsDimension(dimensions['taxon-slugs']);
     this.setTaxonIdsDimension(dimensions['taxon-ids']);
+    this.setTotalNumberOfSections();
+    this.setTotalNumberOfSectionLinks();
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
@@ -173,7 +175,7 @@
 
   StaticAnalytics.prototype.setThemesDimension = function(themes) {
     this.setDimension(3, themes || 'other');
-  }
+  };
 
   StaticAnalytics.prototype.setContentIdDimension = function(contentId) {
     this.setDimension(4, contentId || '00000000-0000-0000-0000-000000000000');
@@ -205,6 +207,26 @@
 
   StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
     this.setDimension(21, position);
+  };
+
+  StaticAnalytics.prototype.setTotalNumberOfSections = function() {
+    var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
+    var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
+    var accordionSubsections = $('[data-track-count="accordionSection"]').length;
+    var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
+    var totalNumberOfSections = sidebarSections || sidebarTaxons || accordionSubsections || gridSections;
+    this.setDimension(26, totalNumberOfSections);
+  };
+
+  StaticAnalytics.prototype.setTotalNumberOfSectionLinks = function() {
+    var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
+    var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
+    // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
+    var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
+      + $('a[data-track-category="navGridLeafLinkClicked"]').length;
+    var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
+    var totalNumberOfSectionLinks = relatedLinks || accordionLinks || gridLinks || leafLinks;
+    this.setDimension(27, totalNumberOfSectionLinks);
   };
 
   StaticAnalytics.prototype.setNavigationPageTypeDimension = function(pageType) {

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -1,7 +1,7 @@
 <% if local_assigns[:sections] && !sections.blank? %>
   <aside class="govuk-related-items" data-module="track-click" role="complementary">
     <% sections.each_with_index do |section, section_index| %>
-      <h2
+      <h2 data-track-count="sidebarRelatedItemSection"
         <% if section[:id] %>id="<%= section[:id] %>"<% end %>
       >
         <%= section[:title] %>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -2,7 +2,7 @@
 
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
     <% items.each_with_index do |item, item_index| %>
-      <div class='sidebar-taxon'>
+      <div class='sidebar-taxon' data-track-count="sidebarTaxonSection">
         <h2>
           <%=
             link_to_if(

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 14;
+    const expectedDefaultArgumentCount = 16;
 
     var universalSetupArguments;
 
@@ -203,6 +203,296 @@ describe("GOVUK.StaticAnalytics", function() {
 
           expect(setupArguments[dimension.setupArgumentsIndex])
             .toEqual(['set', 'dimension' + dimension.number, dimension.defaultValue]);
+        });
+      });
+
+      describe('when tracking the number of sections and links on a page', function() {
+        describe('on a page with a normal sidebar', function() {
+          beforeEach(function() {
+            $('body').append('\
+              <div class="test-fixture">\
+                <aside class="govuk-related-items">\
+                  <h2 data-track-count="sidebarRelatedItemSection">Section 1</h2>\
+                  <nav role="navigation">\
+                    <ul>\
+                      <li>\
+                        <a data-track-category="relatedLinkClicked">\
+                          Link 1.1\
+                        </a>\
+                      </li>\
+                      <li>\
+                        <a data-track-category="relatedLinkClicked">\
+                          Link 1.2\
+                        </a>\
+                      </li>\
+                    </ul>\
+                  </nav>\
+                  <h2 data-track-count="sidebarRelatedItemSection">Section 2</h2>\
+                  <nav role="navigation">\
+                    <ul>\
+                      <li>\
+                        <a data-track-category="relatedLinkClicked">\
+                          Link 2.1\
+                        </a>\
+                      </li>\
+                    </ul>\
+                  </nav>\
+                </aside>\
+              </div>\
+            ');
+          });
+
+          afterEach(function() {
+            $('.test-fixture').remove();
+          });
+
+          it('tracks the number of sidebar sections', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[14])
+              .toEqual(['set', 'dimension26', '2']);
+          });
+
+          it('tracks the total number of related links', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[15])
+              .toEqual(['set', 'dimension27', '3']);
+          });
+        });
+
+        describe('on a page with a taxon sidebar', function() {
+          beforeEach(function() {
+            $('body').append('\
+              <div class="test-fixture">\
+                <aside class="govuk-taxonomy-sidebar">\
+                  <div class="sidebar-taxon" data-track-count="sidebarTaxonSection">\
+                    <h2><a href data-track-category="relatedLinkClicked">Section 1</a></h2>\
+                    <nav role="navigation">\
+                      <ul>\
+                        <li>\
+                          <a href data-track-category="relatedLinkClicked">\
+                            Link 1.1\
+                          </a>\
+                        </li>\
+                        <li>\
+                          <a href data-track-category="relatedLinkClicked">\
+                            Link 1.2\
+                          </a>\
+                        </li>\
+                      </ul>\
+                    </nav>\
+                  </div>\
+                  <div class="sidebar-taxon" data-track-count="sidebarTaxonSection">\
+                    <h2><a href data-track-category="relatedLinkClicked">Section 2</a></h2>\
+                    <nav role="navigation">\
+                      <ul>\
+                        <li>\
+                          <a href data-track-category="relatedLinkClicked">\
+                            Link 2.1\
+                          </a>\
+                        </li>\
+                      </ul>\
+                    </nav>\
+                  </div>\
+                </aside>\
+              </div>\
+            ');
+          });
+
+          afterEach(function() {
+            $('.test-fixture').remove();
+          });
+
+          it('tracks the number of sidebar sections', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[14])
+              .toEqual(['set', 'dimension26', '2']);
+          });
+
+          it('tracks the total number of related links, including headers', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[15])
+              .toEqual(['set', 'dimension27', '5']);
+          });
+        });
+
+        describe('on a page with an accordion', function() {
+          beforeEach(function() {
+            $('body').append('\
+              <div class="test-fixture">\
+                <div class="accordion-with-descriptions">\
+                  <div class="subsection-wrapper">\
+                    <div class="subsection" data-track-count="accordionSection">\
+                      <div class="subsection-header">\
+                        <a href><h2>Section 1</h2></a>\
+                      </div>\
+                      <div class="subsection-content">\
+                        <ol>\
+                          <li>\
+                            <a href data-track-category="navAccordionLinkClicked">\
+                              Link 1.1\
+                            </a>\
+                          </li>\
+                          <li>\
+                            <a href data-track-category="navAccordionLinkClicked">\
+                              Link 1.2\
+                            </a>\
+                          </li>\
+                        </ol>\
+                      </div>\
+                    </div>\
+                    <div class="subsection" data-track-count="accordionSection">\
+                      <div class="subsection-header">\
+                        <a href><h2>Section 2</h2></a>\
+                      </div>\
+                      <div class="subsection-content">\
+                        <ol>\
+                          <li>\
+                            <a href data-track-category="navAccordionLinkClicked">\
+                              Link 2.1\
+                            </a>\
+                          </li>\
+                        </ol>\
+                      </div>\
+                    </div>\
+                  </div>\
+                </div>\
+              </div>\
+            ');
+          });
+
+          afterEach(function() {
+            $('.test-fixture').remove();
+          });
+
+          it('tracks the number of accordion sections', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[14])
+              .toEqual(['set', 'dimension26', '2']);
+          });
+
+          it('tracks the total number of accordion section links', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[15])
+              .toEqual(['set', 'dimension27', '3']);
+          });
+        });
+
+        describe('on a page with an grid', function() {
+          beforeEach(function() {
+            $('body').append('\
+              <div class="test-fixture">\
+                <main class="taxon-page">\
+                  <nav role="navigation">\
+                    <ol>\
+                      <li>\
+                        <h2>\
+                          <a href data-track-category="navGridLinkClicked">Link 1</a>\
+                        </h2>\
+                      </li>\
+                      <li>\
+                        <h2>\
+                          <a href data-track-category="navGridLinkClicked">Link 2</a>\
+                        </h2>\
+                      </li>\
+                      <li>\
+                        <h2>\
+                          <a href data-track-category="navGridLinkClicked">Link 3</a>\
+                        </h2>\
+                      </li>\
+                    </ol>\
+                  </nav>\
+                  <div class="grid-row">\
+                    <div class="parent-topic-contents">\
+                      <div class="topic-content">\
+                        <h2>Grid leaves</h2>\
+                        <ol>\
+                          <li><h2>\
+                            <a href data-track-category="navGridLeafLinkClicked">\
+                              Leaf 1\
+                            </a>\
+                          </h2></li>\
+                          \<li><h2>\
+                            <a href data-track-category="navGridLeafLinkClicked">\
+                              Leaf 2\
+                            </a>\
+                          </h2></li>\
+                        </ol>\
+                      </div>\
+                    </div>\
+                  </div>\
+                </main>\
+              </div>\
+            ');
+          });
+
+          afterEach(function() {
+            $('.test-fixture').remove();
+          });
+
+          it('does tracks sections equal to the number of grid links', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[14])
+              .toEqual(['set', 'dimension26', '3']);
+          });
+
+          it('tracks the total number of grid links and leaf links', function() {
+            analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+            setupArguments = window.ga.calls.allArgs();
+            expect(setupArguments[15])
+              .toEqual(['set', 'dimension27', '5']);
+          });
+        });
+      });
+
+      describe('on a navigation leaf page', function() {
+        beforeEach(function() {
+          $('body').append('\
+              <div class="test-fixture">\
+                <div class="topic-content">\
+                  <ol>\
+                    <li>\
+                      <h2>\
+                        <a href data-track-category="navLeafLinkClicked">\
+                          Link 1\
+                        </a>\
+                      </h2>\
+                    </li>\
+                    <li>\
+                      <h2>\
+                        <a href data-track-category="navLeafLinkClicked">\
+                          Link 2\
+                        </a>\
+                      </h2>\
+                    </li>\
+                  </ol>\
+                </div>\
+              </div>\
+            ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('does not track any sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          setupArguments = window.ga.calls.allArgs();
+          expect(setupArguments[14])
+            .toEqual(['set', 'dimension26', '0']);
+        });
+
+        it('tracks the total number of leaf links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          setupArguments = window.ga.calls.allArgs();
+          expect(setupArguments[15])
+            .toEqual(['set', 'dimension27', '2']);
         });
       });
 


### PR DESCRIPTION
At the moment we only record related link and accordion link information
on the click event (ie only if someone uses the link). We have no
information about if links are not used, since they don’t get clicked
and then never send a tracking event.

This change will add tracking for custom dimensions on the page view,
which will report information on:

- the total number of “sections” on the page
- the total number of “section links” on the page

These values will have different meanings depending on the type of page
we are on.

On a content item, the number of sections will refer to the number of
sections of related links in the sidebar. The total number of links
is the total number of related links in the sidebar (not including
the heading in a taxon sidebar, but including the “More” link).

On a leaf page in the new taxon navigation, the number of sections is
not tracked, and the total number of links is the total number of
leaf links.

On an accordion page in the new taxon navigation, the number of
sections will refer to the number of accordion sections, and the total
number of links will refer to the total number of content items
under all the accordion sections.

On a grid page in the new taxon navigation, the number of sections is
the number of grid links, and the total number of links will refer to
the total number of grid links plus the leaf links.

### Dependencies:

- [x] https://github.com/alphagov/collections/pull/326

### Trello

https://trello.com/c/VS6HcoBS/556-track-the-total-number-of-links-and-sections-for-accordions-and-related-links