### PR TITLE
Revert "Remove un-used print template"

### DIFF
--- a/app/assets/stylesheets/guides-print.scss
+++ b/app/assets/stylesheets/guides-print.scss
@@ -1,0 +1,27 @@
+// PRINT STYLESHEET COMPILER
+
+// STYLEGUIDE
+// Mixins to be shared across gov.uk sites. Anything set in these
+// files can be used in the view files.
+
+// is-print is used by govuk_frontend_toolkit to alter the printed font-stack
+$is-print: true;
+
+// govuk_frontend_toolkit includes
+@import "colours";
+@import "measurements";
+@import "typography";
+
+// OUTPUT
+// The following files and inline CSS will form the output of print.css
+@import "helpers/core-print";
+@import "helpers/print-base";
+
+section > header h1:after {
+  content: "";
+}
+
+#how-to-claim {
+  border: 1pt solid rgb(225,225,225);
+  padding: 2pt 4pt;
+}

--- a/app/views/root/print.html.erb
+++ b/app/views/root/print.html.erb
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="robots" content="noindex, nofollow">
+
+  <%= stylesheet_link_tag 'guides-print', media: 'all' %>
+  <script type="text/javascript">
+    window.onload = function() { window.print(); }
+  </script>
+</head>
+<body>
+  <header role="banner" class="group" id="global-header">
+    <div id="logo">
+      <img src="<%= asset_path 'gov.uk_logotype_crown_invert.png' %>" alt=""> GOV.UK
+    </div>
+  </header>
+
+  <div id="wrapper">
+    <section id="content" role="main" class="group">
+    </section>
+  </div>
+</body>
+</html>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -4,6 +4,7 @@ Rails.application.config.assets.precompile += %w{
   static.css
   static-ie*.css
   fonts*.css
+  guides-print.css
   header-footer-only*.css
   core-layout*.css
   static-print.css


### PR DESCRIPTION
The `print` template is used by travel advice publisher.

https://govuk.zendesk.com/agent/tickets/2159900

https://errbit.publishing.service.gov.uk/apps/53c7ae830da1154f2b000469/problems/5922b4476578632ab5482a00

Reverts alphagov/static#1015.