### PR TITLE
Allow for a description in related link sections

### DIFF
--- a/app/assets/stylesheets/govuk-component/_related-items.scss
+++ b/app/assets/stylesheets/govuk-component/_related-items.scss
@@ -8,6 +8,10 @@
     margin-bottom: 0.5em;
   }
 
+  .description {
+    @include core-16;
+  }
+
   ul {
     // reset the default browser styles
     padding: 0;

--- a/app/views/govuk_component/related_items.raw.html.erb
+++ b/app/views/govuk_component/related_items.raw.html.erb
@@ -13,6 +13,13 @@
       >
         <%= section[:title] %>
       </h2>
+
+      <% if section[:description].present? %>
+        <p class='description'>
+          <%= section[:description] %>
+        </p>
+      <% end %>
+
       <nav role="navigation" <% if section[:id] %>aria-labelledby="<%= section[:id] %>"<% end %>>
         <ul>
           <% total_links_in_section = section[:items].length + (section[:url] ? 1 : 0)  %>


### PR DESCRIPTION
This change is required so we can display the new Register to Vote
section in the related links sidebar. Because there needs to be a
description in there, we need to make sure we add it to the section,
when available.

Trello: https://trello.com/c/QbnidEBA/97-add-promotion-for-register-to-vote-to-transaction-done-pages

Waiting on product/design feedback before this should be merged. This needs data from `govuk_navigation_helpers` in order to display the description. The PR is here: https://github.com/alphagov/govuk_navigation_helpers/pull/76

It currently looks like this:

<img width="1039" alt="screen shot 2017-05-04 at 17 16 36" src="https://cloud.githubusercontent.com/assets/416701/25713684/7694b7e0-30ed-11e7-88b3-310ea1c4d22c.png">
