### PR TITLE
Track navigation sections and links on browse pages

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -227,7 +227,9 @@
       var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
       var accordionSubsections = $('[data-track-count="accordionSection"]').length;
       var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
-      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections;
+      var browsePageSections = $('#subsection ul:visible').length ||
+        $('#section ul').length;
+      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections || browsePageSections;
     }
 
     function totalNumberOfSectionLinks() {
@@ -237,7 +239,9 @@
       var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
         + $('a[data-track-category="navGridLeafLinkClicked"]').length;
       var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
-      return relatedLinks || accordionLinks || gridLinks || leafLinks;
+      var browsePageLinks = $('#subsection ul a:visible').length ||
+        $('#section ul a').length;
+      return relatedLinks || accordionLinks || gridLinks || leafLinks || browsePageLinks;
     }
   }
 


### PR DESCRIPTION
In order to compare with the new taxonomy navigation pages, we are
adding similar tracking for the browse pages, where a “section” is a
demarcated list of links.

## Dependencies

- [x] https://github.com/alphagov/collections/pull/336

## Trello

https://trello.com/c/eiosXmG5/102-add-navigation-link-tracking-to-browse