### PR TITLE
Style address blocks with margins

### DIFF
--- a/app/assets/stylesheets/govuk-component/govspeak/_contact.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_contact.scss
@@ -6,18 +6,17 @@
 // - alphagov/govspeak: ✔︎
 
 .govuk-govspeak {
-  // No obvious signs of the address class being used in alphagov/whitehall or
-  // alphagov/govspeak.
+  // .address is used by the `$A` markdown pattern
   .address,
   .contact {
     border-left: 1px solid $border-colour;
     padding-left: $gutter-half;
+    margin-bottom: $gutter;
+    margin-top: $gutter;
   }
 
   .contact {
     @extend %contain-floats;
-    margin-bottom: $gutter;
-    margin-top: $gutter;
     position: relative;
 
     .content {

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -152,6 +152,21 @@ fixtures:
           </tr>
         </tbody>
       </table>
+  address:
+    content: |
+      <div class="address">
+        <div class="adr org fn">
+          <p>
+            First line of address
+            <br>Second line of address
+            <br>75 This street
+            <br>United Kindom
+            <br>Phone: 07123456789
+            <br>
+          </p>
+        </div>
+      </div>
+      <p>Addresses are generated when using the `$A` markdown pattern.</p>
   contact:
     content: |
       <div class="contact" id="contact_1017">


### PR DESCRIPTION
Addresses are used in the $A markdown pattern:
https://github.com/alphagov/govspeak/blob/a04ef6b54f090ec03911d0daaed4c74741578fea/lib/govspeak.rb#L249-L251

This pattern is used in specialist documents that include contacts:
https://www.gov.uk/drug-device-alerts/transwarmer-infant-transport-mattress-novaplus-transwarmer-infant-heat-therapy-mattress-with-warmgel-infant-heel-warmer-risk-of-serious-burn

| Before | After |
|--|--|
|![screen shot 2017-04-19 at 14 40 08](https://cloud.githubusercontent.com/assets/319055/25184158/883bad74-2511-11e7-870a-c8af183ceace.png)|![screen shot 2017-04-19 at 14 45 42](https://cloud.githubusercontent.com/assets/319055/25184157/883b4596-2511-11e7-9847-a2b585d9e7f0.png)|

## Example

![screen shot 2017-04-19 at 15 01 18](https://cloud.githubusercontent.com/assets/319055/25184169/90e83f64-2511-11e7-8fe9-eb15ca23c9b5.png)