### PR TITLE
Check for curated taxonomy sidebars

### DIFF
--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -28,7 +28,7 @@
         </p>
 
         <% item[:related_content] ||= [] %>
-        <% if item[:related_content].any? && item_index < 2 %>
+        <% if item[:related_content].any? && (item_index < 2 || item[:is_curated]) %>
           <nav role='navigation'>
             <ul class='related-content'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>


### PR DESCRIPTION
In order to allow for the display of curated taxonomy sidebars, we need
to display related links for an arbitrary number of sections. This
change will ignore the check that hides links beyond the second section,
if the sidebar has been curated.

### Trello

https://trello.com/c/J8ofEnrt/167-display-curated-related-links-in-the-sidebar