### PR TITLE
Remove old emergency banner "colour" styles

### DIFF
--- a/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
+++ b/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
@@ -64,15 +64,15 @@
     margin-bottom: 5px;
   }
 
-  &.notable-death, &.black {
+  &.notable-death {
     background-color: $black;
   }
 
-  &.national-emergency, &.red {
+  &.national-emergency {
     background-color: $red;
   }
 
-  &.local-emergency, &.green {
+  &.local-emergency {
     background-color: $turquoise;
   }
 }


### PR DESCRIPTION
Trello card: https://trello.com/c/WoTcRfeI
Related to PR: https://github.com/alphagov/static/pull/1049

The black, red and green campaign classes are no longer being used to define the type of emergency banner. They have been replaced with notable-death, national-emergency and local-emergency.

This PR removes the old CSS styles.