### PR TITLE
Allow bundling with local govuk_frontend_toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,12 @@ group :development, :test do
 end
 
 gem 'plek', '1.11.0'
-gem 'govuk_frontend_toolkit', '~> 6.0.3'
+
+if ENV['GOVUK_FRONTEND_TOOLKIT_DEV']
+  gem 'govuk_frontend_toolkit', path: "./tmp/govuk_frontend_toolkit_gem_dev"
+else
+  gem 'govuk_frontend_toolkit', '~> 6.0.3'
+end
 
 if ENV['GOVUK_TEMPLATE_DEV']
   gem 'govuk_template', path: "../govuk_template"

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ are wrapped around feedback pages, run `bowl feedback
 in a separate terminal. Following local edits to `static`, restarting just
 `feedback` should be sufficient.
 
+#### Testing a local version of govuk_frontend_toolkit
+To test any local updates to [govuk_frontend_toolkit](https://github.com/alphagov/govuk_frontend_toolkit) you can use `./startup.sh --test-govuk-frontend-toolkit`
+
 ### Running the test suite
 
 `bundle exec rake` runs the test suite.

--- a/startup.sh
+++ b/startup.sh
@@ -11,6 +11,7 @@ if [[ $1 == "--test-govuk-frontend-toolkit" ]] ; then
   rm -rf ${temporary_location}
 
   # Copy the old assets aside
+  # Using sudo here since the installed location has elevated permissions
   sudo cp -r ${installed_location} ${temporary_location}
 
   # Remove current submoduled assets

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,29 @@
-#!/bin/bash 
+#!/bin/bash
 
 bundle install
+
+if [[ $1 == "--test-govuk-frontend-toolkit" ]] ; then
+  # Find out where it the gem is installed
+  installed_location="$(bundle show govuk_frontend_toolkit)"
+  temporary_location="./tmp/govuk_frontend_toolkit_gem_dev"
+
+  # Remove any existing tmp file
+  rm -rf ${temporary_location}
+
+  # Copy the old assets aside
+  sudo cp -r ${installed_location} ${temporary_location}
+
+  # Remove current submoduled assets
+  rm -rf ${temporary_location}/app/assets
+
+  # Symlink the local
+  sudo ln -rs ../govuk_frontend_toolkit ${temporary_location}/app/assets
+
+  export GOVUK_FRONTEND_TOOLKIT_DEV=true
+
+  bundle install
+
+  echo "Testing local govuk_frontend_toolkit"
+fi
+
 bundle exec rails s -p 3013


### PR DESCRIPTION
Due to the way the toolkit is distributed we need to do some tomfoolery to get the local version in static, this makes it easy.