### PR TITLE
Pass custom dimensions directly to page tracking

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -1,24 +1,18 @@
-(function() {
+(function () {
   "use strict";
   window.GOVUK = window.GOVUK || {};
 
-  var StaticAnalytics = function(config) {
+  var StaticAnalytics = function (config) {
 
     // Create universal tracker
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
-    var analytics = new GOVUK.Analytics(config);
-    this.analytics = analytics;
+    this.analytics = new GOVUK.Analytics(config);
 
-    setPixelDensityDimension();
-    setHTTPStatusCodeDimension();
-    setTLSVersionDimension();
-    this.setDimensionsFromMetaTags();
-    this.setAbTestDimensionsFromMetaTags();
     this.callMethodRequestedByPreviousPage();
 
     // Track initial pageview
-    analytics.trackPageview();
+    this.trackPageview();
 
     // Begin error and print tracking
     GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
@@ -28,25 +22,9 @@
     GOVUK.analyticsPlugins.downloadLinkTracker({
       selector: 'a[href*="/government/uploads"], a[href*="assets.publishing.service.gov.uk"]'
     });
-
-    function setPixelDensityDimension() {
-      if (window.devicePixelRatio) {
-        analytics.setDimension(11, window.devicePixelRatio);
-      }
-    }
-
-    function setTLSVersionDimension() {
-      var tls_version = GOVUK.cookie('TLSversion') || 'unknown';
-      analytics.setDimension(16, tls_version);
-    }
-
-    function setHTTPStatusCodeDimension() {
-      analytics.setDimension(15, window.httpStatusCode || 200);
-    }
-
   };
 
-  StaticAnalytics.prototype.callOnNextPage = function(method, params) {
+  StaticAnalytics.prototype.callOnNextPage = function (method, params) {
     params = params || [];
 
     if (!$.isArray(params)) {
@@ -59,14 +37,15 @@
     }
   };
 
-  StaticAnalytics.prototype.callMethodRequestedByPreviousPage = function() {
+  StaticAnalytics.prototype.callMethodRequestedByPreviousPage = function () {
     if (GOVUK.cookie && GOVUK.cookie('analytics_next_page_call') !== null) {
       var params, method;
 
       try {
         params = JSON.parse(GOVUK.cookie('analytics_next_page_call'));
         method = params.shift();
-      } catch(e) {}
+      } catch (e) {
+      }
 
       if (method && typeof this[method] === "function") {
         this[method].apply(this, params);
@@ -77,80 +56,38 @@
     }
   };
 
-  StaticAnalytics.load = function() {
+  StaticAnalytics.load = function () {
     GOVUK.Analytics.load();
   };
 
-  StaticAnalytics.prototype.setDimensionsFromMetaTags = function() {
-    var $metas = $('meta[name^="govuk:"]'),
-        dimensions = {};
-
-    $metas.each(function() {
-      var $meta = $(this),
-          key = $meta.attr('name').split('govuk:')[1],
-          value = $meta.attr('content');
-
-      dimensions[key] = value;
-    });
-
-    // Set defaults first, so that we get a stable ordering in tests
-    this.setDimensionsThatHaveDefaultValues(dimensions);
-    this.setDimensionsThatDoNotHaveDefaultValues(dimensions);
+  // TODO: Remove this, and its corresponding call in collections
+  StaticAnalytics.prototype.setSectionDimension = function () {
   };
 
-  StaticAnalytics.prototype.setDimensionsThatHaveDefaultValues = function(dimensions) {
-    this.setThemesDimension(dimensions['themes']);
-    this.setNavigationPageTypeDimension(dimensions['navigation-page-type']);
-    this.setUserJourneyStage(dimensions['user-journey-stage']);
-    this.setNavigationDocumentTypeDimension(dimensions['navigation-document-type']);
-    this.setContentIdDimension(dimensions['content-id']);
-    this.setTaxonSlugDimension(dimensions['taxon-slug']);
-    this.setTaxonIdDimension(dimensions['taxon-id']);
-    this.setTaxonSlugsDimension(dimensions['taxon-slugs']);
-    this.setTaxonIdsDimension(dimensions['taxon-ids']);
-    this.setTotalNumberOfSections();
-    this.setTotalNumberOfSectionLinks();
+  // TODO: We're setting this at a session level, because it's called in frontend's live-search.js to update
+  // the search count. We should make this consistent with the other dimensions and pass the dimension
+  // directly into the pageview arguments.
+  StaticAnalytics.prototype.setResultCountDimension = function (count) {
+    this.setDimension(5, count);
   };
 
-  StaticAnalytics.prototype.setDimensionsThatDoNotHaveDefaultValues = function(dimensions) {
-    this.setSectionDimension(dimensions['section']);
-    this.setFormatDimension(dimensions['format']);
-    this.setResultCountDimension(dimensions['search-result-count']);
-    this.setPublishingGovernmentDimension(dimensions['publishing-government']);
-    this.setPoliticalStatusDimension(dimensions['political-status']);
-    this.setOrganisationsDimension(dimensions['analytics:organisations']);
-    this.setWorldLocationsDimension(dimensions['analytics:world-locations']);
-    this.setRenderingApplicationDimension(dimensions['rendering-application']);
-    this.setSchemaNameDimension(dimensions['schema-name']);
+  // TODO: We're setting this at a session level, because it's used by search through callOnNextPage. We should
+  // make this consistent with the other dimensions and pass the dimension directly into the pageview arguments.
+  StaticAnalytics.prototype.setSearchPositionDimension = function (position) {
+    this.setDimension(21, position);
   };
 
-  StaticAnalytics.prototype.setAbTestDimensionsFromMetaTags = function() {
-      var $abMetas = $('meta[name^="govuk:ab-test"]'),
-          staticAnalytics = this,
-          // This is the block of dimensions assigned to A/B tests
-          minAbTestDimension = 40,
-          maxAbTestDimension = 49;
-
-      $abMetas.each(function() {
-        var $meta = $(this),
-        dimension = parseInt($meta.data('analytics-dimension')),
-        testNameAndBucket = $meta.attr('content');
-
-        if (dimension >= minAbTestDimension && dimension <= maxAbTestDimension) {
-          staticAnalytics.setDimension(dimension, testNameAndBucket);
-        }
-      });
-  }
-
-  StaticAnalytics.prototype.trackPageview = function(path, title, options) {
-    this.analytics.trackPageview(path, title, options);
+  StaticAnalytics.prototype.trackPageview = function (path, title, options) {
+    var trackingOptions = this.customDimensions();
+    $.extend(trackingOptions, options);
+    this.analytics.trackPageview(path, title, trackingOptions);
   };
 
-  StaticAnalytics.prototype.trackEvent = function(category, action, options) {
+  StaticAnalytics.prototype.trackEvent = function (category, action, options) {
     this.analytics.trackEvent(category, action, options);
   };
 
-  StaticAnalytics.prototype.setDimension = function(index, value, name, scope) {
+  StaticAnalytics.prototype.setDimension = function (index, value, name, scope) {
     if (typeof value === "undefined") {
       return;
     }
@@ -158,112 +95,131 @@
     this.analytics.setDimension(index, value, name, scope);
   };
 
-  StaticAnalytics.prototype.trackShare = function(network) {
+  StaticAnalytics.prototype.trackShare = function (network) {
     this.analytics.trackShare(network);
   };
 
-  StaticAnalytics.prototype.addLinkedTrackerDomain = function(trackerId, name, domain) {
+  StaticAnalytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain) {
     this.analytics.addLinkedTrackerDomain(trackerId, name, domain);
   };
 
-  StaticAnalytics.prototype.setSectionDimension = function(section) {
-    this.setDimension(1, section);
+  StaticAnalytics.prototype.customDimensions = function () {
+    var dimensions = $.extend(
+      {},
+      customDimensionsFromBrowser(),
+      customDimensionsFromMetaTags(),
+      customDimensionsFromDom(),
+      abTestCustomDimensions()
+    );
+
+    return $.each(dimensions, function (key, value) {
+      dimensions[key] = String(value);
+    });
   };
 
-  StaticAnalytics.prototype.setFormatDimension = function(format) {
-    this.setDimension(2, format);
-  };
+  function customDimensionsFromBrowser() {
+    var customDimensions = {
+      dimension15: window.httpStatusCode || 200,
+      dimension16: GOVUK.cookie('TLSversion') || 'unknown'
+    };
 
-  StaticAnalytics.prototype.setThemesDimension = function(themes) {
-    this.setDimension(3, themes || 'other');
-  };
+    if (window.devicePixelRatio) {
+      customDimensions.dimension11 = window.devicePixelRatio;
+    }
 
-  StaticAnalytics.prototype.setContentIdDimension = function(contentId) {
-    this.setDimension(4, contentId || '00000000-0000-0000-0000-000000000000');
-  };
+    return customDimensions;
+  }
 
-  StaticAnalytics.prototype.setResultCountDimension = function(count) {
-    this.setDimension(5, count);
-  };
+  function customDimensionsFromMetaTags() {
+    var dimensionMappings = {
+      'section': {dimension: 1},
+      'format': {dimension: 2},
+      'themes': {dimension: 3, defaultValue: 'other'},
+      'content-id': {dimension: 4, defaultValue: '00000000-0000-0000-0000-000000000000'},
+      'search-result-count': {dimension: 5},
+      'publishing-government': {dimension: 6},
+      'political-status': {dimension: 7},
+      'analytics:organisations': {dimension: 9},
+      'analytics:world-locations': {dimension: 10},
+      'schema-name': {dimension: 17},
+      'rendering-application': {dimension: 20},
+      'navigation-page-type': {dimension: 32, defaultValue: 'none'},
+      'user-journey-stage': {dimension: 33, defaultValue: 'thing'},
+      'navigation-document-type': {dimension: 34, defaultValue: 'other'},
+      'taxon-slug': {dimension: 56, defaultValue: 'other'},
+      'taxon-id': {dimension: 57, defaultValue: 'other'},
+      'taxon-slugs': {dimension: 58, defaultValue: 'other'},
+      'taxon-ids': {dimension: 59, defaultValue: 'other'}
+    };
 
-  StaticAnalytics.prototype.setPublishingGovernmentDimension = function(government) {
-    this.setDimension(6, government);
-  };
+    var $metas = $('meta[name^="govuk:"]');
+    var customDimensions = {};
+    var tags = {};
 
-  StaticAnalytics.prototype.setPoliticalStatusDimension = function(status) {
-    this.setDimension(7, status);
-  };
+    $metas.each(function () {
+      var $meta = $(this);
+      var key = $meta.attr('name').split('govuk:')[1];
 
-  StaticAnalytics.prototype.setOrganisationsDimension = function(orgs) {
-    this.setDimension(9, orgs);
-  };
+      var dimension = dimensionMappings[key];
+      if (dimension) {
+        tags[key] = $meta.attr('content');
+      }
+    });
 
-  StaticAnalytics.prototype.setWorldLocationsDimension = function(locations) {
-    this.setDimension(10, locations);
-  };
+    $.each(dimensionMappings, function (key, dimension) {
+      var value = tags[key] || dimension.defaultValue;
+      if (typeof value !== 'undefined') {
+        customDimensions['dimension' + dimension.dimension] = value;
+      }
+    });
 
-  StaticAnalytics.prototype.setRenderingApplicationDimension = function(app) {
-    this.setDimension(20, app);
-  };
+    return customDimensions;
+  }
 
-  StaticAnalytics.prototype.setSearchPositionDimension = function(position) {
-    this.setDimension(21, position);
-  };
+  function customDimensionsFromDom() {
+    return {
+      dimension26: totalNumberOfSections(),
+      dimension27: totalNumberOfSectionLinks()
+    };
 
-  StaticAnalytics.prototype.setSchemaNameDimension = function(position) {
-    this.setDimension(17, position);
-  };
+    function totalNumberOfSections() {
+      var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
+      var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
+      var accordionSubsections = $('[data-track-count="accordionSection"]').length;
+      var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
+      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections;
+    }
 
-  StaticAnalytics.prototype.setTotalNumberOfSections = function() {
-    var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
-    var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
-    var accordionSubsections = $('[data-track-count="accordionSection"]').length;
-    var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
-    var totalNumberOfSections = sidebarSections || sidebarTaxons || accordionSubsections || gridSections;
-    this.setDimension(26, totalNumberOfSections);
-  };
+    function totalNumberOfSectionLinks() {
+      var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
+      var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
+      // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
+      var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
+        + $('a[data-track-category="navGridLeafLinkClicked"]').length;
+      var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
+      return relatedLinks || accordionLinks || gridLinks || leafLinks;
+    }
+  }
 
-  StaticAnalytics.prototype.setTotalNumberOfSectionLinks = function() {
-    var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
-    var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
-    // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
-    var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
-      + $('a[data-track-category="navGridLeafLinkClicked"]').length;
-    var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
-    var totalNumberOfSectionLinks = relatedLinks || accordionLinks || gridLinks || leafLinks;
-    this.setDimension(27, totalNumberOfSectionLinks);
-  };
+  function abTestCustomDimensions() {
+    // This is the block of dimensions assigned to A/B tests
+    var minAbTestDimension = 40;
+    var maxAbTestDimension = 49;
+    var $abMetas = $('meta[name^="govuk:ab-test"]');
+    var customDimensions = {};
 
-  StaticAnalytics.prototype.setNavigationPageTypeDimension = function(pageType) {
-    this.setDimension(32, pageType || 'none');
-  };
+    $abMetas.each(function () {
+      var $meta = $(this);
+      var dimension = parseInt($meta.data('analytics-dimension'));
+      var testNameAndBucket = $meta.attr('content');
 
-  StaticAnalytics.prototype.setUserJourneyStage = function(journeyStage) {
-    // Track the stage of a user's journey through GOV.UK. If the page does not
-    // set a page type in a meta tag, default to "thing", which identifes a page
-    // as containing content rather than some kind of navigation.
-    this.setDimension(33, journeyStage || "thing");
-  };
+      if (dimension >= minAbTestDimension && dimension <= maxAbTestDimension) {
+        customDimensions['dimension' + dimension] = testNameAndBucket;
+      }
+    });
 
-  StaticAnalytics.prototype.setNavigationDocumentTypeDimension = function(documentType) {
-    this.setDimension(34, documentType || "other");
-  };
-
-  StaticAnalytics.prototype.setTaxonSlugDimension = function(taxonSlug) {
-    this.setDimension(56, taxonSlug || "other");
-  };
-
-  StaticAnalytics.prototype.setTaxonIdDimension = function(taxonId) {
-    this.setDimension(57, taxonId || "other");
-  };
-
-  StaticAnalytics.prototype.setTaxonSlugsDimension = function(taxonSlugs) {
-    this.setDimension(58, taxonSlugs || "other");
-  };
-
-  StaticAnalytics.prototype.setTaxonIdsDimension = function (taxonIds) {
-    this.setDimension(59, taxonIds || "other");
-  };
+    return customDimensions;
+  }
 
   GOVUK.StaticAnalytics = StaticAnalytics;
 })();

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,12 +14,14 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const expectedDefaultArgumentCount = 16;
+    const numberOfDimensionsWithDefaultValues = 14;
 
     var universalSetupArguments;
+    var pageViewObject;
 
     beforeEach(function() {
       universalSetupArguments = window.ga.calls.allArgs();
+      pageViewObject = universalSetupArguments[2][2];
     });
 
     it('configures a universal tracker', function() {
@@ -27,15 +29,16 @@ describe("GOVUK.StaticAnalytics", function() {
     });
 
     it('sets the device pixel ratio', function() {
-      expect(universalSetupArguments[2][1]).toEqual('dimension11');
+      expect(Object.keys(pageViewObject)).toContain('dimension11');
     });
 
     it('sets the HTTP status code', function() {
-      expect(universalSetupArguments[3][1]).toEqual('dimension15');
+      expect(Object.keys(pageViewObject)).toContain('dimension15');
     });
 
     it('tracks a pageview in universal', function() {
-      expect(universalSetupArguments[expectedDefaultArgumentCount]).toEqual(['send', 'pageview']);
+      expect(universalSetupArguments[2][0]).toEqual('send');
+      expect(universalSetupArguments[2][1]).toEqual('pageview');
     });
 
     it('begins print tracking', function() {
@@ -68,26 +71,26 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        setupArguments = dimensionSetupArguments();
+        pageViewObject = window.ga.calls.allArgs()[2][2];
 
-        expect(setupArguments[0]).toEqual(['set', 'dimension1', 'section']);
-        expect(setupArguments[1]).toEqual(['set', 'dimension2', 'format']);
-        expect(setupArguments[2]).toEqual(['set', 'dimension5', '1000']);
-        expect(setupArguments[3]).toEqual(['set', 'dimension6', '2005-to-2010-labour-government']);
-        expect(setupArguments[4]).toEqual(['set', 'dimension7', 'historic']);
-        expect(setupArguments[5]).toEqual(['set', 'dimension9', '<D10>']);
-        expect(setupArguments[6]).toEqual(['set', 'dimension10', '<W1>']);
-        expect(setupArguments[7]).toEqual(['set', 'dimension17', 'schema-name']);
+        expect(pageViewObject.dimension1).toEqual('section');
+        expect(pageViewObject.dimension2).toEqual('format');
+        expect(pageViewObject.dimension5).toEqual('1000');
+        expect(pageViewObject.dimension6).toEqual('2005-to-2010-labour-government');
+        expect(pageViewObject.dimension7).toEqual('historic');
+        expect(pageViewObject.dimension9).toEqual('<D10>');
+        expect(pageViewObject.dimension10).toEqual('<W1>');
+        expect(pageViewObject.dimension17).toEqual('schema-name');
       });
 
       it('ignores meta tags not set', function() {
         $('head').append('<meta name="govuk:section" content="section">');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        setupArguments = dimensionSetupArguments();
+        pageViewObject = getPageViewObject();
 
-        expect(setupArguments.length).toEqual(1);
-        expect(setupArguments[0]).toEqual(['set', 'dimension1', 'section']);
+        expect(Object.keys(pageViewObject).length).toEqual(1 + numberOfDimensionsWithDefaultValues);
+        expect(pageViewObject.dimension1).toEqual('section');
       });
 
       it('sets A/B meta tags as dimensions', function() {
@@ -97,10 +100,10 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        setupArguments = dimensionSetupArguments();
+        pageViewObject = getPageViewObject();
 
-        expect(setupArguments[0]).toEqual(['set', 'dimension42', 'name-of-test:name-of-ab-bucket']);
-        expect(setupArguments[1]).toEqual(['set', 'dimension48', 'name-of-other-test:name-of-other-ab-bucket']);
+        expect(pageViewObject.dimension42).toEqual('name-of-test:name-of-ab-bucket');
+        expect(pageViewObject.dimension48).toEqual('name-of-other-test:name-of-other-ab-bucket');
       });
 
       it('ignores dimensions outside of the A/B test range', function () {
@@ -112,11 +115,11 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        setupArguments = dimensionSetupArguments();
+        pageViewObject = getPageViewObject();
 
-        expect(setupArguments.length).toEqual(2);
-        expect(setupArguments[0]).toEqual(['set', 'dimension40', 'name-of-valid-test:some-bucket']);
-        expect(setupArguments[1]).toEqual(['set', 'dimension49', 'name-of-other-valid-test:some-bucket']);
+        expect(Object.keys(pageViewObject).length).toEqual(2 + numberOfDimensionsWithDefaultValues);
+        expect(pageViewObject.dimension40).toEqual('name-of-valid-test:some-bucket');
+        expect(pageViewObject.dimension49).toEqual('name-of-other-valid-test:some-bucket');
       });
 
       it('ignores A/B meta tags with invalid dimensions', function () {
@@ -126,65 +129,56 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        setupArguments = dimensionSetupArguments();
+        pageViewObject = getPageViewObject();
 
-        expect(setupArguments.length).toEqual(0);
+        expect(Object.keys(pageViewObject).length).toEqual(numberOfDimensionsWithDefaultValues);
       });
 
       [
         {
           name: 'themes',
           number: 3,
-          defaultValue: 'other',
-          setupArgumentsIndex: 5
+          defaultValue: 'other'
         },
         {
           name: 'navigation-page-type',
           number: 32,
-          defaultValue: 'none',
-          setupArgumentsIndex: 6
+          defaultValue: 'none'
         },
         {
           name: 'user-journey-stage',
           number: 33,
-          defaultValue: 'thing',
-          setupArgumentsIndex: 7
+          defaultValue: 'thing'
         },
         {
           name: 'navigation-document-type',
           number: 34,
-          defaultValue: 'other',
-          setupArgumentsIndex: 8
+          defaultValue: 'other'
         },
         {
           name: 'content-id',
           number: 4,
-          defaultValue: '00000000-0000-0000-0000-000000000000',
-          setupArgumentsIndex: 9
+          defaultValue: '00000000-0000-0000-0000-000000000000'
         },
         {
           name: 'taxon-slug',
           number: 56,
-          defaultValue: 'other',
-          setupArgumentsIndex: 10
+          defaultValue: 'other'
         },
         {
           name: 'taxon-id',
           number: 57,
-          defaultValue: 'other',
-          setupArgumentsIndex: 11
+          defaultValue: 'other'
         },
         {
           name: 'taxon-slugs',
           number: 58,
-          defaultValue: 'other',
-          setupArgumentsIndex: 12
+          defaultValue: 'other'
         },
         {
           name: 'taxon-ids',
           number: 59,
-          defaultValue: 'other',
-          setupArgumentsIndex: 13
+          defaultValue: 'other'
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {
@@ -193,18 +187,16 @@ describe("GOVUK.StaticAnalytics", function() {
         ');
 
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-          setupArguments = window.ga.calls.allArgs();
+          pageViewObject = getPageViewObject();
 
-          expect(setupArguments[dimension.setupArgumentsIndex])
-            .toEqual(['set', 'dimension' + dimension.number, 'some-' + dimension.name + '-value']);
+          expect(pageViewObject['dimension' + dimension.number]).toEqual('some-' + dimension.name + '-value');
         });
 
         it('sets the default dimension if no ' + dimension.name + ' meta tag is present', function () {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-          setupArguments = window.ga.calls.allArgs();
+          pageViewObject = getPageViewObject();
 
-          expect(setupArguments[dimension.setupArgumentsIndex])
-            .toEqual(['set', 'dimension' + dimension.number, dimension.defaultValue]);
+          expect(pageViewObject['dimension' + dimension.number]).toEqual(dimension.defaultValue);
         });
       });
 
@@ -250,16 +242,14 @@ describe("GOVUK.StaticAnalytics", function() {
 
           it('tracks the number of sidebar sections', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[14])
-              .toEqual(['set', 'dimension26', '2']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension26).toEqual('2');
           });
 
           it('tracks the total number of related links', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[15])
-              .toEqual(['set', 'dimension27', '3']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension27).toEqual('3');
           });
         });
 
@@ -308,16 +298,14 @@ describe("GOVUK.StaticAnalytics", function() {
 
           it('tracks the number of sidebar sections', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[14])
-              .toEqual(['set', 'dimension26', '2']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension26).toEqual('2');
           });
 
           it('tracks the total number of related links, including headers', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[15])
-              .toEqual(['set', 'dimension27', '5']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension27).toEqual('5');
           });
         });
 
@@ -372,16 +360,14 @@ describe("GOVUK.StaticAnalytics", function() {
 
           it('tracks the number of accordion sections', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[14])
-              .toEqual(['set', 'dimension26', '2']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension26).toEqual('2');
           });
 
           it('tracks the total number of accordion section links', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[15])
-              .toEqual(['set', 'dimension27', '3']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension27).toEqual('3');
           });
         });
 
@@ -439,16 +425,14 @@ describe("GOVUK.StaticAnalytics", function() {
 
           it('does tracks sections equal to the number of grid links', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[14])
-              .toEqual(['set', 'dimension26', '3']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension26).toEqual('3');
           });
 
           it('tracks the total number of grid links and leaf links', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-            setupArguments = window.ga.calls.allArgs();
-            expect(setupArguments[15])
-              .toEqual(['set', 'dimension27', '5']);
+            pageViewObject = getPageViewObject();
+            expect(pageViewObject.dimension27).toEqual('5');
           });
         });
       });
@@ -485,61 +469,61 @@ describe("GOVUK.StaticAnalytics", function() {
 
         it('does not track any sections', function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-          setupArguments = window.ga.calls.allArgs();
-          expect(setupArguments[14])
-            .toEqual(['set', 'dimension26', '0']);
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('0');
         });
 
         it('tracks the total number of leaf links', function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-          setupArguments = window.ga.calls.allArgs();
-          expect(setupArguments[15])
-            .toEqual(['set', 'dimension27', '2']);
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('2');
         });
       });
-
-      function dimensionSetupArguments() {
-        // Remove the default calls to the analytics object
-        return window.ga.calls.allArgs().slice(expectedDefaultArgumentCount, -1);
-      }
     });
   });
 
   describe('when there is a TLSversion cookie', function() {
+    var pageViewObject;
+
     beforeEach(function() {
       GOVUK.cookie('TLSversion', '2');
       window.ga.calls.reset();
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-      universalSetupArguments = window.ga.calls.allArgs();
+      pageViewObject = getPageViewObject();
     });
+
     it("sets the cookie value as the value of the tls version custom dimension", function() {
-      expect(universalSetupArguments[4]).toEqual(['set', 'dimension16', '2']);
+      expect(pageViewObject.dimension16).toEqual('2');
     });
   });
 
   describe('when there is no TLSversion cookie', function() {
+    var pageViewObject;
+
     beforeEach(function() {
       GOVUK.cookie('TLSversion', null);
       window.ga.calls.reset();
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-      universalSetupArguments = window.ga.calls.allArgs();
+      pageViewObject = getPageViewObject();
     });
+
     it("sets unknown as the value of the tls version custom dimension", function() {
-      expect(universalSetupArguments[4]).toEqual(['set', 'dimension16', 'unknown']);
+      expect(pageViewObject.dimension16).toEqual('unknown');
     });
   });
 
-  describe('when tracking pageviews, events and custom dimensions', function() {
+  describe('when tracking pageviews and events', function() {
     it('tracks them in universal', function() {
 
       analytics.trackPageview('/path', 'Title');
-      expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', {page: '/path', title: 'Title'}]);
+      trackingArguments = window.ga.calls.mostRecent().args;
+      expect(trackingArguments[0]).toEqual('send');
+      expect(trackingArguments[1]).toEqual('pageview');
+      expect(trackingArguments[2].page).toEqual('/path');
+      expect(trackingArguments[2].title).toEqual('Title');
 
       analytics.trackEvent('category', 'action');
       expect(window.ga.calls.mostRecent().args).toEqual(['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action'}]);
-
-      analytics.setSectionDimension('value');
-      expect(window.ga.calls.mostRecent().args).toEqual(['set', 'dimension1', 'value']);
     });
   });
 
@@ -603,4 +587,8 @@ describe("GOVUK.StaticAnalytics", function() {
       expect(analytics.trackPageview).toHaveBeenCalledWith('/path', 'Title');
     });
   });
+
+  function getPageViewObject() {
+    return window.ga.calls.allArgs()[2][2];
+  }
 });


### PR DESCRIPTION
We’re seeing some weird behaviour on our Google Analytics tracking:
- Some pages appear to have a very high (10-100) repeat visit rate
  within a single (half hour) session
- Dimensions that rely on the DOM having loaded also are reporting 0
  count sometimes.

Noteably, when the count *is* reported correctly, the repeat visit
rate also appears to drop back to “normal levels” (~2).

This could be because of setting custom dimensions at the “session”
level, rather than passing them directly into the page view tracking,
but this is hard to test because we cannot reproduce the bug on our
machines.

In order to debug, we’re attempting to pass custom dimensions
directly to the page view tracking.

### Trello

https://trello.com/c/irHlKtYL/50-review-number-of-links-sections-tracking