### PR TITLE
Remove unused tracking code

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -28,23 +28,6 @@
     GOVUK.Analytics.load();
   };
 
-  // TODO: Remove this, and its corresponding call in collections
-  StaticAnalytics.prototype.setSectionDimension = function () {
-  };
-
-  // TODO: We're setting this at a session level, because it's called in frontend's live-search.js to update
-  // the search count. We should make this consistent with the other dimensions and pass the dimension
-  // directly into the pageview arguments.
-  StaticAnalytics.prototype.setResultCountDimension = function (count) {
-    this.setDimension(5, count);
-  };
-
-  // TODO: We're setting this at a session level, because it's used by search through callOnNextPage. We should
-  // make this consistent with the other dimensions and pass the dimension directly into the pageview arguments.
-  StaticAnalytics.prototype.setSearchPositionDimension = function (position) {
-    this.setDimension(21, position);
-  };
-
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
     var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
@@ -55,7 +38,6 @@
     this.analytics.trackEvent(category, action, trackingOptions);
   };
 
-  // TODO: Check for usage external to this file, and remove
   StaticAnalytics.prototype.setDimension = function (index, value, name, scope) {
     if (typeof value === "undefined") {
       return;

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -9,7 +9,6 @@
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
     this.analytics = new GOVUK.Analytics(config);
 
-    this.callMethodRequestedByPreviousPage();
     var trackingOptions = getOptionsFromCookie();
 
     // Track initial pageview
@@ -23,39 +22,6 @@
     GOVUK.analyticsPlugins.downloadLinkTracker({
       selector: 'a[href*="/government/uploads"], a[href*="assets.publishing.service.gov.uk"]'
     });
-  };
-
-  // TODO: Remove once we're using setOptionsForNextPageview instead
-  StaticAnalytics.prototype.callOnNextPage = function (method, params) {
-    params = params || [];
-
-    if (!$.isArray(params)) {
-      params = [params];
-    }
-
-    if (GOVUK.cookie && typeof this[method] === "function") {
-      params.unshift(method);
-      GOVUK.cookie('analytics_next_page_call', JSON.stringify(params));
-    }
-  };
-
-  // TODO: Remove once we're using setOptionsForNextPageview instead
-  StaticAnalytics.prototype.callMethodRequestedByPreviousPage = function () {
-    if (GOVUK.cookie && GOVUK.cookie('analytics_next_page_call') !== null) {
-      var params, method;
-
-      try {
-        params = JSON.parse(GOVUK.cookie('analytics_next_page_call'));
-        method = params.shift();
-      } catch (e) {
-      }
-
-      if (method && typeof this[method] === "function") {
-        this[method].apply(this, params);
-        // Delete cookie
-        GOVUK.cookie('analytics_next_page_call', null);
-      }
-    }
   };
 
   StaticAnalytics.load = function () {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -549,54 +549,6 @@ describe("GOVUK.StaticAnalytics", function() {
     });
   });
 
-  describe('when setting a method to call on a following page', function() {
-    beforeEach(function() {
-      spyOn(GOVUK, 'cookie');
-    });
-
-    describe('and the method exists', function() {
-      it('sets a cookie with the method name', function() {
-        analytics.callOnNextPage('trackPageview');
-        expect(GOVUK.cookie).toHaveBeenCalledWith('analytics_next_page_call', '["trackPageview"]');
-      });
-
-      it('sets a cookie with the parameters to call', function() {
-        analytics.callOnNextPage('trackPageview', ['/path', 'Custom Title']);
-        expect(GOVUK.cookie).toHaveBeenCalledWith('analytics_next_page_call', '["trackPageview","/path","Custom Title"]');
-      });
-
-      it('sets a cookie with the single parameter to call', function() {
-        analytics.callOnNextPage('trackPageview', '/path');
-        expect(GOVUK.cookie).toHaveBeenCalledWith('analytics_next_page_call', '["trackPageview","/path"]');
-      });
-    });
-
-    describe('and the method doesn’t exist', function() {
-      it('no cookie is set', function() {
-        analytics.callOnNextPage('trackPageviewToNowhere');
-        expect(GOVUK.cookie).not.toHaveBeenCalled();
-      });
-    });
-  });
-
-  describe('when there is a cookie indicating a method to call', function() {
-    beforeEach(function() {
-      spyOn(analytics, 'trackPageview');
-    });
-
-    it('calls the method', function() {
-      spyOn(GOVUK, 'cookie').and.returnValue('["trackPageview"]');
-      analytics.callMethodRequestedByPreviousPage();
-      expect(analytics.trackPageview).toHaveBeenCalledWith();
-    });
-
-    it('calls the method with given parameters', function() {
-      spyOn(GOVUK, 'cookie').and.returnValue('["trackPageview","/path","Title"]');
-      analytics.callMethodRequestedByPreviousPage();
-      expect(analytics.trackPageview).toHaveBeenCalledWith('/path', 'Title');
-    });
-  });
-
   describe('when setting an options object for the next pageview', function() {
     beforeEach(function() {
       analytics.setCookie('analytics_next_page_call', null);


### PR DESCRIPTION
As part of a refactor to reduce the number of public functions we expose on the `StaticAnalytics` object, we have removed now-unused public methods:

- `callOnNextPage`
- `callMethodRequestedByPreviousPage`
- `setSectionDimension`
- `setResultCountDimension`
- `setSearchPositionDimension`

Notably, we have _not_ removed `setDimension`, which is still in use by a range of applications across GDS.

### Trello

https://trello.com/c/5dIbwHvU/120-tidy-up-tracking-changes