### PR TITLE
Adjusting header search box focus style

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -109,6 +109,7 @@
       &.focus,
       &:focus {
         background: #fff;
+        outline-offset: -3px;
       }
 
       @include ie-lte(7){
@@ -116,7 +117,7 @@
       }
       .js-enabled & {
         width: 86%;
-        @include calc(width, "100% - 37px");
+        @include calc(width, "100% - 35.1px"); /* 35.1 is for Safari, which renders this input too narrow */
       }
     }
 
@@ -157,6 +158,11 @@
 
       &:hover {
         background-color: darken($mainstream-brand, 5%);
+      }
+
+      &.focus,
+      &:focus {
+        outline-offset: -3px;
       }
     }
 

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -90,6 +90,9 @@
       border: 0;
       min-height: 36px;
       padding: 6px 0;
+      &::-moz-focus-inner {
+        border: 0;
+      }
       @include ie-lte(8) {
         min-height: 24px;
       }


### PR DESCRIPTION
* Safari rendered this with a 1px gap between the input and the button, all other non-IE browsers happy
* Fixes  #848 

**Safari before**
<img width="356" alt="screen shot 2017-05-24 at 08 15 47" src="https://cloud.githubusercontent.com/assets/861310/26391112/4546183e-4059-11e7-9894-7c04529e5d4d.png">

**Safari after**
<img width="349" alt="screen shot 2017-05-24 at 08 15 57" src="https://cloud.githubusercontent.com/assets/861310/26391129/4ecba784-4059-11e7-99c3-bd8b7a353dba.png">

**Chrome before**
<img width="368" alt="screen shot 2017-05-24 at 08 14 24" src="https://cloud.githubusercontent.com/assets/861310/26391074/1de943ba-4059-11e7-83ad-d79e345886a0.png">

**Chrome after**
<img width="332" alt="screen shot 2017-05-24 at 08 14 38" src="https://cloud.githubusercontent.com/assets/861310/26391078/2679c108-4059-11e7-9f0c-8c1d184ddae8.png">

Worth noting that the negative outline offset isn't supported in IE (even newer versions) so this is generally broken/different in IE anyway. An alternative could be to change the border colour rather than use an outline but I assume there's a good reason for this so didn't want to go off the reservation.

