### PR TITLE
Add flag to disable youtube expansion

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -40,6 +40,7 @@
     }
 
     function enhanceYoutubeVideoLinks($el) {
+      if ($($el).hasClass('disable-youtube')) return ;
       $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function (i){
 
         var $link = $(this);

--- a/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
+++ b/app/assets/javascripts/govuk-component/govspeak-enhance-youtube-video-links.js
@@ -40,7 +40,6 @@
     }
 
     function enhanceYoutubeVideoLinks($el) {
-      if ($($el).hasClass('disable-youtube')) return ;
       $el.find("a[href*='youtube.com'], a[href*='youtu.be']").each(function (i){
 
         var $link = $(this);
@@ -74,6 +73,6 @@
   }
 
   GOVUK.enhanceYoutubeVideoLinks = new GovspeakYoutubeVideoLinks();
-  GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+  GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak:not(.disable-youtube)'));
 
 })(jQuery);

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -263,6 +263,11 @@ fixtures:
     content: |
       <p>This content has a YouTube video link, converted to an accessible embedded player by component JavaScript.</p>
       <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
+  with_youtube_embed_disabled:
+    disable_youtube_expansions: true
+    content: |
+      <p>This content has a YouTube video link, where the govspeak expansion has been disabled</p>
+      <p><a href="https://www.youtube.com/watch?v=y6hbrS3DheU">Operations: a developer's guide, by Anna Shipman</a></p>
   statistic_headlines:
     content: |
       <aside class="stat-headline">

--- a/app/views/govuk_component/govspeak.raw.html.erb
+++ b/app/views/govuk_component/govspeak.raw.html.erb
@@ -1,11 +1,14 @@
 <%
-  direction_class = ""
-  direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
-%>
-<%
-  rich_govspeak = false
+  direction_class = "direction-#{direction}" if local_assigns.include?(:direction)
   rich_govspeak = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+  disable_youtube_expansions = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
+
+  classes = []
+  classes << direction_class if direction_class
+  classes << "rich-govspeak" if rich_govspeak
+  classes << "disable-youtube" if disable_youtube_expansions
 %>
-<div class="govuk-govspeak<%= direction_class %><%= ' rich-govspeak' if rich_govspeak %>">
+
+<div class="govuk-govspeak <%= classes.join(" ") %>">
   <%= raw content %>
 </div>

--- a/app/views/govuk_component/govspeak_html_publication.raw.html.erb
+++ b/app/views/govuk_component/govspeak_html_publication.raw.html.erb
@@ -2,7 +2,9 @@
   govspeak_locals = { content: content }
   govspeak_locals[:direction] = local_assigns.fetch(:direction) if local_assigns.include?(:direction)
   govspeak_locals[:rich_govspeak] = local_assigns.fetch(:rich_govspeak) if local_assigns.include?(:rich_govspeak)
+  govspeak_locals[:disable_youtube_expansions] = local_assigns.fetch(:disable_youtube_expansions) if local_assigns.include?(:disable_youtube_expansions)
   sticky_footer_html = local_assigns.fetch(:sticky_footer_html) if local_assigns.include?(:sticky_footer_html)
+
   direction_class = ""
   direction_class = " direction-#{govspeak_locals[:direction]}" if govspeak_locals[:direction]
 %>

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
@@ -64,7 +64,7 @@ describe('Links to YouTube in govspeak content', function () {
     });
   });
 
-  describe('- An external link to YouTube disabled at component', function () {
+  describe('- Link expansion disabled when disable-youtube class provided on parent', function () {
 
     beforeEach(function() {
 
@@ -75,7 +75,7 @@ describe('Links to YouTube in govspeak content', function () {
                                               '</div>');
 
       $('body').append($turnOffEnhanceYoutubeVideoLinksHTML);
-      GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+      GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak:not(.disable-youtube)'));
     });
 
     afterEach(function() {

--- a/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
+++ b/spec/javascripts/govuk-component/govspeak-enhance-youtube-video-links-spec.js
@@ -62,7 +62,30 @@ describe('Links to YouTube in govspeak content', function () {
     it("is not converted to an embedded player", function () {
       expect($('.media-player')).not.toHaveLength(1);
     });
+  });
 
+  describe('- An external link to YouTube disabled at component', function () {
+
+    beforeEach(function() {
+
+      $turnOffEnhanceYoutubeVideoLinksHTML = $('<div class="govuk-govspeak disable-youtube">'+
+                                                '<a href="https://youtu.be/OzjogCFO4Zo">'+
+                                                  'This link to YouTube'+
+                                                '</a>'+
+                                              '</div>');
+
+      $('body').append($turnOffEnhanceYoutubeVideoLinksHTML);
+      GOVUK.enhanceYoutubeVideoLinks.enhanceYoutubeVideoLinks($('.govuk-govspeak'));
+    });
+
+    afterEach(function() {
+      $turnOffEnhanceYoutubeVideoLinksHTML.remove();
+      $('.media-player').remove();
+    });
+
+    it("is not converted to an embedded player", function () {
+      expect($('.media-player')).not.toHaveLength(1);
+    });
   });
 
 });

--- a/test/govuk_component/govspeak_test.rb
+++ b/test/govuk_component/govspeak_test.rb
@@ -18,6 +18,15 @@ class GovspeakTestCase < ComponentTestCase
     assert_select ".direction-rtl h2", text: 'right to left'
   end
 
+  test "can disable youtube expansion" do
+    render_component({
+      disable_youtube_expansions: true,
+      content: "<h2>youtube</h2>"
+    })
+
+    assert_select ".disable-youtube h2", text: "youtube"
+  end
+
   test "can enable rich govspeak" do
     render_component({
       rich_govspeak: true,
@@ -25,4 +34,6 @@ class GovspeakTestCase < ComponentTestCase
 
     assert_select ".rich-govspeak strong", text: 'boldly go'
   end
+
+
 end

--- a/test/govuk_component/govspeak_test.rb
+++ b/test/govuk_component/govspeak_test.rb
@@ -6,34 +6,36 @@ class GovspeakTestCase < ComponentTestCase
   end
 
   test "renders content in a govspeak wrapper" do
-    render_component({content: '<h1>content</h1>'})
+    render_component(
+      content: '<h1>content</h1>'
+    )
     assert_select ".govuk-govspeak h1", text: 'content'
   end
 
   test "renders right to left content correctly" do
-    render_component({
+    render_component(
       direction: "rtl",
-      content: "<h2>right to left</h2>"})
+      content: "<h2>right to left</h2>"
+    )
 
     assert_select ".direction-rtl h2", text: 'right to left'
   end
 
   test "can disable youtube expansion" do
-    render_component({
+    render_component(
       disable_youtube_expansions: true,
       content: "<h2>youtube</h2>"
-    })
+    )
 
     assert_select ".disable-youtube h2", text: "youtube"
   end
 
   test "can enable rich govspeak" do
-    render_component({
+    render_component(
       rich_govspeak: true,
-      content: "<strong>boldly go</strong>"})
+      content: "<strong>boldly go</strong>"
+    )
 
     assert_select ".rich-govspeak strong", text: 'boldly go'
   end
-
-
 end


### PR DESCRIPTION
this disables youtube expansion on a flag, this is needed for mainstream content
to work correctly in government-frontend as it is being migrated over by
template consolidation