### PR TITLE
No longer check how many sections are displayed on the taxonomy sidebar

### DIFF
--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -28,7 +28,7 @@
         </p>
 
         <% item[:related_content] ||= [] %>
-        <% if item[:related_content].any? && item_index < 2 %>
+        <% if item[:related_content].any? %>
           <nav role='navigation'>
             <ul class='related-content'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -31,53 +31,6 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_equal ["Item 1 title", "Item 2 title"], taxon_titles
   end
 
-  test "renders related content for the first two taxons" do
-    render_component(
-      items: [
-        {
-          title: "Item 1 title",
-          url: "/item-1",
-          description: "item 1",
-          related_content: [
-            {
-              title: "Related link B",
-              link: "/related-link-b",
-            },
-            {
-              title: "Related link A",
-              link: "/related-link-a",
-            },
-          ],
-        },
-        {
-          title: "Item 2 title",
-          url: "/item-2",
-          description: "item 2",
-          related_content: [
-            {
-              title: "Related link C",
-              link: "/related-link-c",
-            },
-          ],
-        },
-        {
-          title: "Item 3 title",
-          url: "/item-3",
-          description: "item 3",
-          related_content: [
-            {
-              title: "Related link D",
-              link: "/related-link-d",
-            },
-          ],
-        }
-      ],
-    )
-
-    related_links = css_select(".related-content a").map(&:text)
-    assert_equal ["Related link B", "Related link A", "Related link C"], related_links
-  end
-
   test "renders all data attributes for tracking" do
     render_component(
       items: [


### PR DESCRIPTION
We previously hid any related links for any sections after the second
section in the taxonomy sidebar.

This logic is actually already handled in `govuk_navigation_helpers`,
which takes responsibility for what to show in the taxonomy sidebar,
so we can remove this logic.

### Trello

https://trello.com/c/J8ofEnrt/167-display-curated-related-links-in-the-sidebar