### PR TITLE
Remove underline from buttons

### DIFF
--- a/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
@@ -66,6 +66,12 @@
     text-decoration: underline;
   }
 
+  // Buttons
+
+  .button {
+    text-decoration: none;
+  }
+
   // Lists
 
   ol,


### PR DESCRIPTION
Publishers unofficially add button html to mainstream content
This has not been componentised yet. Button styles need to be
provided by the app.

BEFORE
<img width="232" alt="screen shot 2017-04-24 at 15 22 21" src="https://cloud.githubusercontent.com/assets/248888/25341757/d7a7df56-2901-11e7-8935-a1d303a8c2a5.png">
AFTER
<img width="243" alt="screen shot 2017-04-24 at 15 23 00" src="https://cloud.githubusercontent.com/assets/248888/25341788/ed7ea4a4-2901-11e7-9549-02e7c7b05f0c.png">


