### PR TITLE
Linting to unpollute metadata pull request

### DIFF
--- a/app/assets/javascripts/modules/toggle.js
+++ b/app/assets/javascripts/modules/toggle.js
@@ -6,54 +6,53 @@
   controls. This is synonymous with ARIA attributes, which
   get added when starting.
 */
-(function(Modules) {
-  "use strict";
+(function (Modules) {
+  'use strict'
 
-  Modules.Toggle = function() {
-    this.start = function($el) {
-      var toggleSelector = '[data-controls][data-expanded]';
+  Modules.Toggle = function () {
+    this.start = function ($el) {
+      var toggleSelector = '[data-controls][data-expanded]'
 
-      $el.on('click', toggleSelector, toggle);
-      $el.find(toggleSelector).each(addAriaAttrs);
+      $el.on('click', toggleSelector, toggle)
+      $el.find(toggleSelector).each(addAriaAttrs)
 
       // Add the ARIA attributes with JavaScript
       // If the JS fails and there's no interactive elements, having
       // no aria attributes is an accurate representation.
-      function addAriaAttrs() {
-        var $toggle = $(this);
-        $toggle.attr('role', 'button');
-        $toggle.attr('aria-controls', $toggle.data('controls'));
-        $toggle.attr('aria-expanded', $toggle.data('expanded'));
+      function addAriaAttrs () {
+        var $toggle = $(this)
+        $toggle.attr('role', 'button')
+        $toggle.attr('aria-controls', $toggle.data('controls'))
+        $toggle.attr('aria-expanded', $toggle.data('expanded'))
 
-        var $targets = getTargetElements($toggle);
-        $targets.attr('aria-live', 'polite');
-        $targets.attr('role', 'region');
-        $toggle.data('$targets', $targets);
+        var $targets = getTargetElements($toggle)
+        $targets.attr('aria-live', 'polite')
+        $targets.attr('role', 'region')
+        $toggle.data('$targets', $targets)
       }
 
-      function toggle(event) {
+      function toggle (event) {
         var $toggle = $(event.target),
-            expanded = $toggle.attr('aria-expanded') === "true",
-            $targets = $toggle.data('$targets');
+          expanded = $toggle.attr('aria-expanded') === 'true',
+          $targets = $toggle.data('$targets')
 
         if (expanded) {
-          $toggle.attr('aria-expanded', false);
-          $targets.addClass('js-hidden');
+          $toggle.attr('aria-expanded', false)
+          $targets.addClass('js-hidden')
         } else {
-          $toggle.attr('aria-expanded', true);
-          $targets.removeClass('js-hidden');
+          $toggle.attr('aria-expanded', true)
+          $targets.removeClass('js-hidden')
         }
 
-        event.preventDefault();
+        event.preventDefault()
       }
 
-      function getTargetElements($toggle) {
+      function getTargetElements ($toggle) {
         var ids = $toggle.attr('aria-controls').split(' '),
-            selector = '#' + ids.join(', #');
+          selector = '#' + ids.join(', #')
 
-        return $el.find(selector);
+        return $el.find(selector)
       }
-    };
-  };
-
-})(window.GOVUK.Modules);
+    }
+  }
+})(window.GOVUK.Modules)

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,9 +1,9 @@
-//= require govuk/modules
-//= require modules/global-bar
-//= require modules/sticky-element-container
-//= require modules/toggle
-//= require modules/track-click
+// = require govuk/modules
+// = require modules/global-bar
+// = require modules/sticky-element-container
+// = require modules/toggle
+// = require modules/track-click
 
 $(document).ready(function () {
-  GOVUK.modules.start();
-});
+  GOVUK.modules.start()
+})

--- a/spec/javascripts/modules/toggle.spec.js
+++ b/spec/javascripts/modules/toggle.spec.js
@@ -1,78 +1,78 @@
-describe('A toggle module', function() {
-  "use strict";
+describe('A toggle module', function () {
+  'use strict'
 
   var toggle,
-      element;
+    element
 
-  beforeEach(function() {
-    toggle = new GOVUK.Modules.Toggle();
-  });
+  beforeEach(function () {
+    toggle = new GOVUK.Modules.Toggle()
+  })
 
-  describe('when starting', function() {
+  describe('when starting', function () {
     var element = $('\
       <div>\
         <a href="#" class="my-toggle" data-expanded="false" data-controls="target">Toggle</a>\
         <div id="target">Target</div>\
-      </div>');
+      </div>')
 
-    it('adds aria attributes to toggles', function() {
-      toggle.start(element);
-      
-      var $toggle = element.find('.my-toggle');
-      expect($toggle.attr('role')).toBe('button');
-      expect($toggle.attr('aria-expanded')).toBe('false');
-      expect($toggle.attr('aria-controls')).toBe('target');
-    });
-  });
+    it('adds aria attributes to toggles', function () {
+      toggle.start(element)
 
-  describe('when clicking a toggle', function() {
-    var element;
+      var $toggle = element.find('.my-toggle')
+      expect($toggle.attr('role')).toBe('button')
+      expect($toggle.attr('aria-expanded')).toBe('false')
+      expect($toggle.attr('aria-controls')).toBe('target')
+    })
+  })
 
-    beforeEach(function() {
+  describe('when clicking a toggle', function () {
+    var element
+
+    beforeEach(function () {
       element = $('\
         <div>\
           <a href="#" class="my-toggle" data-expanded="false" data-controls="target">Toggle</a>\
           <div id="target" class="js-hidden">Target</div>\
-        </div>');
+        </div>')
 
-      toggle.start(element);
-      element.find('.my-toggle').trigger('click');
-    });
+      toggle.start(element)
+      element.find('.my-toggle').trigger('click')
+    })
 
-    it('toggles the display of a target', function() {
-      expect(element.find('#target').is('.js-hidden')).toBe(false);
-      element.find('.my-toggle').trigger('click');
-      expect(element.find('#target').is('.js-hidden')).toBe(true);
-    });
+    it('toggles the display of a target', function () {
+      expect(element.find('#target').is('.js-hidden')).toBe(false)
+      element.find('.my-toggle').trigger('click')
+      expect(element.find('#target').is('.js-hidden')).toBe(true)
+    })
 
-    it('updates the aria-expanded attribute on the toggle', function() {
-      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('true');
+    it('updates the aria-expanded attribute on the toggle', function () {
+      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('true')
 
-      element.find('.my-toggle').trigger('click');
-      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('false');
-    });
-  });
+      element.find('.my-toggle').trigger('click')
+      expect(element.find('.my-toggle').attr('aria-expanded')).toBe('false')
+    })
+  })
 
-  describe('when clicking a toggle that controls multiple targets', function() {
-    it('toggles the display of each target', function() {
+  describe('when clicking a toggle that controls multiple targets', function () {
+    it('toggles the display of each target', function () {
       var element = $('\
         <div>\
           <a href="#" class="my-toggle" data-expanded="false" data-controls="target another-target">Toggle</a>\
           <div id="target" class="js-hidden">Target</div>\
           <div id="another-target" class="js-hidden">Another target</div>\
-        </div>');
+        </div>')
 
-      toggle.start(element);
-      expect(element.find('#target').is('.js-hidden')).toBe(true);
-      expect(element.find('#another-target').is('.js-hidden')).toBe(true);
+      toggle.start(element)
+      expect(element.find('#target').is('.js-hidden')).toBe(true)
+      expect(element.find('#another-target').is('.js-hidden')).toBe(true)
 
-      element.find('.my-toggle').trigger('click');
-      expect(element.find('#target').is('.js-hidden')).toBe(false);
-      expect(element.find('#another-target').is('.js-hidden')).toBe(false);
+      element.find('.my-toggle').trigger('click')
+      expect(element.find('#target').is('.js-hidden')).toBe(false)
+      expect(element.find('#another-target').is('.js-hidden')).toBe(false)
 
-      element.find('.my-toggle').trigger('click');
-      expect(element.find('#target').is('.js-hidden')).toBe(true);
-      expect(element.find('#another-target').is('.js-hidden')).toBe(true);
-    });
-  });
-});
+      element.find('.my-toggle').trigger('click')
+      expect(element.find('#target').is('.js-hidden')).toBe(true)
+      expect(element.find('#another-target').is('.js-hidden')).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
* Changes in metadata expand/collapse PR had included linting, making reading the changes difficult. This commit contains all of the linting and none of the changes, so should make that PR more readable once merged