### PR TITLE
Pass custom dimension to event and share tracking

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -80,13 +80,13 @@
   };
 
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
-    var trackingOptions = this.customDimensions();
-    $.extend(trackingOptions, options);
+    var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
   };
 
   StaticAnalytics.prototype.trackEvent = function (category, action, options) {
-    this.analytics.trackEvent(category, action, options);
+    var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
+    this.analytics.trackEvent(category, action, trackingOptions);
   };
 
   // TODO: Check for usage external to this file, and remove
@@ -99,7 +99,8 @@
   };
 
   StaticAnalytics.prototype.trackShare = function (network) {
-    this.analytics.trackShare(network);
+    var trackingOptions = this.getAndExtendDefaultTrackingOptions();
+    this.analytics.trackShare(network, trackingOptions);
   };
 
   StaticAnalytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain) {
@@ -145,7 +146,7 @@
     }
   };
 
-  StaticAnalytics.prototype.getCookie = function(cookieName) {
+  StaticAnalytics.prototype.getCookie = function (cookieName) {
     if (!GOVUK.cookie) {
       return;
     }
@@ -155,6 +156,11 @@
     } catch (error) {
       return null;
     }
+  };
+
+  StaticAnalytics.prototype.getAndExtendDefaultTrackingOptions = function (extraOptions) {
+    var trackingOptions = this.customDimensions();
+    return $.extend(trackingOptions, extraOptions);
   };
 
   function customDimensionsFromBrowser() {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -523,7 +523,14 @@ describe("GOVUK.StaticAnalytics", function() {
       expect(trackingArguments[2].title).toEqual('Title');
 
       analytics.trackEvent('category', 'action');
-      expect(window.ga.calls.mostRecent().args).toEqual(['send', {hitType: 'event', eventCategory: 'category', eventAction: 'action'}]);
+
+      var lastArguments = window.ga.calls.mostRecent().args;
+      expect(lastArguments[0]).toEqual('send');
+      
+      var trackingOptions = lastArguments[1];
+      expect(trackingOptions.hitType).toEqual('event');
+      expect(trackingOptions.eventCategory).toEqual('category');
+      expect(trackingOptions.eventAction).toEqual('action');
     });
   });
 


### PR DESCRIPTION
When we removed the session-level custom dimension setting, we did not
add these explicitly to the event or share tracking.

This change passes these options on to the `trackEvent` and `trackShare`
methods so that they are tracked as well as on `trackPageview`.