### PR TITLE
Add border to info-notice when printing

### DIFF
--- a/app/assets/stylesheets/govuk-component/_govspeak-print.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-print.scss
@@ -3,6 +3,7 @@
     display: none;
   }
 
+  .info-notice,
   .help-notice,
   .call-to-action {
     margin: $gutter-half 0;


### PR DESCRIPTION
* Match print styles for other callouts
* Matches frontend’s print styles for information notices

# Screen styles
![screen shot 2017-05-08 at 14 59 14](https://cloud.githubusercontent.com/assets/319055/25807520/01e0e29c-33ff-11e7-83f7-e36307814fe7.png)

# Print styles
![screen shot 2017-05-08 at 14 59 05](https://cloud.githubusercontent.com/assets/319055/25807523/03510616-33ff-11e7-92a1-bcafd8b7018e.png)
