### PR TITLE
Add REDIS_URL to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essenti
 
 ENV GOVUK_APP_NAME static
 ENV RAILS_ENV development
+ENV REDIS_URL redis://redis
 ENV PORT 3013
 
 ENV APP_HOME /app


### PR DESCRIPTION
This is used to run https://github.com/alphagov/publishing-e2e-tests

Currently we're seeing a bunch of errors from Redis not connecting.