### PR TITLE
Track page views on DOM ready

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -8,6 +8,7 @@
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
     var analytics = new GOVUK.Analytics(config);
+    var staticAnalytics = this;
     this.analytics = analytics;
 
     setPixelDensityDimension();
@@ -17,8 +18,11 @@
     this.setAbTestDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
 
-    // Track initial pageview
-    analytics.trackPageview();
+    $(function() {
+      staticAnalytics.setDimensionsFromDom();
+      // Track initial pageview
+      analytics.trackPageview();
+    });
 
     // Begin error and print tracking
     GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
@@ -98,6 +102,11 @@
     this.setDimensionsThatDoNotHaveDefaultValues(dimensions);
   };
 
+  StaticAnalytics.prototype.setDimensionsFromDom = function() {
+    this.setTotalNumberOfSections();
+    this.setTotalNumberOfSectionLinks();
+  };
+
   StaticAnalytics.prototype.setDimensionsThatHaveDefaultValues = function(dimensions) {
     this.setThemesDimension(dimensions['themes']);
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
@@ -108,8 +117,6 @@
     this.setTaxonIdDimension(dimensions['taxon-id']);
     this.setTaxonSlugsDimension(dimensions['taxon-slugs']);
     this.setTaxonIdsDimension(dimensions['taxon-ids']);
-    this.setTotalNumberOfSections();
-    this.setTotalNumberOfSectionLinks();
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,9 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 16;
+    const expectedDefaultArgumentCount = 14;
+    // The number of setup argumnets which are set on DOM ready, after everything else
+    const expectedDomReadyArgumentCount = 2;
 
     var universalSetupArguments;
 
@@ -35,7 +37,8 @@ describe("GOVUK.StaticAnalytics", function() {
     });
 
     it('tracks a pageview in universal', function() {
-      expect(universalSetupArguments[expectedDefaultArgumentCount]).toEqual(['send', 'pageview']);
+      expect(universalSetupArguments[expectedDefaultArgumentCount + expectedDomReadyArgumentCount])
+        .toEqual(['send', 'pageview']);
     });
 
     it('begins print tracking', function() {
@@ -500,7 +503,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
       function dimensionSetupArguments() {
         // Remove the default calls to the analytics object
-        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1);
+        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1 - expectedDomReadyArgumentCount);
       }
     });
   });


### PR DESCRIPTION
We have a bug that means that some page views do not correctly have
the number of links and sections set. This could be because these values
are tracked through counting DOM elements, but the code is run before
`document.ready`.

This change attempts to fix the bug by performing the count after the
DOM has fully loaded, and only then tracking the page view.

### Trello

https://trello.com/c/irHlKtYL/50-review-number-of-links-sections-tracking