### PR TITLE
Add an analytics dimension for 'govuk:content-has-history'

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -143,7 +143,8 @@
       'taxon-slug': {dimension: 56, defaultValue: 'other'},
       'taxon-id': {dimension: 57, defaultValue: 'other'},
       'taxon-slugs': {dimension: 58, defaultValue: 'other'},
-      'taxon-ids': {dimension: 59, defaultValue: 'other'}
+      'taxon-ids': {dimension: 59, defaultValue: 'other'},
+      'content-has-history': {dimension: 39, defaultValue: 'false'}
     };
 
     var $metas = $('meta[name^="govuk:"]');

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -77,6 +77,15 @@
   meta_tags["govuk:taxon-ids"] = taxon_ids.join(',') unless taxon_ids.empty?
   meta_tags["govuk:taxon-slug"] = taxon_slugs_without_theme.first unless taxon_slugs_without_theme.empty?
   meta_tags["govuk:taxon-slugs"] = taxon_slugs_without_theme.join(',') unless taxon_slugs_without_theme.empty?
+
+  def has_content_history(content_item)
+    details = content_item.fetch(:details, {})
+
+    (content_item[:public_updated_at] && details[:first_public_at] && content_item[:public_updated_at] != details[:first_public_at]) ||
+      (details[:change_history] && details[:change_history].size > 1)
+  end
+
+  meta_tags["govuk:content-has-history"] = "true" if has_content_history(content_item_hash)
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const numberOfDimensionsWithDefaultValues = 14;
+    const numberOfDimensionsWithDefaultValues = 15;
 
     var universalSetupArguments;
     var pageViewObject;

--- a/test/govuk_component/analytics_meta_tags_test.rb
+++ b/test/govuk_component/analytics_meta_tags_test.rb
@@ -353,6 +353,22 @@ class AnalyticsMetaTagsTestCase < ComponentTestCase
     assert_select "meta[name='govuk:taxon-ids']", 0
   end
 
+  test "renders the has-content-history tag as true when the content has history" do
+    content_item = {
+      public_updated_at: Time.parse("2017-01-01"),
+      details: {
+        first_public_at: Time.parse("2016-01-01"),
+        change_history: [
+          { note: "test", public_timestamp: Time.parse("2016-01-01") }
+        ]
+      }
+    }
+
+    render_component(content_item: example_document_for('case_study', 'case_study').merge(content_item))
+
+    assert_meta_tag("govuk:content-has-history", "true")
+  end
+
   def assert_political_status_for(political, current, expected_political_status)
     render_component(content_item: { details: { political: political, government: { current: current, slug: 'government' } } })
     assert_meta_tag('govuk:political-status', expected_political_status)


### PR DESCRIPTION
This will be set in the various frontends.

[Trello Card](https://trello.com/c/uHiHx5RQ/56-custom-dimension-to-identify-session-where-content-history-is-available)