### PR TITLE
Revert "Track page views on DOM ready"

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -8,7 +8,6 @@
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
     var analytics = new GOVUK.Analytics(config);
-    var staticAnalytics = this;
     this.analytics = analytics;
 
     setPixelDensityDimension();
@@ -18,11 +17,8 @@
     this.setAbTestDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
 
-    $(function() {
-      staticAnalytics.setDimensionsFromDom();
-      // Track initial pageview
-      analytics.trackPageview();
-    });
+    // Track initial pageview
+    analytics.trackPageview();
 
     // Begin error and print tracking
     GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
@@ -102,11 +98,6 @@
     this.setDimensionsThatDoNotHaveDefaultValues(dimensions);
   };
 
-  StaticAnalytics.prototype.setDimensionsFromDom = function() {
-    this.setTotalNumberOfSections();
-    this.setTotalNumberOfSectionLinks();
-  };
-
   StaticAnalytics.prototype.setDimensionsThatHaveDefaultValues = function(dimensions) {
     this.setThemesDimension(dimensions['themes']);
     this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
@@ -117,6 +108,8 @@
     this.setTaxonIdDimension(dimensions['taxon-id']);
     this.setTaxonSlugsDimension(dimensions['taxon-slugs']);
     this.setTaxonIdsDimension(dimensions['taxon-ids']);
+    this.setTotalNumberOfSections();
+    this.setTotalNumberOfSectionLinks();
   };
 
   StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,9 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 14;
-    // The number of setup argumnets which are set on DOM ready, after everything else
-    const expectedDomReadyArgumentCount = 2;
+    const expectedDefaultArgumentCount = 16;
 
     var universalSetupArguments;
 
@@ -37,8 +35,7 @@ describe("GOVUK.StaticAnalytics", function() {
     });
 
     it('tracks a pageview in universal', function() {
-      expect(universalSetupArguments[expectedDefaultArgumentCount + expectedDomReadyArgumentCount])
-        .toEqual(['send', 'pageview']);
+      expect(universalSetupArguments[expectedDefaultArgumentCount]).toEqual(['send', 'pageview']);
     });
 
     it('begins print tracking', function() {
@@ -503,7 +500,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
       function dimensionSetupArguments() {
         // Remove the default calls to the analytics object
-        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1 - expectedDomReadyArgumentCount);
+        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1);
       }
     });
   });


### PR DESCRIPTION
This reverts commit 8cc61f56d8c1762f1589348153be10d0719f7ff1.

We previously pushed a speculative fix to track down an unreproducible tracking bug. The fix was not effective, so we're backing it out.

### Trello

https://trello.com/c/irHlKtYL/50-review-number-of-links-sections-tracking