### PR TITLE
Add data attributes to track history link events

### DIFF
--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -40,7 +40,12 @@
     <% if history.any? %>
       <div class="change-notes" data-module="toggle">
         <p>
-          <a href="#full-history" data-controls="full-history" data-expanded="false">
+          <a href="#full-history" data-controls="full-history"
+                                  data-expanded="false"
+                                  data-module="track-click"
+                                  data-track-category="content-history"
+                                  data-track-action="full-page-history-toggled"
+                                  data-track-label="full-history">
             + <%= t("govuk_component.document_footer.full_page_history", default: "full page history") %>
           </a>
         </p>

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -32,7 +32,10 @@
       <dt><%= t("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
       <dd>
         <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>,
-          <a href="#history">
+          <a href="#history" data-module="track-click"
+                             data-track-category="content-history"
+                             data-track-action="see-all-updates-link-clicked"
+                             data-track-label="history">
             <%= t("govuk_component.metadata.see_all_updates", default: "see all updates") %>
           </a>
         <% end %>


### PR DESCRIPTION
https://trello.com/c/AmrwFMJU/22-implement-ga-event-tracking-on-content-history-see-all-updates-and-full-page-history-links

We'd like to understand how users interact with the page history
and updates links on a page, so add the data attributes which
enable tracking and provide the appropriate tracking options

cc @fofr 