### PR TITLE
Extract surveys.js as a separate JS bundle

### DIFF
--- a/app/assets/javascripts/core.js
+++ b/app/assets/javascripts/core.js
@@ -7,11 +7,11 @@ $(document).ready(function() {
       $(el).addClass('focus');
     }
   });
-  
+
   $searchFocus.on('focus', function(e) {
     $(e.target).addClass('focus');
   });
-  
+
   $searchFocus.on('blur', function(e) {
     if($(e.target).val() === '') {
       $(e.target).removeClass('focus');
@@ -19,10 +19,6 @@ $(document).ready(function() {
   });
 
   if (window.GOVUK) {
-    if (GOVUK.userSurveys) {
-      GOVUK.userSurveys.init();
-    }
-
     // for radio buttons and checkboxes
     var buttonsSelector = "label.selectable input[type='radio'], label.selectable input[type='checkbox']";
     new GOVUK.SelectionButtons(buttonsSelector);

--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -2,7 +2,6 @@
 //= require vendor/polyfills/bind
 //= require analytics
 //= require start-modules
-//= require surveys
 //= require core
 //= require report-a-problem-form
 //= require report-a-problem

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -1,9 +1,8 @@
-(function() {
-  "use strict";
+//= require_self
 
-  var root = this,
-      $ = root.jQuery;
-  if(typeof root.GOVUK === 'undefined') { root.GOVUK = {}; }
+(function($) {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
 
   var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
@@ -287,6 +286,12 @@
     currentPath: function() { return window.location.pathname; }
   };
 
-  root.GOVUK.userSurveys = userSurveys;
-}).call(this);
+  GOVUK.userSurveys = userSurveys;
+
+  $(document).ready(function() {
+    if (GOVUK.userSurveys) {
+      GOVUK.userSurveys.init();
+    }
+  });
+})(jQuery);
 

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,2 +1,3 @@
 <%= javascript_include_tag 'libs/jquery/jquery-1.11.3.js' %>
 <%= javascript_include_tag local_assigns[:js_file] || 'application' %>
+<%= javascript_include_tag 'surveys' %>

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -1,3 +1,4 @@
+//= require surveys
 describe("Surveys", function() {
   var surveys = GOVUK.userSurveys;
   var $block;


### PR DESCRIPTION
For: https://trello.com/c/ZEJRuWiU/151-reduce-need-to-change-static-js-when-deploying-surveys-part-2

The contents of surveys.js can change frequently as we introduce new
surveys and retire old ones.  Every time we deploy these changes the
application.js bundle gets a new digest hash and so frequent visitors
have to re-download the whole JS bundle just to get these updates to
surveys.  To avoid this we separate the surveys.js so it is required
separately and changes to it will not change the digest of the main
application.js.

The assumption here is that applications using the JS provided by
static only do so by using the layouts via slimmer and not by requesting
the application.js or header-footer-only.js files directly.  If that
is the case they will also need to be updated to also request the
surveys.js bundle.