### PR TITLE
Add Navigation Tracking Metatags shim

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -81,3 +81,5 @@
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">
 <% end %>
+
+<%= yield :analytics_meta_tags %>

--- a/app/views/govuk_component/analytics_meta_tags_navigation.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags_navigation.raw.html.erb
@@ -1,0 +1,9 @@
+<%
+  number_of_sections ||= 0
+  number_of_links ||= 0
+%>
+
+<% content_for :analytics_meta_tags do %>
+  <meta name="govuk:navigation-sections" content="<%= number_of_sections %>">
+  <meta name="govuk:navigation-links" content="<%= number_of_links %>">
+<% end %>

--- a/app/views/govuk_component/docs/analytics_meta_tags_navigation.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags_navigation.yml
@@ -1,0 +1,10 @@
+name: Analytics Meta Tags
+description: Meta tags to provide analytics information about the current page
+body: |
+  A component that appends counts for navigation elements to the analytics_meta_tags component.
+
+  The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
+fixtures:
+  default:
+    number_of_sections: 2
+    number_of_links: 6

--- a/test/govuk_component/analytics_meta_tags_navigation_test.rb
+++ b/test/govuk_component/analytics_meta_tags_navigation_test.rb
@@ -1,0 +1,13 @@
+require 'govuk_component_test_helper'
+
+class AnalyticsMetaTagsNavigationTestCase < ComponentTestCase
+  def component_name
+    "analytics_meta_tags_navigation"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+    end
+  end
+end

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -19,7 +19,7 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   end
 
   test "no meta tags are rendered when there's no trackable data" do
-    assert_empty render_component(content_item: {})
+    assert_empty render_component(content_item: {}).strip
   end
 
   test "renders format in a meta tag" do
@@ -85,8 +85,8 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
   end
 
   test "does not render publishing government or political status when political or government is missing" do
-    assert_empty render_component(content_item: { details: { government: { current: true, slug: 'government' } } })
-    assert_empty render_component(content_item: { details: { political: true } })
+    assert_empty render_component(content_item: { details: { government: { current: true, slug: 'government' } } }).strip
+    assert_empty render_component(content_item: { details: { political: true } }).strip
   end
 
   test "renders user journey stage when user journey supertype is included" do


### PR DESCRIPTION
In order to remove the navigation analytics meta tags, we need to do
two stages:

1. Remove all references to the meta tags (ie in taxonomy sidebar
   and related items)
2. Remove the component itself

This is because Static/Slimmer will have a cached set of sidebar
components that will continue trying to use the old meta tags. Hence
we need to leave the meta tags in place, and then remove them after
the cache has cleared.