### PR TITLE
Replaces survey monkey with smart survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -248,8 +248,8 @@
       var $surveyLink = $('#take-survey');
       var surveyUrl = survey.url;
 
-      // Survey monkey can record the URL of the survey link if passed through as a query param
-      if ((/surveymonkey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
+      // Smart survey can record the URL of the survey link if passed through as a query param
+      if ((/smartsurvey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
         surveyUrl += "?c=" + userSurveys.currentPath();
       }
 

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -12,7 +12,7 @@ There are sections of the site that should not show any surveys and these can be
 
 ```javascript
 {
-  url: 'https://www.surveymonkey.com/s/2AAAAAA/',
+  url: 'https://www.smartsurvey.co.uk/s/gov-uk',
   identifier: 'education_only_survey',
   frequency: 50,
   template: TEMPLATE,
@@ -43,7 +43,7 @@ What type of survey is this.  Currently either `url` or `email` is supported.  `
 Note that for `email` surveys the users email is submitted back to the [feedback](https://github.com/alphagov/feedback) app which actually sends the email.  The email address is sent with the `identifier` of the survey and this identifier must match with the `id` of a survey defined in [`app/models/email_survey.rb`](https://github.com/alphagov/feedback/blob/85e07b0c572a91be02b64af1d551df313f2695f9/app/models/email_survey.rb#L24).  Make sure you define the survey in both `static` and `feedback`.
 
 ### `url` - required for `url` surveys
-This should link to a surveymonkey -- or other survey page -- that allows the visitor to take the survey.
+This should link to a smartsurvey -- or other survey page -- that allows the visitor to take the survey.
 
 ### `template` - OPTIONAL
 This describes the UI that the survey will use to encourage users to sign up.  If omitted the default survey for the `surveyType` will be used.

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -3,7 +3,7 @@ describe("Surveys", function() {
   var $block;
 
   var defaultSurvey = {
-    url: 'surveymonkey.com/default',
+    url: 'smartsurvey.co.uk/default',
     frequency: 1, // no randomness in the test suite pls
     identifier: 'user_satisfaction_survey',
     template: '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
@@ -20,7 +20,7 @@ describe("Surveys", function() {
   };
   var urlSurvey = {
     surveyType: 'url',
-    url: 'surveymonkey.com/default',
+    url: 'smartsurvey.co.ukdefault',
     identifier: 'url-survey',
   };
   var emailSurvey = {
@@ -75,7 +75,7 @@ describe("Surveys", function() {
     });
 
     describe("for a 'url' survey", function() {
-      it("links to the url for a surveymonkey survey with a completion redirect query parameter", function () {
+      it("links to the url for a smartsurvey survey with a completion redirect query parameter", function () {
         surveys.displaySurvey(urlSurvey);
 
         expect($('#take-survey').attr('href')).toContain(urlSurvey.url);


### PR DESCRIPTION
[Trello card](https://trello.com/c/fg1pm35A/157-re-add-custom-variable-to-survey)

This will add back the custom variable that was being appended to the end of survey monkey urls.
All survey monkey urls have been replaced with smart survey urls, so this should have been corrected as well.