### PR TITLE
Add schema name analytics meta tag

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -121,6 +121,7 @@
     this.setOrganisationsDimension(dimensions['analytics:organisations']);
     this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
     this.setRenderingApplicationDimension(dimensions['rendering-application']);
+    this.setSchemaNameDimension(dimensions['schema-name']);
   };
 
   StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
@@ -207,6 +208,10 @@
 
   StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
     this.setDimension(21, position);
+  };
+
+  StaticAnalytics.prototype.setSchemaNameDimension = function(position) {
+    this.setDimension(17, position);
   };
 
   StaticAnalytics.prototype.setTotalNumberOfSections = function() {

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -8,6 +8,7 @@
   meta_tags = {}
 
   meta_tags["govuk:format"] = content_item_hash[:document_type] if content_item_hash[:document_type]
+  meta_tags["govuk:schema-name"] = content_item_hash[:schema_name] if content_item_hash[:schema_name]
 
   organisations = []
   organisations += links_hash[:organisations] || []

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -64,6 +64,7 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
+          <meta name="govuk:schema-name" content="schema-name">\
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
@@ -76,6 +77,7 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(setupArguments[4]).toEqual(['set', 'dimension7', 'historic']);
         expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
         expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
+        expect(setupArguments[7]).toEqual(['set', 'dimension17', 'schema-name']);
       });
 
       it('ignores meta tags not set', function() {

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -23,7 +23,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   end
 
   test "renders format in a meta tag" do
-    render_component(content_item: { document_type: "case_study" })
+    render_component(content_item: example_document_for('case_study', 'case_study'))
     assert_meta_tag('govuk:format', 'case_study')
   end
 

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -23,8 +23,13 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   end
 
   test "renders format in a meta tag" do
-    render_component(content_item: example_document_for('case_study', 'case_study'))
-    assert_meta_tag('govuk:format', 'case_study')
+    render_component(content_item: example_document_for('publication', 'statistics_publication'))
+    assert_meta_tag('govuk:format', 'national_statistics')
+  end
+
+  test "renders schema-name in a meta tag" do
+    render_component(content_item: example_document_for('publication', 'statistics_publication'))
+    assert_meta_tag('govuk:schema-name', 'publication')
   end
 
   test "renders organisations in a meta tag with angle brackets" do


### PR DESCRIPTION
Part of https://trello.com/c/0xPPAdDd/286-track-schema-name-in-google-analytics

Paired with @michaelihejirika 

Also tested locally with government-frontend and can confirm calls to GA with dimension17 are set correctly.