### PR TITLE
Better algorithm for picking surveys

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -68,7 +68,7 @@
     init: function () {
       if (userSurveys.canShowAnySurvey()) {
         var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys)
-        if (userSurveys.isSurveyToBeDisplayed(activeSurvey)) {
+        if (activeSurvey !== undefined) {
           userSurveys.displaySurvey(activeSurvey)
         }
       }
@@ -91,20 +91,38 @@
       }
     },
 
-    getActiveSurvey: function (defaultSurvey, smallSurveys) {
-      var activeSurvey = defaultSurvey
-
-      $.each(smallSurveys, function (_index, survey) {
+    getActiveSurveys: function (surveys) {
+      return $.grep(surveys, function (survey, _index) {
         if (userSurveys.currentTime() >= survey.startTime && userSurveys.currentTime() <= survey.endTime) {
           if (typeof (survey.activeWhen) === 'function') {
-            if (survey.activeWhen()) { activeSurvey = survey }
+            return survey.activeWhen()
           } else {
-            activeSurvey = survey
+            return true
           }
         }
       })
+    },
 
-      return activeSurvey
+    getDisplayableSurveys: function (surveys) {
+      return $.grep(surveys, function (survey, _index) {
+        return userSurveys.isSurveyToBeDisplayed(survey)
+      })
+    },
+
+    getActiveSurvey: function (defaultSurvey, smallSurveys) {
+      var activeSurveys = userSurveys.getActiveSurveys(smallSurveys)
+      var allSurveys = [defaultSurvey].concat(activeSurveys)
+      var displayableSurveys = userSurveys.getDisplayableSurveys(allSurveys)
+
+      if (displayableSurveys.length < 1) {
+        return displayableSurveys[0]
+      } else {
+        // At this point, if there are multiple surveys that could be shown
+        // it is fair to roll the dice and pick one; we've already considered
+        // frequency in isSurveyToBeDisplayed so we don't need to worry about
+        // it here
+        return displayableSurveys[Math.floor(Math.random() * displayableSurveys.length)]
+      }
     },
 
     displaySurvey: function (survey) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -66,9 +66,28 @@
     ],
 
     init: function () {
-      var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys)
-      if (userSurveys.isSurveyToBeDisplayed(activeSurvey)) {
-        userSurveys.displaySurvey(activeSurvey)
+      if (userSurveys.canShowAnySurvey()) {
+        var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys)
+        if (userSurveys.isSurveyToBeDisplayed(activeSurvey)) {
+          userSurveys.displaySurvey(activeSurvey)
+        }
+      }
+    },
+
+    canShowAnySurvey: function() {
+      if (userSurveys.pathInBlacklist()) {
+        return false
+      } else if (userSurveys.otherNotificationVisible()) {
+        return false
+      } else if (userSurveys.userCompletedTransaction()) {
+        // We don't want any survey appearing for users who have completed a
+        // transaction as they may complete the survey with the department's
+        // transaction in mind as opposed to the GOV.UK content.
+        return false
+      } else if ($('#user-satisfaction-survey-container').length <= 0) {
+        return false
+      } else {
+        return true
       }
     },
 
@@ -224,17 +243,7 @@
     },
 
     isSurveyToBeDisplayed: function (survey) {
-      if (userSurveys.pathInBlacklist()) {
-        return false
-      } else if (userSurveys.otherNotificationVisible() ||
-          window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
-        return false
-      } else if (userSurveys.userCompletedTransaction()) {
-        // We don't want any survey appearing for users who have completed a
-        // transaction as they may complete the survey with the department's
-        // transaction in mind as opposed to the GOV.UK content.
-        return false
-      } else if ($('#user-satisfaction-survey-container').length <= 0) {
+      if (GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
         return false
       } else if (userSurveys.randomNumberMatches(survey.frequency)) {
         return true


### PR DESCRIPTION
For: https://trello.com/c/X88IDU6Q/117-permit-concurrent-short-surveys-for-the-same-page

The previous algorithm was to choose the default survey and then ask every
other survey defined in `smallSurveys` in turn if it was active. If the
survey says it is then we record it as the active survey and move on to
the next survey to ask if it is active. Once we have a survey then we
check if the survey has already been completed, and roll the dice to check
against the frequency.  Only then do we show it.

There are a couple of problems with this algorithm.  First; if we have two
or more active surveys that could run on a given page we always pick the
one defined last in smallSurveys.  This means that on that page we'll
never show the ones defined earlier.  Specifically this means that we'll
never show the default survey on a page that another survey is running on.
This is not about showing multiple surveys on a page at one time, just that
across all page views we will only ever show the last defined one.  Second;
by choosing the active survey before we check if it can be shown we run the
risk of picking a survey that we can't actually show and thus showing no
survey at all when another survey we could have picked would be showable.

To solve this we select all possible small surveys for the page looking at
their start and end times, and at the `activeWhen` function.  We add the
default survey to this list and then filter out any that can't be shown
because they have already been completed, or their frequency doesn't
match.  If after doing this we have more than one survey we roll the dice
to pick one of them.  It should be safe enough to do this as we have no
other way of choosing which should run, and we've already checked their
frequencies.  This means that a high frequency survey that runs on a page
won't always be shown in favour of a low frequency survey that also runs
on that page, and also that the last defined survey won't always be the
winner either.

Note: the above taken from the commit message on the `Improve mechanism for selecting which survey to run` commit, you'll want to check the other commit too.