### PR TITLE
Indent report a problem toggle and form correctly

### DIFF
--- a/app/assets/stylesheets/helpers/_report-a-problem.scss
+++ b/app/assets/stylesheets/helpers/_report-a-problem.scss
@@ -2,10 +2,29 @@
   display: none;
 }
 
-.report-a-problem-container{
+.report-a-problem-container,
+.report-a-problem-toggle-wrapper {
   @extend %site-width-container;
   clear: both;
 
+  // TODO: Refactor to avoid having to extend site-width-container
+  //       The pattern should be flexible in its placement
+  // #wrapper extends `site-width-container` too, which leads to
+  // double margins on mobile viewports, reset margins when nested
+  // within #wrapper
+  #wrapper & {
+    margin-left: 0;
+    margin-right: 0;
+  }
+
+  // The homepage removes margins from wrapper
+  // Be specific to override the above margin resets
+  .homepage #wrapper & {
+    @extend %site-width-container;
+  }
+}
+
+.report-a-problem-container {
   .report-a-problem-inner {
     margin-bottom: 60px;
     .report-a-problem-content {
@@ -83,9 +102,4 @@
   @include media-down(mobile) {
     margin-top:2em;
   }
-}
-
-.report-a-problem-toggle-wrapper {
-  @extend %site-width-container;
-  clear:both;
 }


### PR DESCRIPTION
When on mobile, in some layouts the report a problem link and form get indented twice – once because of a 15px margin applied to #wrapper, and once again on report a problem itself.

* If the link is nested within wrapper, don’t indent again
* Keeps indentation if no wrapper is present

The homepage is a special case, it uses #wrapper but removes the margin

* Include site-width-container again with higher specificity for the homepage. This prevents the `0` margin resets from taking effect.

## Before
![screen shot 2017-05-23 at 13 38 21](https://cloud.githubusercontent.com/assets/319055/26354604/2ec4fec8-3fbd-11e7-82da-bd8a7d7460e0.png)

## After
![screen shot 2017-05-23 at 13 38 07](https://cloud.githubusercontent.com/assets/319055/26354603/2ec16cfe-3fbd-11e7-9bfa-3d2a6eb8ec82.png)

Previous attempt to fix: https://github.com/alphagov/static/pull/660 reverted in https://github.com/alphagov/static/pull/662

Fixes #998