### PR TITLE
Enable GOV.UK analytics tracker configuration

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -15,6 +15,8 @@
     universalId: universalId,
     cookieDomain: cookieDomain,
     allowLinker: true,
+    // This is served by Fastly in production, and returns an empty 200 response
+    govukTrackerGifUrl: '<%= asset_path "/static/a" %>',
   });
 
   // Make interface public for virtual pageviews and events


### PR DESCRIPTION
The configuration variable is misnamed and will be changed once this is
proven to work. The endpoint is now served entirely by Fastly, and
returns an empty 200 response. We only call the endpoint using
`$.get()` and ignore the response so its `Content-Type` doesn’t matter.