### PR TITLE
Add emergency banner for homepage

### DIFF
--- a/app/assets/stylesheets/helpers/_emergency-banner-notifications.scss
+++ b/app/assets/stylesheets/helpers/_emergency-banner-notifications.scss
@@ -53,3 +53,61 @@
     background: #000000;
   }
 }
+
+@mixin campaign-styles($background, $foreground) {
+  background: $background;
+
+  h1,
+  p,
+  a {
+    color: $foreground;
+  }
+}
+
+#campaign {
+  &.black {
+    @include campaign-styles($black, $white);
+  }
+
+  &.red {
+    @include campaign-styles($red, $white);
+  }
+
+  &.green {
+    @include campaign-styles($turquoise, $white);
+  }
+
+  border: 5px solid $white;
+  border-width: 5px 0;
+
+  .campaign-inner {
+    @extend %contain-floats;
+    @extend %site-width-container;
+    position: relative;
+    padding: 15px 0;
+
+    h1 {
+      @include bold-48;
+    }
+
+    p {
+      @include media(tablet) {
+        width: 66.66%; // this is the same as .welcome-text
+        float: left;
+      }
+    }
+
+    a {
+      // this is the same as .content-links
+      @include media(tablet) {
+        position: absolute;
+        bottom: 1em;
+        left: 66.66%;
+        width: 33.33%;
+        padding: 0 10px;
+        display: block;
+      }
+      @include core-19;
+    }
+  }
+}

--- a/app/views/notifications/_homepage_emergency_banner.erb
+++ b/app/views/notifications/_homepage_emergency_banner.erb
@@ -1,0 +1,11 @@
+<div id="campaign" class="<%= banner.campaign_class %>">
+  <div class="campaign-inner">
+    <h1><%= banner.heading %></h1>
+    <p>
+      <%= banner.short_description %>
+    </p>
+    <% if banner.link %>
+      <a href="<%= banner.link %>">More information</a>
+    <% end %>
+  </div>
+</div>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -1,7 +1,8 @@
 <% content_for :homepage_url, Plek.new.website_root %>
 <% content_for :page_title, content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %>
 <% @banner_notification = banner_notification unless local_assigns[:hide_banner_notification] %>
-<% @emergency_banner = emergency_banner_notification unless local_assigns[:hide_banner_notification] %>
+<% @emergency_banner = emergency_banner_notification %>
+<% @is_home_page = local_assigns[:is_home_page] %>
 
 <% if ENV["DRAFT_ENVIRONMENT"].present? %>
   <% content_for :body_classes, "draft" %>
@@ -33,7 +34,11 @@
   <% end %>
 
   <% if @emergency_banner %>
-    <%= render "notifications/emergency_banner", banner: @emergency_banner %>
+    <% if @is_home_page %>
+      <%= render "notifications/homepage_emergency_banner", banner: @emergency_banner %>
+    <% else %>
+      <%= render "notifications/emergency_banner", banner: @emergency_banner %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/root/homepage.html.erb
+++ b/app/views/root/homepage.html.erb
@@ -8,6 +8,6 @@
  # template on frontend due to the way slimmer would not copy over the
  # comment
 %>
-<%= render partial: 'base', locals: { hide_nav: true, hide_banner_notification: true } %>
+<%= render partial: 'base', locals: { hide_nav: true, hide_banner_notification: true, is_home_page: true } %>
 <%= render :file => 'layouts/govuk_template' %>
 <!-- Thanks Martha -->

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -16,69 +16,112 @@ class NotificationsTest < ActionDispatch::IntegrationTest
   end
 
   context "emergency banner notifications" do
-    should "not render a banner if one does not exist" do
-      EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(false)
-      visit "/templates/wrapper.html.erb"
-      refute page.has_selector? "#emergency-banner-notification"
+    context "homepage" do
+      should "not render a banner if one does not exist" do
+        EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(false)
+        visit "/templates/homepage.html.erb"
+        refute page.has_selector? "#campaign"
+      end
+
+      should "render a banner if one does exist" do
+        EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(true)
+        visit "/templates/homepage.html.erb"
+        assert page.has_selector? "#campaign"
+      end
+
+      should "only render the homepage emergency banner, not the general population emergency banner" do
+        EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(true)
+        visit "/templates/homepage.html.erb"
+        assert page.has_selector? "#campaign"
+        refute page.has_selector? "#emergency-banner-notification"
+      end
+
+      should "render a homepage banner with a heading and campaign colour" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        visit "/templates/homepage.html.erb"
+        assert page.has_selector? "#campaign.black"
+        assert_match 'Alas poor Yorick', page.body
+      end
+
+      should "render the short description and more information link" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        EmergencyBanner::Display.any_instance.stubs(:link).returns("https://yoricks.gov")
+        EmergencyBanner::Display.any_instance.stubs(:short_description).returns("I knew him well")
+
+        visit "/templates/homepage.html.erb"
+        assert_match "I knew him well", page.body
+        assert_match "More information", page.body
+        assert_match /yoricks\.gov/, page.body
+      end
     end
 
-    should "render a banner if one does exist" do
-      EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(true)
-      visit "/templates/wrapper.html.erb"
-      assert page.has_selector? "#emergency-banner-notification"
-    end
+    context "all other pages" do
+      should "not render a banner if one does not exist" do
+        EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(false)
+        visit "/templates/wrapper.html.erb"
+        refute page.has_selector? "#emergency-banner-notification"
+      end
 
-    should "render a banner with a heading and campaign colour" do
-      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
-      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+      should "render a banner if one does exist" do
+        EmergencyBanner::Display.any_instance.stubs(:enabled?).returns(true)
+        visit "/templates/wrapper.html.erb"
+        assert page.has_selector? "#emergency-banner-notification"
+      end
 
-      visit "/templates/wrapper.html.erb"
+      should "render a banner with a heading and campaign colour" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
 
-      assert page.has_selector? "#emergency-banner-notification.black"
-      assert_match 'Alas poor Yorick', page.body
-    end
+        visit "/templates/wrapper.html.erb"
 
-    should "render the more information link" do
-      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
-      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
-      EmergencyBanner::Display.any_instance.stubs(:link).returns("https://yoricks.gov")
+        assert page.has_selector? "#emergency-banner-notification.black"
+        assert_match 'Alas poor Yorick', page.body
+      end
 
-      visit "/templates/wrapper.html.erb"
+      should "render the more information link" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        EmergencyBanner::Display.any_instance.stubs(:link).returns("https://yoricks.gov")
 
-      assert page.has_selector? ".more-information"
-      assert_match "More information", page.body
-      assert_match /yoricks\.gov/, page.body
-    end
+        visit "/templates/wrapper.html.erb"
 
-    should "not render the more information link if it does not exist" do
-      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
-      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
-      EmergencyBanner::Display.any_instance.stubs(:link).returns(nil)
+        assert page.has_selector? ".more-information"
+        assert_match "More information", page.body
+        assert_match /yoricks\.gov/, page.body
+      end
 
-      visit "/templates/wrapper.html.erb"
+      should "not render the more information link if it does not exist" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        EmergencyBanner::Display.any_instance.stubs(:link).returns(nil)
 
-      refute page.has_selector? ".more-information"
-      refute_match /yoricks\.gov/, page.body
-    end
+        visit "/templates/wrapper.html.erb"
 
-    should "render the extra information" do
-      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
-      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
-      EmergencyBanner::Display.any_instance.stubs(:short_description).returns("I knew him well")
+        refute page.has_selector? ".more-information"
+        refute_match /yoricks\.gov/, page.body
+      end
 
-      visit "/templates/wrapper.html.erb"
+      should "render the extra information" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        EmergencyBanner::Display.any_instance.stubs(:short_description).returns("I knew him well")
 
-      assert_match "I knew him well", page.body
-    end
+        visit "/templates/wrapper.html.erb"
 
-    should "does not render the extra information if it does not exist" do
-      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
-      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
-      EmergencyBanner::Display.any_instance.stubs(:short_description).returns(nil)
+        assert_match "I knew him well", page.body
+      end
 
-      visit "/templates/wrapper.html.erb"
+      should "does not render the extra information if it does not exist" do
+        EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+        EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("black")
+        EmergencyBanner::Display.any_instance.stubs(:short_description).returns(nil)
 
-      refute_match "I knew him well", page.body
+        visit "/templates/wrapper.html.erb"
+
+        refute_match "I knew him well", page.body
+      end
     end
   end
 


### PR DESCRIPTION
## Context
We are consolidating the emergency banner templates in Static and Frontend - see the [Trello card](https://trello.com/c/3eq0AeHA/30-consolidate-emergency-banner-templates-in-static-and-frontend)

## This PR
This PR does the work of bringing the homepage emergency banner display into Static. This will result in two different partials in Static that are responsible for displaying the emergency banner. One for the home page and one for all other pages. Although not ideal, at the moment, this is a good first step because the markup and styling is different between the two classes of page.

Work included in this PR:

* Create new partial that will render the emergency banner for the homepage.
* Include logic in `_base` to selectively display the correct emergency banner partial.
* Pass additional `is_home_page` local variable from `homepage.html.erb` to help decide which emergency banner partial to display.
* Include styles for the homepage emergency banner copied over from frontend.

The test file diff will be a bit noisy because of some added `context`.