### PR TITLE
Make steps not images and accessible via css

### DIFF
--- a/app/assets/stylesheets/govuk-component/govspeak/_steps.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_steps.scss
@@ -9,15 +9,27 @@
     list-style-type: decimal;
     margin-left: 0;
     padding: 0.75em 0 0.75em 2.2em;
+    position: relative;
+
+    &:before {
+      position: absolute;
+      left: 0;
+      margin-top: -1px;
+      height: 18px;
+      width: 18px;
+      padding: 4px;
+      border-radius: 50%;
+      background-color: $black;
+      color: $white;
+      @include core-16();
+      font-weight: bold;
+      text-align: center;
+    }
 
     @for $i from 1 through 14 {
-      &:nth-child(#{$i}) {
-        background-image: image-url("icon-steps/icon-step-#{$i}.png");
-
-        @include device-pixel-ratio() {
-          background-image: image-url("icon-steps/icon-step-#{$i}-2x.png");
-          background-size: 24px 24px;
-        }
+      &:nth-child(#{$i}):before,
+      .steps-step#{$i}:before {
+        content: "#{$i}";
       }
     }
   }


### PR DESCRIPTION
So the Initial aim was just to add some css so i could access the numbers through css
i then dicovered a few issues with them. The first was the excessive amount
of css it generated due to having two images. The next one was that the
content was in an image, so didnt scale properly or accessible in the dom.

due to the concerns of adding extra html in, i decided to use before and after
which seems to be reasonably well supported. It's an improvement over what
was there, but maybe not perfect. it seems to be supported by a lot of assistive
technology, but not maybe it all, which is an improvement over none.

### old
<img width="211" alt="screen shot 2017-05-18 at 14 23 05" src="https://cloud.githubusercontent.com/assets/248888/26204087/a265dabe-3bd5-11e7-88f1-01514814a608.png">

### new
<img width="206" alt="screen shot 2017-05-18 at 14 26 02" src="https://cloud.githubusercontent.com/assets/248888/26204263/1e1cfe6c-3bd6-11e7-9ada-9077419aaa08.png">



