### PR TITLE
Make email survey banner accessible

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -3,58 +3,58 @@
 (function ($) {
   'use strict'
   window.GOVUK = window.GOVUK || {}
-  var cancelButton = '<a href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>'
-  var surveyTitle = ' <h2 class="survey-title" id="survey-title">Tell us what you think of GOV.UK</h2>'
   var takeSurveyLink = function (text, className) {
     className = className ? 'class="' + className + '"' : ''
     return '<a ' + className + ' href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">' + text + '</a>'
   }
+  var templateBase = function (children) {
+    return (
+      '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
+      '  <div class="wrapper">' +
+      '    <a href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>' +
+      '    <h2 class="survey-title" id="survey-title">Tell us what you think of GOV.UK</h2>' +
+           children +
+      '  </div>' +
+      '</section>'
+    )
+  }
 
-  var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-                            '  <div class="wrapper">' +
-                                 cancelButton +
-                                 surveyTitle +
-                            '    <p>' +
-                                 takeSurveyLink('Take the 3 minute survey', 'survey-primary-link') +
-                            '    This will open a short survey on another website</p>' +
-                            '  </div>' +
-                            '</section>'
-  var EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-                            '  <div class="wrapper">' +
-                                 cancelButton +
-                            '    <div class="inner-wrapper">' +
-                                   surveyTitle +
-                            '      <div id="email-survey-pre">' +
-                            '        <a class="survey-primary-link" href="#email-survey-form" aria-labelledby="survey-title email-survey-open" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
-                            '          Take a short survey to give us your feedback' +
-                            '        </a>' +
-                            '      </div>' +
-                            '      <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
-                            '        <div id="feedback-prototype-form">' +
-                            '          <div id="survey-form-description" class="survey-form-description">We\'ll send you a link to a feedback form. It only takes 2 minutes to fill in.<br> Don\'t worry: we won\'t send you spam or share your email address with anyone.</div>' +
-                            '          <label class="survey-form-label" aria-describedby="survey-form-description" for="survey-email-address">' +
-                            '            Email Address' +
-                            '          </label>' +
-                            '          <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
-                            '          <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-                            '          <input name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
-                            '          <div class="actions">' +
-                            '            <button type="submit">Send</button>' +
-                            '            <span class="button-info">' +
-                                           takeSurveyLink('Don\'t have an email address?') +
-                            '            </span >' +
-                            '          </div>' +
-                            '        </div>' +
-                            '      </form>' +
-                            '      <div id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +
-                            '        Thanks, we\'ve sent you an email with a link to the survey.' +
-                            '      </div>' +
-                            '      <div id="email-survey-post-failure" class="js-hidden" aria-hidden="true" tabindex="-1">' +
-                            '        Sorry, we’re unable to send you an email right now.  Please try again later.' +
-                            '      </div>' +
-                            '    </div>' +
-                            '  </div>' +
-                            '</section>'
+  var URL_SURVEY_TEMPLATE = templateBase(
+    '<p>' +
+      takeSurveyLink('Take the 3 minute survey', 'survey-primary-link') +
+    '  This will open a short survey on another website' +
+    '</p>'
+  )
+  var EMAIL_SURVEY_TEMPLATE = templateBase(
+    '<div id="email-survey-pre">' +
+    '  <a class="survey-primary-link" href="#email-survey-form" aria-labelledby="survey-title email-survey-open" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
+    '    Take a short survey to give us your feedback' +
+    '  </a>' +
+    '</div>' +
+    '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden inner-wrapper" aria-hidden="true">' +
+    '  <div id="feedback-prototype-form">' +
+    '    <div id="survey-form-description" class="survey-form-description">We\'ll send you a link to a feedback form. It only takes 2 minutes to fill in.<br> Don\'t worry: we won\'t send you spam or share your email address with anyone.</div>' +
+    '    <label class="survey-form-label" aria-describedby="survey-form-description" for="survey-email-address">' +
+    '      Email Address' +
+    '    </label>' +
+    '    <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
+    '    <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
+    '    <input name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
+    '    <div class="actions">' +
+    '      <button type="submit">Send</button>' +
+    '      <span class="button-info">' +
+             takeSurveyLink('Don\'t have an email address?') +
+    '      </span>' +
+    '    </div>' +
+    '  </div>' +
+    '</form>' +
+    '<div id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+    '  Thanks, we\'ve sent you an email with a link to the survey.' +
+    '</div>' +
+    '<div id="email-survey-post-failure" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+    '  Sorry, we’re unable to send you an email right now.  Please try again later.' +
+    '</div>'
+  )
 
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -29,19 +29,19 @@
   )
   var EMAIL_SURVEY_TEMPLATE = templateBase(
     '<div id="email-survey-pre">' +
-    '  <a class="survey-primary-link" href="#email-survey-form" aria-labelledby="survey-title email-survey-open" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
+    '  <a class="survey-primary-link" href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
     '    Take a short survey to give us your feedback' +
     '  </a>' +
     '</div>' +
     '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
     '  <div class="survey-inner-wrapper">' +
     '    <div id="survey-form-description" class="survey-form-description">We\'ll send you a link to a feedback form. It only takes 2 minutes to fill in.<br> Don\'t worry: we won\'t send you spam or share your email address with anyone.</div>' +
-    '    <label class="survey-form-label" aria-describedby="survey-form-description" for="survey-email-address">' +
+    '    <label class="survey-form-label" for="survey-email-address">' +
     '      Email Address' +
     '    </label>' +
     '    <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
     '    <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-    '    <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
+    '    <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text" aria-describedby="survey-form-description">' +
     '    <button class="survey-form-button" type="submit">Send me the survey</button>' +
          takeSurveyLink('Don\'t have an email address?') +
     '  </div>' +

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -18,8 +18,8 @@
                                  takeSurveyLink('Take the 3 minute survey', 'survey-primary-link') +
                             '    This will open a short survey on another website</p>' +
                             '  </div>' +
-                            '</section>',
-    EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
+                            '</section>'
+  var EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
                                  cancelButton +
                             '    <div class="inner-wrapper">' +
@@ -118,8 +118,8 @@
     displayEmailSurvey: function (survey, surveyContainer) {
       surveyContainer.append(survey.template || EMAIL_SURVEY_TEMPLATE)
 
-      var $surveyId = $('#email-survey-form input[name="email_survey_signup[survey_id]"]'),
-        $surveySource = $('#email-survey-form input[name="email_survey_signup[survey_source]"]')
+      var $surveyId = $('#email-survey-form input[name="email_survey_signup[survey_id]"]')
+      var $surveySource = $('#email-survey-form input[name="email_survey_signup[survey_source]"]')
 
       $surveyId.val(survey.identifier)
       $surveySource.val(userSurveys.currentPath())
@@ -141,13 +141,13 @@
     },
 
     setEmailSurveyEventHandlers: function (survey) {
-      var $emailSurveyOpen = $('#email-survey-open'),
-        $emailSurveyCancel = $('#email-survey-cancel'),
-        $emailSurveyPre = $('#email-survey-pre'),
-        $emailSurveyForm = $('#email-survey-form'),
-        $emailSurveyPostSuccess = $('#email-survey-post-success'),
-        $emailSurveyPostFailure = $('#email-survey-post-failure'),
-        $emailSurveyField = $('#survey-email-address')
+      var $emailSurveyOpen = $('#email-survey-open')
+      var $emailSurveyCancel = $('#email-survey-cancel')
+      var $emailSurveyPre = $('#email-survey-pre')
+      var $emailSurveyForm = $('#email-survey-form')
+      var $emailSurveyPostSuccess = $('#email-survey-post-success')
+      var $emailSurveyPostFailure = $('#email-survey-post-failure')
+      var $emailSurveyField = $('#survey-email-address')
 
       $emailSurveyOpen.click(function (e) {
         survey.surveyExpanded = true
@@ -173,19 +173,19 @@
 
       $emailSurveyForm.submit(function (e) {
         var successCallback = function () {
-            $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
-            $emailSurveyPostSuccess.removeClass('js-hidden').attr('aria-hidden', 'false')
-            $emailSurveyPostSuccess.focus()
-            userSurveys.setSurveyTakenCookie(survey)
-            userSurveys.trackEvent(survey.identifier, 'email_survey_taken', 'Email survey taken')
-            userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey')
-          },
-          errorCallback = function () {
-            $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
-            $emailSurveyPostFailure.removeClass('js-hidden').attr('aria-hidden', 'false')
-            $emailSurveyPostFailure.focus()
-          },
-          surveyFormUrl = $emailSurveyForm.attr('action')
+          $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
+          $emailSurveyPostSuccess.removeClass('js-hidden').attr('aria-hidden', 'false')
+          $emailSurveyPostSuccess.focus()
+          userSurveys.setSurveyTakenCookie(survey)
+          userSurveys.trackEvent(survey.identifier, 'email_survey_taken', 'Email survey taken')
+          userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey')
+        }
+        var errorCallback = function () {
+          $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
+          $emailSurveyPostFailure.removeClass('js-hidden').attr('aria-hidden', 'false')
+          $emailSurveyPostFailure.focus()
+        }
+        var surveyFormUrl = $emailSurveyForm.attr('action')
         // make sure the survey form is a js url
         if (!(/\.js$/.test(surveyFormUrl))) {
           surveyFormUrl += '.js'
@@ -229,7 +229,7 @@
       if (userSurveys.pathInBlacklist()) {
         return false
       } else if (userSurveys.otherNotificationVisible() ||
-          GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
+          window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
         return false
       } else if (userSurveys.userCompletedTransaction()) {
         // We don't want any survey appearing for users who have completed a
@@ -270,7 +270,7 @@
     },
 
     trackEvent: function (identifier, action, label) {
-      GOVUK.analytics.trackEvent(identifier, action, {
+      window.GOVUK.analytics.trackEvent(identifier, action, {
         label: label,
         value: 1,
         nonInteraction: true
@@ -278,7 +278,7 @@
     },
 
     setSurveyTakenCookie: function (survey) {
-      GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 4 })
+      window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 4 })
     },
 
     hideSurvey: function (_survey) {
@@ -312,11 +312,11 @@
     currentPath: function () { return window.location.pathname }
   }
 
-  GOVUK.userSurveys = userSurveys
+  window.GOVUK.userSurveys = userSurveys
 
   $(document).ready(function () {
-    if (GOVUK.userSurveys) {
-      GOVUK.userSurveys.init()
+    if (window.GOVUK.userSurveys) {
+      window.GOVUK.userSurveys.init()
     }
   })
-})(jQuery)
+})(window.jQuery)

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -3,39 +3,42 @@
 (function ($) {
   'use strict'
   window.GOVUK = window.GOVUK || {}
+  var cancelButton = '<a href="#email-survey-cancel" aria-labelledby="feedback-heading email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>'
 
   var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
-                            '    <h1>Tell us what you think of GOV.UK</h1>' +
-                            '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
+                                 cancelButton +
+                            '    <h1 id="feedback-heading">Tell us what you think of GOV.UK</h1>' +
                             '    <p><a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">Take the 3 minute survey</a> This will open a short survey on another website</p>' +
                             '  </div>' +
                             '</section>',
     EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-                            '  <div id="email-survey-pre" class="wrapper">' +
-                            '    <h1>Tell us what you think of GOV.UK</h1>' +
-                            '    <p class="right"><a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a></p>' +
-                            '    <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer">Your feedback will help us improve this website</a></p>' +
-                            '  </div>' +
-                            '  <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <div id="feedback-prototype-form">' +
-                            '      <h1>We\'d like to hear from you</h1>' +
-                            '      <p class="right"><a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a></p>' +
-                            '      <label for="email">Tell us your email address and we\'ll send you a link to a quick feedback form.</label>' +
-                            '      <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
-                            '      <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-                            '      <input name="email_survey_signup[email_address]" type="text" placeholder="Your email address">' +
-                            '      <div class="actions">' +
-                            '        <button type="submit">Send</button>' +
-                            '        <p class="button-info">We won\'t store your email address or share it with anyone</span>' +
+                            '  <div class="wrapper">' +
+                                 cancelButton +
+                            '    <div class="inner-wrapper">' +
+                            '      <h1 id="feedback-heading">We\'d like to hear from you</h1>' +
+                            '      <div id="email-survey-pre">' +
+                            '        <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">Your feedback will help us improve this website</a></p>' +
                             '      </div>' +
+                            '      <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
+                            '        <div id="feedback-prototype-form">' +
+                            '          <label for="survey-email-address">Tell us your email address and we\'ll send you a link to a quick feedback form.</label>' +
+                            '          <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
+                            '          <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
+                            '          <input name="email_survey_signup[email_address]" id="survey-email-address" type="text" placeholder="Your email address">' +
+                            '          <div class="actions">' +
+                            '            <button type="submit">Send</button>' +
+                            '            <p class="button-info">We won\'t store your email address or share it with anyone</span>' +
+                            '          </div>' +
+                            '        </div>' +
+                            '      </form>' +
+                            '      <p id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+                            '        Thanks, we\'ve sent you an email with a link to the survey.' +
+                            '      </p>' +
+                            '      <p id="email-survey-post-failure" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+                            '        Sorry, we’re unable to send you an email right now.  Please try again later.' +
+                            '      </p>' +
                             '    </div>' +
-                            '  </form>' +
-                            '  <div id="email-survey-post-success" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <p>Thanks, we\'ve sent you an email with a link to the survey.</p>' +
-                            '  </div>' +
-                            '  <div id="email-survey-post-failure" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <p>Sorry, we’re unable to send you an email right now.  Please try again later.</h2>' +
                             '  </div>' +
                             '</section>'
 
@@ -48,6 +51,13 @@
       surveyType: 'url'
     },
     smallSurveys: [
+      {
+        url: 'https://www.smartsurvey.co.uk/s/gov-uk',
+        identifier: 'user_satisfaction_survey',
+        frequency: 50,
+        surveyType: 'email',
+        surveyExpanded: false
+      }
     ],
 
     init: function () {
@@ -120,20 +130,14 @@
         $emailSurveyForm = $('#email-survey-form'),
         $emailSurveyPostSuccess = $('#email-survey-post-success'),
         $emailSurveyPostFailure = $('#email-survey-post-failure'),
-        $noThanks = $('#survey-no-thanks')
-
-      $noThanks.click(function (e) {
-        userSurveys.setSurveyTakenCookie(survey)
-        userSurveys.hideSurvey(survey)
-        userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked')
-        e.stopPropagation()
-        return false
-      })
+        $emailSurveyField = $('#survey-email-address')
 
       $emailSurveyOpen.click(function (e) {
+        survey.surveyExpanded = true
         userSurveys.trackEvent(survey.identifier, 'email_survey_open', 'Email survey opened')
         $emailSurveyPre.addClass('js-hidden').attr('aria-hidden', 'true')
         $emailSurveyForm.removeClass('js-hidden').attr('aria-hidden', 'false')
+        $emailSurveyField.focus()
         e.stopPropagation()
         return false
       })
@@ -141,7 +145,11 @@
       $emailSurveyCancel.click(function (e) {
         userSurveys.setSurveyTakenCookie(survey)
         userSurveys.hideSurvey(survey)
-        userSurveys.trackEvent(survey.identifier, 'email_survey_cancel', 'Email survey cancelled')
+        if (survey.surveyExpanded) {
+          userSurveys.trackEvent(survey.identifier, 'email_survey_cancel', 'Email survey cancelled')
+        } else {
+          userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked')
+        }
         e.stopPropagation()
         return false
       })
@@ -150,6 +158,7 @@
         var successCallback = function () {
             $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
             $emailSurveyPostSuccess.removeClass('js-hidden').attr('aria-hidden', 'false')
+            $emailSurveyPostSuccess.focus()
             userSurveys.setSurveyTakenCookie(survey)
             userSurveys.trackEvent(survey.identifier, 'email_survey_taken', 'Email survey taken')
             userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey')
@@ -157,6 +166,7 @@
           errorCallback = function () {
             $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
             $emailSurveyPostFailure.removeClass('js-hidden').attr('aria-hidden', 'false')
+            $emailSurveyPostFailure.focus()
           },
           surveyFormUrl = $emailSurveyForm.attr('action')
         // make sure the survey form is a js url
@@ -181,10 +191,10 @@
     },
 
     setURLSurveyEventHandlers: function (survey) {
-      var $noThanks = $('#survey-no-thanks')
+      var $emailSurveyCancel = $('#email-survey-cancel')
       var $takeSurvey = $('#take-survey')
 
-      $noThanks.click(function (e) {
+      $emailSurveyCancel.click(function (e) {
         userSurveys.setSurveyTakenCookie(survey)
         userSurveys.hideSurvey(survey)
         userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked')

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -13,7 +13,7 @@
     return (
       '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
       '  <div class="survey-wrapper">' +
-      '    <a class="survey-close-button" href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button">Close</a>' +
+      '    <a class="survey-close-button" href="#user-survey-cancel" aria-labelledby="survey-title user-survey-cancel" id="user-survey-cancel" role="button">Close</a>' +
       '    <h2 class="survey-title" id="survey-title">Tell us what you think of GOV.UK</h2>' +
            children +
       '  </div>' +
@@ -133,7 +133,7 @@
 
     setEmailSurveyEventHandlers: function (survey) {
       var $emailSurveyOpen = $('#email-survey-open')
-      var $emailSurveyCancel = $('#email-survey-cancel')
+      var $emailSurveyCancel = $('#user-survey-cancel')
       var $emailSurveyPre = $('#email-survey-pre')
       var $emailSurveyForm = $('#email-survey-form')
       var $emailSurveyPostSuccess = $('#email-survey-post-success')
@@ -206,7 +206,7 @@
     },
 
     setURLSurveyEventHandlers: function (survey) {
-      var $emailSurveyCancel = $('#email-survey-cancel')
+      var $emailSurveyCancel = $('#user-survey-cancel')
       var $takeSurvey = $('#take-survey')
 
       $emailSurveyCancel.click(function (e) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -3,15 +3,17 @@
 (function ($) {
   'use strict'
   window.GOVUK = window.GOVUK || {}
+
   var takeSurveyLink = function (text, className) {
     className = className ? 'class="' + className + '"' : ''
     return '<a ' + className + ' href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">' + text + '</a>'
   }
+
   var templateBase = function (children) {
     return (
       '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-      '  <div class="wrapper">' +
-      '    <a href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>' +
+      '  <div class="survey-wrapper">' +
+      '    <a class="survey-close-button" href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button">Close</a>' +
       '    <h2 class="survey-title" id="survey-title">Tell us what you think of GOV.UK</h2>' +
            children +
       '  </div>' +
@@ -31,21 +33,17 @@
     '    Take a short survey to give us your feedback' +
     '  </a>' +
     '</div>' +
-    '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden inner-wrapper" aria-hidden="true">' +
-    '  <div id="feedback-prototype-form">' +
+    '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
+    '  <div class="survey-inner-wrapper">' +
     '    <div id="survey-form-description" class="survey-form-description">We\'ll send you a link to a feedback form. It only takes 2 minutes to fill in.<br> Don\'t worry: we won\'t send you spam or share your email address with anyone.</div>' +
     '    <label class="survey-form-label" aria-describedby="survey-form-description" for="survey-email-address">' +
     '      Email Address' +
     '    </label>' +
     '    <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
     '    <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-    '    <input name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
-    '    <div class="actions">' +
-    '      <button type="submit">Send</button>' +
-    '      <span class="button-info">' +
-             takeSurveyLink('Don\'t have an email address?') +
-    '      </span>' +
-    '    </div>' +
+    '    <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
+    '    <button class="survey-form-button" type="submit">Send</button>' +
+         takeSurveyLink('Don\'t have an email address?') +
     '  </div>' +
     '</form>' +
     '<div id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -3,41 +3,55 @@
 (function ($) {
   'use strict'
   window.GOVUK = window.GOVUK || {}
-  var cancelButton = '<a href="#email-survey-cancel" aria-labelledby="feedback-heading email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>'
+  var cancelButton = '<a href="#email-survey-cancel" aria-labelledby="survey-title email-survey-cancel" id="email-survey-cancel" role="button" class="close-button">Close</a>'
+  var surveyTitle = ' <h2 class="survey-title" id="survey-title">Tell us what you think of GOV.UK</h2>'
+  var takeSurveyLink = function (text, className) {
+    className = className ? 'class="' + className + '"' : ''
+    return '<a ' + className + ' href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">' + text + '</a>'
+  }
 
   var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
                                  cancelButton +
-                            '    <h1 id="feedback-heading">Tell us what you think of GOV.UK</h1>' +
-                            '    <p><a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">Take the 3 minute survey</a> This will open a short survey on another website</p>' +
+                                 surveyTitle +
+                            '    <p>' +
+                                 takeSurveyLink('Take the 3 minute survey', 'survey-primary-link') +
+                            '    This will open a short survey on another website</p>' +
                             '  </div>' +
                             '</section>',
     EMAIL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
                                  cancelButton +
                             '    <div class="inner-wrapper">' +
-                            '      <h1 id="feedback-heading">We\'d like to hear from you</h1>' +
+                                   surveyTitle +
                             '      <div id="email-survey-pre">' +
-                            '        <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">Your feedback will help us improve this website</a></p>' +
+                            '        <a class="survey-primary-link" href="#email-survey-form" aria-labelledby="survey-title email-survey-open" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
+                            '          Take a short survey to give us your feedback' +
+                            '        </a>' +
                             '      </div>' +
                             '      <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
                             '        <div id="feedback-prototype-form">' +
-                            '          <label for="survey-email-address">Tell us your email address and we\'ll send you a link to a quick feedback form.</label>' +
+                            '          <div id="survey-form-description" class="survey-form-description">We\'ll send you a link to a feedback form. It only takes 2 minutes to fill in.<br> Don\'t worry: we won\'t send you spam or share your email address with anyone.</div>' +
+                            '          <label class="survey-form-label" aria-describedby="survey-form-description" for="survey-email-address">' +
+                            '            Email Address' +
+                            '          </label>' +
                             '          <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
                             '          <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
-                            '          <input name="email_survey_signup[email_address]" id="survey-email-address" type="text" placeholder="Your email address">' +
+                            '          <input name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
                             '          <div class="actions">' +
                             '            <button type="submit">Send</button>' +
-                            '            <p class="button-info">We won\'t store your email address or share it with anyone</span>' +
+                            '            <span class="button-info">' +
+                                           takeSurveyLink('Don\'t have an email address?') +
+                            '            </span >' +
                             '          </div>' +
                             '        </div>' +
                             '      </form>' +
-                            '      <p id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+                            '      <div id="email-survey-post-success" class="js-hidden" aria-hidden="true" tabindex="-1">' +
                             '        Thanks, we\'ve sent you an email with a link to the survey.' +
-                            '      </p>' +
-                            '      <p id="email-survey-post-failure" class="js-hidden" aria-hidden="true" tabindex="-1">' +
+                            '      </div>' +
+                            '      <div id="email-survey-post-failure" class="js-hidden" aria-hidden="true" tabindex="-1">' +
                             '        Sorry, we’re unable to send you an email right now.  Please try again later.' +
-                            '      </p>' +
+                            '      </div>' +
                             '    </div>' +
                             '  </div>' +
                             '</section>'
@@ -97,17 +111,7 @@
 
     displayURLSurvey: function (survey, surveyContainer) {
       surveyContainer.append(survey.template || URL_SURVEY_TEMPLATE)
-
-      var $surveyLink = $('#take-survey')
-      var surveyUrl = survey.url
-
-      // Smart survey can record the URL of the survey link if passed through as a query param
-      if ((/smartsurvey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
-        surveyUrl += '?c=' + userSurveys.currentPath()
-      }
-
-      $surveyLink.attr('href', surveyUrl)
-
+      userSurveys.setURLSurveyLink(survey)
       userSurveys.setURLSurveyEventHandlers(survey)
     },
 
@@ -120,7 +124,20 @@
       $surveyId.val(survey.identifier)
       $surveySource.val(userSurveys.currentPath())
 
+      userSurveys.setURLSurveyLink(survey)
       userSurveys.setEmailSurveyEventHandlers(survey)
+    },
+
+    setURLSurveyLink: function (survey) {
+      var $surveyLink = $('#take-survey')
+      var surveyUrl = survey.url
+
+      // Smart survey can record the URL of the survey link if passed through as a query param
+      if ((/smartsurvey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
+        surveyUrl += '?c=' + userSurveys.currentPath()
+      }
+
+      $surveyLink.attr('href', surveyUrl)
     },
 
     setEmailSurveyEventHandlers: function (survey) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -139,6 +139,13 @@
       var $emailSurveyPostSuccess = $('#email-survey-post-success')
       var $emailSurveyPostFailure = $('#email-survey-post-failure')
       var $emailSurveyField = $('#survey-email-address')
+      var $takeSurvey = $('#take-survey')
+
+      $takeSurvey.click(function () {
+        userSurveys.setSurveyTakenCookie(survey)
+        userSurveys.hideSurvey(survey)
+        userSurveys.trackEvent(survey.identifier, 'no_email_link', 'User taken survey via no email link')
+      })
 
       $emailSurveyOpen.click(function (e) {
         survey.surveyExpanded = true

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -1,8 +1,8 @@
-//= require_self
+// = require_self
 
-(function($) {
-  "use strict";
-  window.GOVUK = window.GOVUK || {};
+(function ($) {
+  'use strict'
+  window.GOVUK = window.GOVUK || {}
 
   var URL_SURVEY_TEMPLATE = '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
                             '  <div class="wrapper">' +
@@ -18,8 +18,8 @@
                             '    <p><a href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer">Your feedback will help us improve this website</a></p>' +
                             '  </div>' +
                             '  <form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="wrapper js-hidden" aria-hidden="true">' +
-                            '    <div id="feedback-prototype-form">'+
-                            '      <h1>We\'d like to hear from you</h1>'+
+                            '    <div id="feedback-prototype-form">' +
+                            '      <h1>We\'d like to hear from you</h1>' +
                             '      <p class="right"><a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a></p>' +
                             '      <label for="email">Tell us your email address and we\'ll send you a link to a quick feedback form.</label>' +
                             '      <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
@@ -37,7 +37,7 @@
                             '  <div id="email-survey-post-failure" class="wrapper js-hidden" aria-hidden="true">' +
                             '    <p>Sorry, we’re unable to send you an email right now.  Please try again later.</h2>' +
                             '  </div>' +
-                            '</section>';
+                            '</section>'
 
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
@@ -50,195 +50,195 @@
     smallSurveys: [
     ],
 
-    init: function() {
-      var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys);
+    init: function () {
+      var activeSurvey = userSurveys.getActiveSurvey(userSurveys.defaultSurvey, userSurveys.smallSurveys)
       if (userSurveys.isSurveyToBeDisplayed(activeSurvey)) {
-        userSurveys.displaySurvey(activeSurvey);
+        userSurveys.displaySurvey(activeSurvey)
       }
     },
 
-    getActiveSurvey: function(defaultSurvey, smallSurveys) {
-      var activeSurvey = defaultSurvey;
+    getActiveSurvey: function (defaultSurvey, smallSurveys) {
+      var activeSurvey = defaultSurvey
 
-      $.each(smallSurveys, function(_index, survey) {
-        if(userSurveys.currentTime() >= survey.startTime && userSurveys.currentTime() <= survey.endTime) {
-          if(typeof(survey.activeWhen) === 'function') {
-            if(survey.activeWhen()) { activeSurvey = survey; }
+      $.each(smallSurveys, function (_index, survey) {
+        if (userSurveys.currentTime() >= survey.startTime && userSurveys.currentTime() <= survey.endTime) {
+          if (typeof (survey.activeWhen) === 'function') {
+            if (survey.activeWhen()) { activeSurvey = survey }
           } else {
-            activeSurvey = survey;
+            activeSurvey = survey
           }
         }
-      });
+      })
 
-      return activeSurvey;
+      return activeSurvey
     },
 
-    displaySurvey: function(survey) {
-      var surveyContainer = $("#user-satisfaction-survey-container");
+    displaySurvey: function (survey) {
+      var surveyContainer = $('#user-satisfaction-survey-container')
       if (survey.surveyType === 'email') {
-        userSurveys.displayEmailSurvey(survey, surveyContainer);
+        userSurveys.displayEmailSurvey(survey, surveyContainer)
       } else if ((survey.surveyType === 'url') || (survey.surveyType === undefined)) {
-        userSurveys.displayURLSurvey(survey, surveyContainer);
+        userSurveys.displayURLSurvey(survey, surveyContainer)
       } else {
-        return;
+        return
       }
-      userSurveys.trackEvent(survey.identifier, 'banner_shown', 'Banner has been shown');
+      userSurveys.trackEvent(survey.identifier, 'banner_shown', 'Banner has been shown')
     },
 
-    displayURLSurvey: function(survey, surveyContainer) {
-      surveyContainer.append(survey.template || URL_SURVEY_TEMPLATE);
+    displayURLSurvey: function (survey, surveyContainer) {
+      surveyContainer.append(survey.template || URL_SURVEY_TEMPLATE)
 
-      var $surveyLink = $('#take-survey');
-      var surveyUrl = survey.url;
+      var $surveyLink = $('#take-survey')
+      var surveyUrl = survey.url
 
       // Smart survey can record the URL of the survey link if passed through as a query param
       if ((/smartsurvey/.test(surveyUrl)) && (surveyUrl.indexOf('?c=') === -1)) {
-        surveyUrl += "?c=" + userSurveys.currentPath();
+        surveyUrl += '?c=' + userSurveys.currentPath()
       }
 
-      $surveyLink.attr('href', surveyUrl);
+      $surveyLink.attr('href', surveyUrl)
 
-      userSurveys.setURLSurveyEventHandlers(survey);
+      userSurveys.setURLSurveyEventHandlers(survey)
     },
 
-    displayEmailSurvey: function(survey, surveyContainer) {
-      surveyContainer.append(survey.template || EMAIL_SURVEY_TEMPLATE);
+    displayEmailSurvey: function (survey, surveyContainer) {
+      surveyContainer.append(survey.template || EMAIL_SURVEY_TEMPLATE)
 
       var $surveyId = $('#email-survey-form input[name="email_survey_signup[survey_id]"]'),
-        $surveySource = $('#email-survey-form input[name="email_survey_signup[survey_source]"]');
+        $surveySource = $('#email-survey-form input[name="email_survey_signup[survey_source]"]')
 
-      $surveyId.val(survey.identifier);
-      $surveySource.val(userSurveys.currentPath());
+      $surveyId.val(survey.identifier)
+      $surveySource.val(userSurveys.currentPath())
 
-      userSurveys.setEmailSurveyEventHandlers(survey);
+      userSurveys.setEmailSurveyEventHandlers(survey)
     },
 
-    setEmailSurveyEventHandlers: function(survey) {
+    setEmailSurveyEventHandlers: function (survey) {
       var $emailSurveyOpen = $('#email-survey-open'),
         $emailSurveyCancel = $('#email-survey-cancel'),
         $emailSurveyPre = $('#email-survey-pre'),
         $emailSurveyForm = $('#email-survey-form'),
         $emailSurveyPostSuccess = $('#email-survey-post-success'),
         $emailSurveyPostFailure = $('#email-survey-post-failure'),
-        $noThanks = $('#survey-no-thanks');
+        $noThanks = $('#survey-no-thanks')
 
       $noThanks.click(function (e) {
-        userSurveys.setSurveyTakenCookie(survey);
-        userSurveys.hideSurvey(survey);
-        userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked');
-        e.stopPropagation();
-        return false;
-      });
+        userSurveys.setSurveyTakenCookie(survey)
+        userSurveys.hideSurvey(survey)
+        userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked')
+        e.stopPropagation()
+        return false
+      })
 
       $emailSurveyOpen.click(function (e) {
-        userSurveys.trackEvent(survey.identifier, 'email_survey_open', 'Email survey opened');
-        $emailSurveyPre.addClass('js-hidden').attr('aria-hidden', 'true');
-        $emailSurveyForm.removeClass('js-hidden').attr('aria-hidden', 'false');
-        e.stopPropagation();
-        return false;
-      });
+        userSurveys.trackEvent(survey.identifier, 'email_survey_open', 'Email survey opened')
+        $emailSurveyPre.addClass('js-hidden').attr('aria-hidden', 'true')
+        $emailSurveyForm.removeClass('js-hidden').attr('aria-hidden', 'false')
+        e.stopPropagation()
+        return false
+      })
 
       $emailSurveyCancel.click(function (e) {
-        userSurveys.setSurveyTakenCookie(survey);
-        userSurveys.hideSurvey(survey);
-        userSurveys.trackEvent(survey.identifier, 'email_survey_cancel', 'Email survey cancelled');
-        e.stopPropagation();
-        return false;
-      });
+        userSurveys.setSurveyTakenCookie(survey)
+        userSurveys.hideSurvey(survey)
+        userSurveys.trackEvent(survey.identifier, 'email_survey_cancel', 'Email survey cancelled')
+        e.stopPropagation()
+        return false
+      })
 
-      $emailSurveyForm.submit(function(e) {
-        var successCallback = function() {
-          $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true');
-          $emailSurveyPostSuccess.removeClass('js-hidden').attr('aria-hidden', 'false');
-          userSurveys.setSurveyTakenCookie(survey);
-          userSurveys.trackEvent(survey.identifier, 'email_survey_taken', 'Email survey taken');
-          userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey');
-        },
-        errorCallback = function() {
-          $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true');
-          $emailSurveyPostFailure.removeClass('js-hidden').attr('aria-hidden', 'false');
-        },
-        surveyFormUrl = $emailSurveyForm.attr('action');
+      $emailSurveyForm.submit(function (e) {
+        var successCallback = function () {
+            $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
+            $emailSurveyPostSuccess.removeClass('js-hidden').attr('aria-hidden', 'false')
+            userSurveys.setSurveyTakenCookie(survey)
+            userSurveys.trackEvent(survey.identifier, 'email_survey_taken', 'Email survey taken')
+            userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey')
+          },
+          errorCallback = function () {
+            $emailSurveyForm.addClass('js-hidden').attr('aria-hidden', 'true')
+            $emailSurveyPostFailure.removeClass('js-hidden').attr('aria-hidden', 'false')
+          },
+          surveyFormUrl = $emailSurveyForm.attr('action')
         // make sure the survey form is a js url
         if (!(/\.js$/.test(surveyFormUrl))) {
-          surveyFormUrl += '.js';
+          surveyFormUrl += '.js'
         }
 
         $.ajax({
-          type: "POST",
+          type: 'POST',
           url: surveyFormUrl,
-          dataType: "json",
+          dataType: 'json',
           data: $emailSurveyForm.serialize(),
           success: successCallback,
           error: errorCallback,
           statusCode: {
             500: errorCallback
           }
-        });
-        e.stopPropagation();
-        return false;
-      });
+        })
+        e.stopPropagation()
+        return false
+      })
     },
 
-    setURLSurveyEventHandlers: function(survey) {
-      var $noThanks = $('#survey-no-thanks');
-      var $takeSurvey = $('#take-survey');
+    setURLSurveyEventHandlers: function (survey) {
+      var $noThanks = $('#survey-no-thanks')
+      var $takeSurvey = $('#take-survey')
 
       $noThanks.click(function (e) {
-        userSurveys.setSurveyTakenCookie(survey);
-        userSurveys.hideSurvey(survey);
-        userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked');
-        e.stopPropagation();
-        return false;
-      });
+        userSurveys.setSurveyTakenCookie(survey)
+        userSurveys.hideSurvey(survey)
+        userSurveys.trackEvent(survey.identifier, 'banner_no_thanks', 'No thanks clicked')
+        e.stopPropagation()
+        return false
+      })
       $takeSurvey.click(function () {
-        userSurveys.setSurveyTakenCookie(survey);
-        userSurveys.hideSurvey(survey);
-        userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey');
-      });
+        userSurveys.setSurveyTakenCookie(survey)
+        userSurveys.hideSurvey(survey)
+        userSurveys.trackEvent(survey.identifier, 'banner_taken', 'User taken survey')
+      })
     },
 
-    isSurveyToBeDisplayed: function(survey) {
+    isSurveyToBeDisplayed: function (survey) {
       if (userSurveys.pathInBlacklist()) {
-        return false;
+        return false
       } else if (userSurveys.otherNotificationVisible() ||
           GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
-        return false;
+        return false
       } else if (userSurveys.userCompletedTransaction()) {
         // We don't want any survey appearing for users who have completed a
         // transaction as they may complete the survey with the department's
         // transaction in mind as opposed to the GOV.UK content.
-        return false;
+        return false
       } else if ($('#user-satisfaction-survey-container').length <= 0) {
-        return false;
+        return false
       } else if (userSurveys.randomNumberMatches(survey.frequency)) {
-        return true;
+        return true
       } else {
-        return false;
+        return false
       }
     },
 
-    pathInBlacklist: function() {
-      var blackList = new RegExp('^/(?:'
-        + /service-manual/.source
+    pathInBlacklist: function () {
+      var blackList = new RegExp('^/(?:' +
+        /service-manual/.source +
         // add more blacklist paths in the form:
         // + /|path-to\/blacklist/.source
-        + ')(?:\/|$)'
-      );
-      return blackList.test(userSurveys.currentPath());
+        ')(?:\/|$)'
+      )
+      return blackList.test(userSurveys.currentPath())
     },
 
-    userCompletedTransaction: function() {
-      var path = userSurveys.currentPath();
+    userCompletedTransaction: function () {
+      var path = userSurveys.currentPath()
 
-      function stringContains(str, substr) {
-        return str.indexOf(substr) > -1;
+      function stringContains (str, substr) {
+        return str.indexOf(substr) > -1
       }
 
-      if (stringContains(path, "/done") ||
-          stringContains(path, "/transaction-finished") ||
-          stringContains(path, "/driving-transaction-finished")) {
-            return true;
+      if (stringContains(path, '/done') ||
+          stringContains(path, '/transaction-finished') ||
+          stringContains(path, '/driving-transaction-finished')) {
+        return true
       }
     },
 
@@ -247,49 +247,49 @@
         label: label,
         value: 1,
         nonInteraction: true
-      });
+      })
     },
 
     setSurveyTakenCookie: function (survey) {
-      GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30*4 });
+      GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 4 })
     },
 
-    hideSurvey: function(_survey) {
-      $("#user-satisfaction-survey").removeClass('visible').attr('aria-hidden', 'true');
+    hideSurvey: function (_survey) {
+      $('#user-satisfaction-survey').removeClass('visible').attr('aria-hidden', 'true')
     },
 
-    randomNumberMatches: function(frequency) {
-      return (Math.floor(Math.random() * frequency) === 0);
+    randomNumberMatches: function (frequency) {
+      return (Math.floor(Math.random() * frequency) === 0)
     },
 
-    otherNotificationVisible: function() {
+    otherNotificationVisible: function () {
       var notificationIds = [
         '.govuk-emergency-banner:visible',
         '#global-cookie-message:visible',
         '#global-browser-prompt:visible',
         '#taxonomy-survey:visible'
       ]
-      return $(notificationIds.join(', ')).length > 0;
+      return $(notificationIds.join(', ')).length > 0
     },
 
-    surveyTakenCookieName: function(survey) {
-      //user_satisfaction_survey => takenUserSatisfactionSurvey
-      var cookieStr = "taken_" + survey.identifier;
-      var cookieStub = cookieStr.replace(/(\_\w)/g, function(m) {
-        return m.charAt(1).toUpperCase();
-      });
-      return "govuk_" + cookieStub;
+    surveyTakenCookieName: function (survey) {
+      // user_satisfaction_survey => takenUserSatisfactionSurvey
+      var cookieStr = 'taken_' + survey.identifier
+      var cookieStub = cookieStr.replace(/(\_\w)/g, function (m) {
+        return m.charAt(1).toUpperCase()
+      })
+      return 'govuk_' + cookieStub
     },
 
-    currentTime: function() { return new Date().getTime(); },
-    currentPath: function() { return window.location.pathname; }
-  };
+    currentTime: function () { return new Date().getTime() },
+    currentPath: function () { return window.location.pathname }
+  }
 
-  GOVUK.userSurveys = userSurveys;
+  GOVUK.userSurveys = userSurveys
 
-  $(document).ready(function() {
+  $(document).ready(function () {
     if (GOVUK.userSurveys) {
-      GOVUK.userSurveys.init();
+      GOVUK.userSurveys.init()
     }
-  });
-})(jQuery);
+  })
+})(jQuery)

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -42,7 +42,7 @@
     '    <input name="email_survey_signup[survey_id]" type="hidden" value="">' +
     '    <input name="email_survey_signup[survey_source]" type="hidden" value="">' +
     '    <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text">' +
-    '    <button class="survey-form-button" type="submit">Send</button>' +
+    '    <button class="survey-form-button" type="submit">Send me the survey</button>' +
          takeSurveyLink('Don\'t have an email address?') +
     '  </div>' +
     '</form>' +

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -65,13 +65,6 @@
       surveyType: 'url'
     },
     smallSurveys: [
-      {
-        url: 'https://www.smartsurvey.co.uk/s/gov-uk',
-        identifier: 'user_satisfaction_survey',
-        frequency: 50,
-        surveyType: 'email',
-        surveyExpanded: false
-      }
     ],
 
     init: function () {

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -246,43 +246,43 @@
     clear: both;
     padding: 0 15px;
 
+    .inner-wrapper {
+      max-width: 30em;
+    }
+
     h1 {
       @include bold-19;
 
       margin-left: 20px;
     }
 
+    a {
+      &:link,
+      &:active,
+      &:visited {
+        color: #fff;
+      }
+
+      &:hover {
+        color: #fff;
+      }
+
+      &#take-survey {
+        @include core-19;
+
+        padding-right: 5px;
+      }
+    }
+
+    .close-button {
+      float: right;
+      margin: 0px 20px 0 0;
+      @include core-14;
+    }
+
     p {
       @include core-14;
-
       margin: 0 0 0 20px;
-
-      a {
-        &:link,
-        &:active,
-        &:visited {
-          color: #fff;
-        }
-
-        &:hover {
-          color: #fff;
-        }
-
-        &#take-survey {
-          @include core-19;
-
-          padding-right: 5px;
-        }
-      }
-
-      &.right {
-        float: right;
-        margin: -20px 20px 0 0;
-
-        @include ie-lte(7) {
-          margin-top: -25px;
-        }
-      }
     }
 
     input {

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -230,9 +230,10 @@
    * JavaScript enabled.
    */
   display: none;
-  background-color: #2B358B;
-  padding: 0.5em 0;
-  color: #fff;
+  background-color: $govuk-blue;
+  margin-bottom: 1px;
+  color: $white;
+  @include core-16;
 
   &.visible {
     @include media(desktop) {
@@ -240,80 +241,83 @@
     }
   }
 
+  [tabindex="-1"]:focus {
+    outline: none;
+  }
+
   .wrapper {
-    margin: 0 auto;
-    max-width: 990px;
+    @extend %site-width-container;
+    padding-top: $gutter-half;
+    padding-bottom: $gutter-two-thirds;
     clear: both;
-    padding: 0 15px;
 
     .inner-wrapper {
       max-width: 30em;
     }
 
-    h1 {
+    .survey-title {
       @include bold-19;
-
-      margin-left: 20px;
+      margin-bottom: .5em;
     }
 
     a {
       &:link,
       &:active,
+      &:hover,
       &:visited {
-        color: #fff;
+        color: inherit;
       }
-
-      &:hover {
-        color: #fff;
-      }
-
-      &#take-survey {
-        @include core-19;
-
-        padding-right: 5px;
+      &:focus {
+        color: $black;
       }
     }
 
     .close-button {
       float: right;
-      margin: 0px 20px 0 0;
       @include core-14;
     }
 
-    p {
-      @include core-14;
-      margin: 0 0 0 20px;
+    .survey-primary-link {
+      @include core-19;
+      margin-right: .5em;
+    }
+
+    .survey-form-label {
+      display: block;
+      margin-bottom: .25em;
     }
 
     input {
-      @include core-14;
-
       display: block;
-      margin: 0 20px 0 20px;
-      max-width: 940px;
+      -webkit-box-sizing: border-box;
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
       width: 100%;
-
-      @include ie-lte(6) {
-        width: 940px;
-      }
+      padding: 5px 4px 4px;
+      border: 2px solid $white;
+      margin-bottom: 1em;
     }
 
-    label {
+    .survey-form-description {
       @include core-14;
-      margin: 0 0 0 20px;
+      margin-bottom: .5em;
     }
 
     .actions {
-      margin: 0.5em 0 0.5em 20px;
-
       button {
-        @include button;
-        display: inline-block;
-      }
+        @include button($white);
+        @include bold-19($line-height: 1.1);
+        color: $govuk-blue;
 
-      .button-info {
-        @include core-14;
-        display: inline-block;
+        &:hover,
+        &:focus {
+          color: darken($govuk-blue, 5%);
+        }
+
+        &:focus {
+          outline: 3px solid $focus-colour;
+        }
+        margin-right: .5em;
       }
     }
   }

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -245,80 +245,78 @@
     outline: none;
   }
 
-  .wrapper {
+  a {
+    &:link,
+    &:active,
+    &:hover,
+    &:visited {
+      color: inherit;
+    }
+    &:focus {
+      color: $black;
+    }
+  }
+
+  .survey-wrapper {
     @extend %site-width-container;
     padding-top: $gutter-half;
     padding-bottom: $gutter-two-thirds;
     clear: both;
+  }
 
-    .inner-wrapper {
-      max-width: 30em;
+  .survey-inner-wrapper {
+    max-width: 30em;
+  }
+
+  .survey-title {
+    @include bold-19;
+    margin-bottom: .5em;
+  }
+
+  .survey-close-button {
+    float: right;
+    @include core-14;
+  }
+
+  .survey-primary-link {
+    @include core-19;
+    margin-right: .5em;
+  }
+
+  .survey-form-label {
+    display: block;
+    margin-bottom: .25em;
+  }
+
+  .survey-form-input {
+    display: block;
+    -webkit-box-sizing: border-box;
+    -moz-box-sizing: border-box;
+    box-sizing: border-box;
+    width: 100%;
+    padding: 5px 4px 4px;
+    border: 2px solid $white;
+    margin-bottom: 1em;
+  }
+
+  .survey-form-description {
+    @include core-14;
+    margin-bottom: .5em;
+  }
+
+  .survey-form-button {
+    @include button($white);
+    @include bold-19($line-height: 1.1);
+    color: $govuk-blue;
+
+    &:hover,
+    &:focus {
+      color: darken($govuk-blue, 5%);
     }
 
-    .survey-title {
-      @include bold-19;
-      margin-bottom: .5em;
+    &:focus {
+      outline: 3px solid $focus-colour;
     }
-
-    a {
-      &:link,
-      &:active,
-      &:hover,
-      &:visited {
-        color: inherit;
-      }
-      &:focus {
-        color: $black;
-      }
-    }
-
-    .close-button {
-      float: right;
-      @include core-14;
-    }
-
-    .survey-primary-link {
-      @include core-19;
-      margin-right: .5em;
-    }
-
-    .survey-form-label {
-      display: block;
-      margin-bottom: .25em;
-    }
-
-    input {
-      display: block;
-      -webkit-box-sizing: border-box;
-      -moz-box-sizing: border-box;
-      box-sizing: border-box;
-      width: 100%;
-      padding: 5px 4px 4px;
-      border: 2px solid $white;
-      margin-bottom: 1em;
-    }
-
-    .survey-form-description {
-      @include core-14;
-      margin-bottom: .5em;
-    }
-
-    .actions {
-      button {
-        @include button($white);
-        @include bold-19($line-height: 1.1);
-        color: $govuk-blue;
-
-        &:hover,
-        &:focus {
-          color: darken($govuk-blue, 5%);
-        }
-
-        &:focus {
-          outline: 3px solid $focus-colour;
-        }
-        margin-right: .5em;
-      }
-    }
+    margin-right: .5em;
   }
 }

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -76,7 +76,7 @@ An HTML fragment representing the interactive UI for entering an email address. 
   <form id="email-survey-form" action="/contact/govuk/email-survey-request" method="post" class="wrapper js-hidden" aria-hidden="true">
     <div id="feedback-prototype-form">
       <h1>We'd like to hear from you</h1>
-      <p class="right"><a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a></p>
+      <p class="right"><a href="#user-survey-cancel" id="user-survey-cancel">No thanks</a></p>
       <label for="email">Tell us your email address and we'll send you a link to a quick feedback form.</label>
       <input name="survey_id" type="hidden" value="">
       <input name="survey_source" type="hidden" value="">
@@ -96,7 +96,7 @@ An HTML fragment representing the interactive UI for entering an email address. 
 </section>
 ```
 
-Behaviour will be added so that clicking the `#email-survey-open` element hides the `#email-survey-pre` container and opens the `#email-survey-form` container.  Submitting the form will hide the `#email-survey-form` container and show the `#email-survey-post-success` or `#email-survey-post-failure` container depending on what happens when submitting the form via AJAX.  The `survey_id` and `survey_source` inputs will be filled in with the appropriate elements.  The `#survey-no-thanks` and `#email-survey-cancel` are also required for dismissing the UI.  Successfully submitting the form or dismissing the UI will set cookies to avoid re-showing the UI to the user again.
+Behaviour will be added so that clicking the `#email-survey-open` element hides the `#email-survey-pre` container and opens the `#email-survey-form` container.  Submitting the form will hide the `#email-survey-form` container and show the `#email-survey-post-success` or `#email-survey-post-failure` container depending on what happens when submitting the form via AJAX.  The `survey_id` and `survey_source` inputs will be filled in with the appropriate elements.  The `#survey-no-thanks` and `#user-survey-cancel` are also required for dismissing the UI.  Successfully submitting the form or dismissing the UI will set cookies to avoid re-showing the UI to the user again.
 
 ### `activeWhen` - OPTIONAL
 A callback function returning true or false allowing further scoping of when the survey is considered "active".

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -42,8 +42,8 @@ What type of survey is this.  Currently either `url` or `email` is supported.  `
 
 Note that for `email` surveys the users email is submitted back to the [feedback](https://github.com/alphagov/feedback) app which actually sends the email.  The email address is sent with the `identifier` of the survey and this identifier must match with the `id` of a survey defined in [`app/models/email_survey.rb`](https://github.com/alphagov/feedback/blob/85e07b0c572a91be02b64af1d551df313f2695f9/app/models/email_survey.rb#L24).  Make sure you define the survey in both `static` and `feedback`.
 
-### `url` - required for `url` surveys
-This should link to a smartsurvey -- or other survey page -- that allows the visitor to take the survey.
+### `url` - required
+Used in a link in the survey that the user is directed to click on. This should be the URL of a smartsurvey -- or other survey page -- that allows the visitor to take the survey. Required, but not currently used in 'email'.
 
 ### `template` - OPTIONAL
 This describes the UI that the survey will use to encourage users to sign up.  If omitted the default survey for the `surveyType` will be used.

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -8,7 +8,7 @@ describe('Surveys', function () {
     frequency: 1, // no randomness in the test suite pls
     identifier: 'user_satisfaction_survey',
     template: '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-              '  <a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a>' +
+              '  <a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a>' +
               '  <a href="javascript:void()" id="take-survey" target="_blank"></a>' +
               '</section>',
     surveyType: 'url'
@@ -226,7 +226,7 @@ describe('Surveys', function () {
       })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true')
       })
 
@@ -237,7 +237,7 @@ describe('Surveys', function () {
       })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
       })
 
@@ -249,7 +249,7 @@ describe('Surveys', function () {
 
       it("records an event when clicking 'no thanks'", function () {
         spyOn(surveys, 'trackEvent')
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
       })
     })
@@ -265,18 +265,18 @@ describe('Surveys', function () {
       })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
       })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
       })
 
       it("records an event when clicking 'no thanks'", function () {
         spyOn(surveys, 'trackEvent')
-        $('#survey-no-thanks').trigger('click')
+        $('#email-survey-cancel').trigger('click')
         expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
       })
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -8,7 +8,7 @@ describe('Surveys', function () {
     frequency: 1, // no randomness in the test suite pls
     identifier: 'user_satisfaction_survey',
     template: '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-              '  <a href="#email-survey-cancel" id="email-survey-cancel">No thanks</a>' +
+              '  <a href="#user-survey-cancel" id="user-survey-cancel">No thanks</a>' +
               '  <a href="javascript:void()" id="take-survey" target="_blank"></a>' +
               '</section>',
     surveyType: 'url'
@@ -226,7 +226,7 @@ describe('Surveys', function () {
       })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true')
       })
 
@@ -237,7 +237,7 @@ describe('Surveys', function () {
       })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
       })
 
@@ -249,7 +249,7 @@ describe('Surveys', function () {
 
       it("records an event when clicking 'no thanks'", function () {
         spyOn(surveys, 'trackEvent')
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
       })
     })
@@ -265,18 +265,18 @@ describe('Surveys', function () {
       })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
       })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
       })
 
       it("records an event when clicking 'no thanks'", function () {
         spyOn(surveys, 'trackEvent')
-        $('#email-survey-cancel').trigger('click')
+        $('#user-survey-cancel').trigger('click')
         expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
       })
 
@@ -378,18 +378,18 @@ describe('Surveys', function () {
         })
 
         it("hides the email form when clicking 'No thanks'", function () {
-          $('#email-survey-cancel').trigger('click')
+          $('#user-survey-cancel').trigger('click')
           expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
         })
 
         it("hides the whole email survey interface after clicking 'no thanks'", function () {
-          $('#email-survey-cancel').trigger('click')
+          $('#user-survey-cancel').trigger('click')
           expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
         })
 
         it("records an event when clicking 'no thanks'", function () {
           spyOn(surveys, 'trackEvent')
-          $('#email-survey-cancel').trigger('click')
+          $('#user-survey-cancel').trigger('click')
           expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_cancel', 'Email survey cancelled')
         })
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -1,7 +1,7 @@
-//= require surveys
-describe("Surveys", function() {
-  var surveys = GOVUK.userSurveys;
-  var $block;
+// = require surveys
+describe('Surveys', function () {
+  var surveys = GOVUK.userSurveys
+  var $block
 
   var defaultSurvey = {
     url: 'smartsurvey.co.uk/default',
@@ -11,454 +11,454 @@ describe("Surveys", function() {
               '  <a href="#survey-no-thanks" id="survey-no-thanks">No thanks</a>' +
               '  <a href="javascript:void()" id="take-survey" target="_blank"></a>' +
               '</section>',
-    surveyType: 'url',
-  };
+    surveyType: 'url'
+  }
   var smallSurvey = {
-    startTime: new Date("July 5, 2016").getTime(),
-    endTime: new Date("July 10, 2016 23:50:00").getTime(),
+    startTime: new Date('July 5, 2016').getTime(),
+    endTime: new Date('July 10, 2016 23:50:00').getTime(),
     url: 'example.com/small-survey',
-    surveyType: 'url',
-  };
+    surveyType: 'url'
+  }
   var urlSurvey = {
     surveyType: 'url',
     url: 'smartsurvey.co.ukdefault',
-    identifier: 'url-survey',
-  };
+    identifier: 'url-survey'
+  }
   var emailSurvey = {
     surveyType: 'email',
-    identifier: 'email-survey',
-  };
+    identifier: 'email-survey'
+  }
 
   beforeEach(function () {
     $block = $('<div class="govuk-emergency-banner" style="display: none"></div>' +
                '<div id="global-cookie-message" style="display: none"></div>' +
                '<div id="global-browser-prompt" style="display: none"></div>' +
-               '<div id="user-satisfaction-survey-container"></div>');
+               '<div id="user-satisfaction-survey-container"></div>')
 
-    $('body').append($block);
-    $("#user-satisfaction-survey").remove();
+    $('body').append($block)
+    $('#user-satisfaction-survey').remove()
 
     // Don't actually try and take a survey in test.
-    $('#take-survey').on('click', function(e) {
-      e.preventDefault();
-    });
-  });
+    $('#take-survey').on('click', function (e) {
+      e.preventDefault()
+    })
+  })
 
   afterEach(function () {
-    GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey), null);
-    GOVUK.cookie(surveys.surveyTakenCookieName(smallSurvey), null);
-    GOVUK.cookie(surveys.surveyTakenCookieName(urlSurvey), null);
-    GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey), null);
-    $block.remove();
-  });
+    GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey), null)
+    GOVUK.cookie(surveys.surveyTakenCookieName(smallSurvey), null)
+    GOVUK.cookie(surveys.surveyTakenCookieName(urlSurvey), null)
+    GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey), null)
+    $block.remove()
+  })
 
-  describe("init", function() {
-    it("shows the default survey", function() {
-      spyOn(surveys, 'randomNumberMatches').and.returnValue(true);
+  describe('init', function () {
+    it('shows the default survey', function () {
+      spyOn(surveys, 'randomNumberMatches').and.returnValue(true)
       // So we're working with the user satisfaction survey, not any future small survey
-      spyOn(surveys, 'currentTime').and.returnValue(new Date("July 11, 201610:00:00").getTime());
-      surveys.init();
+      spyOn(surveys, 'currentTime').and.returnValue(new Date('July 11, 201610:00:00').getTime())
+      surveys.init()
 
-      expect($('#take-survey').attr('href')).toContain(surveys.defaultSurvey.url);
-      expect($('#user-satisfaction-survey').length).toBe(1);
-      expect($('#user-satisfaction-survey').hasClass('visible')).toBe(true);
-      expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false');
-    });
-  });
+      expect($('#take-survey').attr('href')).toContain(surveys.defaultSurvey.url)
+      expect($('#user-satisfaction-survey').length).toBe(1)
+      expect($('#user-satisfaction-survey').hasClass('visible')).toBe(true)
+      expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false')
+    })
+  })
 
-  describe("displaySurvey", function() {
-    it("displays the user satisfaction div", function () {
-      expect($('#user-satisfaction-survey').length).toBe(0);
-      surveys.displaySurvey(defaultSurvey);
-      expect($('#user-satisfaction-survey').length).toBe(1);
-      expect($('#user-satisfaction-survey').hasClass('visible')).toBe(true);
-      expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false');
-    });
+  describe('displaySurvey', function () {
+    it('displays the user satisfaction div', function () {
+      expect($('#user-satisfaction-survey').length).toBe(0)
+      surveys.displaySurvey(defaultSurvey)
+      expect($('#user-satisfaction-survey').length).toBe(1)
+      expect($('#user-satisfaction-survey').hasClass('visible')).toBe(true)
+      expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false')
+    })
 
-    describe("for a 'url' survey", function() {
-      it("links to the url for a smartsurvey survey with a completion redirect query parameter", function () {
-        surveys.displaySurvey(urlSurvey);
+    describe("for a 'url' survey", function () {
+      it('links to the url for a smartsurvey survey with a completion redirect query parameter', function () {
+        surveys.displaySurvey(urlSurvey)
 
-        expect($('#take-survey').attr('href')).toContain(urlSurvey.url);
-        expect($('#take-survey').attr('href')).toContain("?c=" + window.location.pathname);
-      });
+        expect($('#take-survey').attr('href')).toContain(urlSurvey.url)
+        expect($('#take-survey').attr('href')).toContain('?c=' + window.location.pathname)
+      })
 
-      it("records an event when showing the survey", function() {
-        spyOn(surveys, 'trackEvent');
-        surveys.displaySurvey(urlSurvey);
-        expect(surveys.trackEvent).toHaveBeenCalledWith(urlSurvey.identifier, 'banner_shown', 'Banner has been shown');
-      });
+      it('records an event when showing the survey', function () {
+        spyOn(surveys, 'trackEvent')
+        surveys.displaySurvey(urlSurvey)
+        expect(surveys.trackEvent).toHaveBeenCalledWith(urlSurvey.identifier, 'banner_shown', 'Banner has been shown')
+      })
 
-      it("sets event handlers on the survey", function() {
-        spyOn(surveys, 'setURLSurveyEventHandlers');
-        surveys.displaySurvey(urlSurvey);
-        expect(surveys.setURLSurveyEventHandlers).toHaveBeenCalledWith(urlSurvey);
-      });
+      it('sets event handlers on the survey', function () {
+        spyOn(surveys, 'setURLSurveyEventHandlers')
+        surveys.displaySurvey(urlSurvey)
+        expect(surveys.setURLSurveyEventHandlers).toHaveBeenCalledWith(urlSurvey)
+      })
 
-      it("records an event when showing the survey", function() {
-        spyOn(surveys, 'trackEvent');
-        surveys.displaySurvey(urlSurvey);
-        expect(surveys.trackEvent).toHaveBeenCalledWith(urlSurvey.identifier, 'banner_shown', 'Banner has been shown');
-      });
-    });
+      it('records an event when showing the survey', function () {
+        spyOn(surveys, 'trackEvent')
+        surveys.displaySurvey(urlSurvey)
+        expect(surveys.trackEvent).toHaveBeenCalledWith(urlSurvey.identifier, 'banner_shown', 'Banner has been shown')
+      })
+    })
 
-    describe("for an 'email' survey", function() {
-      it("adds the survey identifier to the form", function() {
-        surveys.displaySurvey(emailSurvey);
+    describe("for an 'email' survey", function () {
+      it('adds the survey identifier to the form', function () {
+        surveys.displaySurvey(emailSurvey)
 
-        expect($('#email-survey-form input[name="email_survey_signup[survey_id]"]').val()).toEqual(emailSurvey.identifier);
-      });
+        expect($('#email-survey-form input[name="email_survey_signup[survey_id]"]').val()).toEqual(emailSurvey.identifier)
+      })
 
-      it("adds the current path to the form", function() {
-        surveys.displaySurvey(emailSurvey);
+      it('adds the current path to the form', function () {
+        surveys.displaySurvey(emailSurvey)
 
-        expect($('#email-survey-form input[name="email_survey_signup[survey_source]"]').val()).toEqual(window.location.pathname);
-      });
+        expect($('#email-survey-form input[name="email_survey_signup[survey_source]"]').val()).toEqual(window.location.pathname)
+      })
 
-      it("sets event handlers on the survey", function() {
-        spyOn(surveys, 'setEmailSurveyEventHandlers');
-        surveys.displaySurvey(emailSurvey);
-        expect(surveys.setEmailSurveyEventHandlers).toHaveBeenCalledWith(emailSurvey);
-      });
+      it('sets event handlers on the survey', function () {
+        spyOn(surveys, 'setEmailSurveyEventHandlers')
+        surveys.displaySurvey(emailSurvey)
+        expect(surveys.setEmailSurveyEventHandlers).toHaveBeenCalledWith(emailSurvey)
+      })
 
-      it("records an event when showing the survey", function() {
-        spyOn(surveys, 'trackEvent');
-        surveys.displaySurvey(emailSurvey);
-        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_shown', 'Banner has been shown');
-      });
-    });
-  });
+      it('records an event when showing the survey', function () {
+        spyOn(surveys, 'trackEvent')
+        surveys.displaySurvey(emailSurvey)
+        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_shown', 'Banner has been shown')
+      })
+    })
+  })
 
-  describe("isSurveyToBeDisplayed", function() {
-    it("returns false if another notification banner is visible", function() {
-      $('#global-cookie-message').css('display', 'block');
+  describe('isSurveyToBeDisplayed', function () {
+    it('returns false if another notification banner is visible', function () {
+      $('#global-cookie-message').css('display', 'block')
 
-      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
-    });
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy()
+    })
 
-    it("returns false if the path is blacklisted", function() {
-      spyOn(surveys, 'pathInBlacklist').and.returnValue(true);
+    it('returns false if the path is blacklisted', function () {
+      spyOn(surveys, 'pathInBlacklist').and.returnValue(true)
 
-      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy()
     })
 
     it("returns false if the 'survey taken' cookie is set", function () {
-      GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey), 'true');
+      GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey), 'true')
 
-      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
-    });
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy()
+    })
 
-    it("returns false when the random number does not match", function() {
-      spyOn(surveys, 'randomNumberMatches').and.returnValue(false);
-      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy();
-    });
+    it('returns false when the random number does not match', function () {
+      spyOn(surveys, 'randomNumberMatches').and.returnValue(false)
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeFalsy()
+    })
 
-    it("returns true when the random number matches", function() {
-      spyOn(surveys, 'randomNumberMatches').and.returnValue(true);
-      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeTruthy();
-    });
-  });
+    it('returns true when the random number matches', function () {
+      spyOn(surveys, 'randomNumberMatches').and.returnValue(true)
+      expect(surveys.isSurveyToBeDisplayed(defaultSurvey)).toBeTruthy()
+    })
+  })
 
-  describe("pathInBlacklist", function() {
+  describe('pathInBlacklist', function () {
     // we make sure that slash-terminated and slash-unterminated versions
     // of these paths work
-    it("returns true if the path is /service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/service-manual', '/service-manual/');
-      expect(surveys.pathInBlacklist()).toBeTruthy();
-      expect(surveys.pathInBlacklist()).toBeTruthy();
-    });
+    it('returns true if the path is /service-manual', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/service-manual', '/service-manual/')
+      expect(surveys.pathInBlacklist()).toBeTruthy()
+      expect(surveys.pathInBlacklist()).toBeTruthy()
+    })
 
-    it("returns true if the path is a sub-folder under /service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/service-manual/some-other-page', '/service-manual/some-other-page/');
-      expect(surveys.pathInBlacklist()).toBeTruthy();
-      expect(surveys.pathInBlacklist()).toBeTruthy();
-    });
+    it('returns true if the path is a sub-folder under /service-manual', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/service-manual/some-other-page', '/service-manual/some-other-page/')
+      expect(surveys.pathInBlacklist()).toBeTruthy()
+      expect(surveys.pathInBlacklist()).toBeTruthy()
+    })
 
-    it("returns false if the path is /service-manual-with-a-suffix", function() {
-      spyOn(surveys, 'currentPath').and.returnValues('/service-manual-with-a-suffix', '/service-manual-with-a-suffix/');
-      expect(surveys.pathInBlacklist()).toBeFalsy();
-      expect(surveys.pathInBlacklist()).toBeFalsy();
-    });
+    it('returns false if the path is /service-manual-with-a-suffix', function () {
+      spyOn(surveys, 'currentPath').and.returnValues('/service-manual-with-a-suffix', '/service-manual-with-a-suffix/')
+      expect(surveys.pathInBlacklist()).toBeFalsy()
+      expect(surveys.pathInBlacklist()).toBeFalsy()
+    })
 
-    it("returns false if the path is /some-other-parent-of/service-manual", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/some-other-parent-of/service-manual', '/some-other-parent-of/service-manual/');
-      expect(surveys.pathInBlacklist()).toBeFalsy();
-      expect(surveys.pathInBlacklist()).toBeFalsy();
-    });
+    it('returns false if the path is /some-other-parent-of/service-manual', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/some-other-parent-of/service-manual', '/some-other-parent-of/service-manual/')
+      expect(surveys.pathInBlacklist()).toBeFalsy()
+      expect(surveys.pathInBlacklist()).toBeFalsy()
+    })
 
-    it("returns false otherwise", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/');
-      expect(surveys.pathInBlacklist()).toBeFalsy();
-    });
-  });
+    it('returns false otherwise', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/')
+      expect(surveys.pathInBlacklist()).toBeFalsy()
+    })
+  })
 
-  describe("userCompletedTransaction", function() {
-    it("normally returns false", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/');
-      expect(surveys.userCompletedTransaction()).toBeFalsy();
-    });
+  describe('userCompletedTransaction', function () {
+    it('normally returns false', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/')
+      expect(surveys.userCompletedTransaction()).toBeFalsy()
+    })
 
-    it("returns true when /done", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/done');
-      expect(surveys.userCompletedTransaction()).toBeTruthy();
-    });
+    it('returns true when /done', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/done')
+      expect(surveys.userCompletedTransaction()).toBeTruthy()
+    })
 
-    it("returns true when /transaction-finished", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/transaction-finished');
-      expect(surveys.userCompletedTransaction()).toBeTruthy();
-    });
+    it('returns true when /transaction-finished', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/transaction-finished')
+      expect(surveys.userCompletedTransaction()).toBeTruthy()
+    })
 
-    it("returns true when /driving-transaction-finished", function() {
-      spyOn(surveys, 'currentPath').and.returnValue('/driving-transaction-finished');
-      expect(surveys.userCompletedTransaction()).toBeTruthy();
-    });
-  });
+    it('returns true when /driving-transaction-finished', function () {
+      spyOn(surveys, 'currentPath').and.returnValue('/driving-transaction-finished')
+      expect(surveys.userCompletedTransaction()).toBeTruthy()
+    })
+  })
 
-  describe("Event handlers", function () {
-    describe("for a url survey", function() {
-      beforeEach(function() {
-        surveys.displaySurvey(defaultSurvey);
-      });
+  describe('Event handlers', function () {
+    describe('for a url survey', function () {
+      beforeEach(function () {
+        surveys.displaySurvey(defaultSurvey)
+      })
 
       it("sets a cookie when clicking 'take survey'", function () {
-        $('#take-survey').trigger('click');
-        expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true');
-      });
+        $('#take-survey').trigger('click')
+        expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true')
+      })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click');
-        expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true');
-      });
+        $('#survey-no-thanks').trigger('click')
+        expect(GOVUK.cookie(surveys.surveyTakenCookieName(defaultSurvey))).toBe('true')
+      })
 
       it("hides the satisfaction survey bar after clicking 'take survey'", function () {
-        $('#take-survey').trigger('click');
-        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false);
-        expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('true');
-      });
+        $('#take-survey').trigger('click')
+        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
+        expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('true')
+      })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click');
-        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false);
-      });
+        $('#survey-no-thanks').trigger('click')
+        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
+      })
 
-      it("records an event when clicking 'take survey'", function() {
-        spyOn(surveys, 'trackEvent');
-        $('#take-survey').trigger('click');
-        expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_taken', 'User taken survey');
-      });
+      it("records an event when clicking 'take survey'", function () {
+        spyOn(surveys, 'trackEvent')
+        $('#take-survey').trigger('click')
+        expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_taken', 'User taken survey')
+      })
 
-      it("records an event when clicking 'no thanks'", function() {
-        spyOn(surveys, 'trackEvent');
-        $('#survey-no-thanks').trigger('click');
-        expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_no_thanks', 'No thanks clicked');
-      });
-    });
+      it("records an event when clicking 'no thanks'", function () {
+        spyOn(surveys, 'trackEvent')
+        $('#survey-no-thanks').trigger('click')
+        expect(surveys.trackEvent).toHaveBeenCalledWith(defaultSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
+      })
+    })
 
-    describe("for an email survey", function() {
+    describe('for an email survey', function () {
       var emailSurvey = {
         surveyType: 'email',
-        identifier: 'email-survey',
-      };
+        identifier: 'email-survey'
+      }
 
-      beforeEach(function() {
-        surveys.displaySurvey(emailSurvey);
-      });
+      beforeEach(function () {
+        surveys.displaySurvey(emailSurvey)
+      })
 
       it("sets a cookie when clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click');
-        expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true');
-      });
+        $('#survey-no-thanks').trigger('click')
+        expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
+      })
 
       it("hides the satisfaction survey bar after clicking 'no thanks'", function () {
-        $('#survey-no-thanks').trigger('click');
-        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false);
-      });
+        $('#survey-no-thanks').trigger('click')
+        expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
+      })
 
-      it("records an event when clicking 'no thanks'", function() {
-        spyOn(surveys, 'trackEvent');
-        $('#survey-no-thanks').trigger('click');
-        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_no_thanks', 'No thanks clicked');
-      });
+      it("records an event when clicking 'no thanks'", function () {
+        spyOn(surveys, 'trackEvent')
+        $('#survey-no-thanks').trigger('click')
+        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
+      })
 
-      it("opens the email form when clicking on 'Your feedback will help us ...'", function() {
-        $('#email-survey-open').trigger('click');
-        expect($('#email-survey-form').hasClass('js-hidden')).toBe(false);
-      });
+      it("opens the email form when clicking on 'Your feedback will help us ...'", function () {
+        $('#email-survey-open').trigger('click')
+        expect($('#email-survey-form').hasClass('js-hidden')).toBe(false)
+      })
 
-      it("hides the invitation to take the survey when clicking on 'Your feedback will help us ...'", function() {
-        $('#email-survey-open').trigger('click');
-        expect($('#email-survey-pre').hasClass('js-hidden')).toBe(true);
-      });
+      it("hides the invitation to take the survey when clicking on 'Your feedback will help us ...'", function () {
+        $('#email-survey-open').trigger('click')
+        expect($('#email-survey-pre').hasClass('js-hidden')).toBe(true)
+      })
 
-      it("records an event when clicking on 'Your feedback will help us ...'", function() {
-        spyOn(surveys, 'trackEvent');
-        $('#email-survey-open').trigger('click');
-        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_open', 'Email survey opened');
-      });
+      it("records an event when clicking on 'Your feedback will help us ...'", function () {
+        spyOn(surveys, 'trackEvent')
+        $('#email-survey-open').trigger('click')
+        expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_open', 'Email survey opened')
+      })
 
-      describe("once the email form is opened", function() {
-        it("sends the details to the feedback app with ajax when submitting the form", function() {
-          spyOn($, "ajax");
-          $('#email-survey-form').trigger('submit');
+      describe('once the email form is opened', function () {
+        it('sends the details to the feedback app with ajax when submitting the form', function () {
+          spyOn($, 'ajax')
+          $('#email-survey-form').trigger('submit')
 
-          expect($.ajax).toHaveBeenCalled();
-          var args = $.ajax.calls.mostRecent().args;
-          expect(args[0].url).toBe('/contact/govuk/email-survey-signup.js');
-        });
+          expect($.ajax).toHaveBeenCalled()
+          var args = $.ajax.calls.mostRecent().args
+          expect(args[0].url).toBe('/contact/govuk/email-survey-signup.js')
+        })
 
-        it("doesn't add .js to the form action if it's already a .js url when submitting the form", function() {
-          spyOn($, "ajax");
+        it("doesn't add .js to the form action if it's already a .js url when submitting the form", function () {
+          spyOn($, 'ajax')
           $('#email-survey-form').attr('action', '/contact/govuk/js-already/email-survey-signup.js')
-          $('#email-survey-form').trigger('submit');
+          $('#email-survey-form').trigger('submit')
 
-          expect($.ajax).toHaveBeenCalled();
-          var args = $.ajax.calls.mostRecent().args;
-          expect(args[0].url).toBe('/contact/govuk/js-already/email-survey-signup.js');
-        });
+          expect($.ajax).toHaveBeenCalled()
+          var args = $.ajax.calls.mostRecent().args
+          expect(args[0].url).toBe('/contact/govuk/js-already/email-survey-signup.js')
+        })
 
-        describe("and submitting it is a success", function() {
-          beforeEach(function() {
-            spyOn($, "ajax").and.callFake(function(options) {
+        describe('and submitting it is a success', function () {
+          beforeEach(function () {
+            spyOn($, 'ajax').and.callFake(function (options) {
               if (options.success) {
-                options.success({message: 'great success!'});
+                options.success({message: 'great success!'})
               }
-            });
-          });
+            })
+          })
 
-          it("opens the post submit success message", function() {
-            $('#email-survey-form').trigger('submit');
-            expect($('#email-survey-post-success').hasClass('js-hidden')).toBe(false);
-          });
+          it('opens the post submit success message', function () {
+            $('#email-survey-form').trigger('submit')
+            expect($('#email-survey-post-success').hasClass('js-hidden')).toBe(false)
+          })
 
-          it("hides the email form", function() {
-            $('#email-survey-form').trigger('submit');
-            expect($('#email-survey-form').hasClass('js-hidden')).toBe(true);
-          });
+          it('hides the email form', function () {
+            $('#email-survey-form').trigger('submit')
+            expect($('#email-survey-form').hasClass('js-hidden')).toBe(true)
+          })
 
-          it("sets a cookie", function () {
-            $('#email-survey-form').trigger('submit');
-            expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true');
-          });
+          it('sets a cookie', function () {
+            $('#email-survey-form').trigger('submit')
+            expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
+          })
 
-          it("records an event", function() {
-            spyOn(surveys, 'trackEvent');
-            $('#email-survey-form').trigger('submit');
-            expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_taken', 'Email survey taken');
-            expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_taken', 'User taken survey');
-          });
-        });
+          it('records an event', function () {
+            spyOn(surveys, 'trackEvent')
+            $('#email-survey-form').trigger('submit')
+            expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_taken', 'Email survey taken')
+            expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_taken', 'User taken survey')
+          })
+        })
 
-        describe("but submitting it results in an error", function() {
-          beforeEach(function() {
-            spyOn($, "ajax").and.callFake(function(options) {
-              options.error({message: 'bad error!'});
-            });
-          });
+        describe('but submitting it results in an error', function () {
+          beforeEach(function () {
+            spyOn($, 'ajax').and.callFake(function (options) {
+              options.error({message: 'bad error!'})
+            })
+          })
 
-          it("opens the post submit failure message", function() {
-            $('#email-survey-form').trigger('submit');
-            expect($('#email-survey-post-failure').hasClass('js-hidden')).toBe(false);
-          });
+          it('opens the post submit failure message', function () {
+            $('#email-survey-form').trigger('submit')
+            expect($('#email-survey-post-failure').hasClass('js-hidden')).toBe(false)
+          })
 
-          it("hides the email form", function() {
-            $('#email-survey-form').trigger('submit');
-            expect($('#email-survey-form').hasClass('js-hidden')).toBe(true);
-          });
+          it('hides the email form', function () {
+            $('#email-survey-form').trigger('submit')
+            expect($('#email-survey-form').hasClass('js-hidden')).toBe(true)
+          })
 
-          it("does not sets a cookie", function () {
-            $('#email-survey-form').trigger('submit');
-            expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).not.toBe('true');
-          });
+          it('does not sets a cookie', function () {
+            $('#email-survey-form').trigger('submit')
+            expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).not.toBe('true')
+          })
 
-          it("does not records any events", function() {
-            spyOn(surveys, 'trackEvent');
-            $('#email-survey-form').trigger('submit');
-            expect(surveys.trackEvent).not.toHaveBeenCalled();
-          });
-        });
+          it('does not records any events', function () {
+            spyOn(surveys, 'trackEvent')
+            $('#email-survey-form').trigger('submit')
+            expect(surveys.trackEvent).not.toHaveBeenCalled()
+          })
+        })
 
-        it("hides the email form when clicking 'No thanks'", function() {
-          $('#email-survey-cancel').trigger('click');
-          expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true');
-        });
+        it("hides the email form when clicking 'No thanks'", function () {
+          $('#email-survey-cancel').trigger('click')
+          expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
+        })
 
         it("hides the whole email survey interface after clicking 'no thanks'", function () {
-          $('#email-survey-cancel').trigger('click');
-          expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false);
-        });
+          $('#email-survey-cancel').trigger('click')
+          expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
+        })
 
-        it("records an event when clicking 'no thanks'", function() {
-          spyOn(surveys, 'trackEvent');
-          $('#email-survey-cancel').trigger('click');
-          expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_cancel', 'Email survey cancelled');
-        });
-      });
-    });
-  });
+        it("records an event when clicking 'no thanks'", function () {
+          spyOn(surveys, 'trackEvent')
+          $('#email-survey-cancel').trigger('click')
+          expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_cancel', 'Email survey cancelled')
+        })
+      })
+    })
+  })
 
-  describe("currentTime", function() {
-    it("actually returns a value from `currentTime`", function() {
-      expect(surveys.currentTime()).not.toBe(undefined);
-    });
-  });
+  describe('currentTime', function () {
+    it('actually returns a value from `currentTime`', function () {
+      expect(surveys.currentTime()).not.toBe(undefined)
+    })
+  })
 
-  describe("surveyTakenCookieName", function() {
-    it("returns a cookie name based on the survey identifier", function() {
+  describe('surveyTakenCookieName', function () {
+    it('returns a cookie name based on the survey identifier', function () {
       var surveyMock = {identifier: 'sample_survey'}
-      expect(surveys.surveyTakenCookieName(surveyMock)).toBe('govuk_takenSampleSurvey');
-    });
-  });
+      expect(surveys.surveyTakenCookieName(surveyMock)).toBe('govuk_takenSampleSurvey')
+    })
+  })
 
-  describe("getActiveSurvey", function() {
-    it("returns the default survey when no smallSurveys are present", function() {
-      var smallSurveys = [smallSurvey];
+  describe('getActiveSurvey', function () {
+    it('returns the default survey when no smallSurveys are present', function () {
+      var smallSurveys = [smallSurvey]
 
-      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys);
-      expect(activeSurvey).toBe(defaultSurvey);
-    });
+      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys)
+      expect(activeSurvey).toBe(defaultSurvey)
+    })
 
-    it("returns the default survey when a smallSurvey is not active", function() {
-      var smallSurveys = [smallSurvey];
-      spyOn(surveys, 'currentTime').and.returnValue(new Date("July 11, 2016 10:00:00").getTime());
+    it('returns the default survey when a smallSurvey is not active', function () {
+      var smallSurveys = [smallSurvey]
+      spyOn(surveys, 'currentTime').and.returnValue(new Date('July 11, 2016 10:00:00').getTime())
 
-      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys);
-      expect(activeSurvey).toBe(defaultSurvey);
-    });
+      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys)
+      expect(activeSurvey).toBe(defaultSurvey)
+    })
 
-    it("returns the small survey when a smallSurvey is active", function() {
-      var smallSurveys = [smallSurvey];
-      spyOn(surveys, 'currentTime').and.returnValue(new Date("July 9, 2016 10:00:00").getTime());
+    it('returns the small survey when a smallSurvey is active', function () {
+      var smallSurveys = [smallSurvey]
+      spyOn(surveys, 'currentTime').and.returnValue(new Date('July 9, 2016 10:00:00').getTime())
 
-      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys);
-      expect(activeSurvey).toBe(smallSurvey);
-    });
+      var activeSurvey = surveys.getActiveSurvey(defaultSurvey, smallSurveys)
+      expect(activeSurvey).toBe(smallSurvey)
+    })
 
-    describe("activeWhen function call", function() {
-      it("returns the test survey when the callback returns true", function() {
-        spyOn(surveys, 'currentTime').and.returnValue(new Date("July 9, 2016 10:00:00").getTime());
+    describe('activeWhen function call', function () {
+      it('returns the test survey when the callback returns true', function () {
+        spyOn(surveys, 'currentTime').and.returnValue(new Date('July 9, 2016 10:00:00').getTime())
         var testSurvey = {
-          startTime: new Date("July 5, 2016").getTime(),
-          endTime: new Date("July 10, 2016 23:50:00").getTime(),
-          activeWhen: function() { return true; },
+          startTime: new Date('July 5, 2016').getTime(),
+          endTime: new Date('July 10, 2016 23:50:00').getTime(),
+          activeWhen: function () { return true },
           url: 'example.com/small-survey'
-        };
+        }
 
-        var activeSurvey = surveys.getActiveSurvey(defaultSurvey, [testSurvey]);
-        expect(activeSurvey).toBe(testSurvey);
-      });
+        var activeSurvey = surveys.getActiveSurvey(defaultSurvey, [testSurvey])
+        expect(activeSurvey).toBe(testSurvey)
+      })
 
-      it("returns the default when the callback returns false", function() {
-        spyOn(surveys, 'currentTime').and.returnValue(new Date("July 9, 2016 10:00:00").getTime());
+      it('returns the default when the callback returns false', function () {
+        spyOn(surveys, 'currentTime').and.returnValue(new Date('July 9, 2016 10:00:00').getTime())
         var testSurvey = {
-          startTime: new Date("July 5, 2016").getTime(),
-          endTime: new Date("July 10, 2016 23:50:00").getTime(),
-          activeWhen: function() { return false; },
+          startTime: new Date('July 5, 2016').getTime(),
+          endTime: new Date('July 10, 2016 23:50:00').getTime(),
+          activeWhen: function () { return false },
           url: 'example.com/small-survey'
-        };
+        }
 
-        var activeSurvey = surveys.getActiveSurvey(defaultSurvey, [testSurvey]);
-        expect(activeSurvey).toBe(defaultSurvey);
-      });
-    });
-  });
-});
+        var activeSurvey = surveys.getActiveSurvey(defaultSurvey, [testSurvey])
+        expect(activeSurvey).toBe(defaultSurvey)
+      })
+    })
+  })
+})

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -392,6 +392,22 @@ describe('Surveys', function () {
           $('#email-survey-cancel').trigger('click')
           expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_cancel', 'Email survey cancelled')
         })
+
+        it("hides the email form when clicking 'take survey' if no email", function () {
+          $('#take-survey').trigger('click')
+          expect(GOVUK.cookie(surveys.surveyTakenCookieName(emailSurvey))).toBe('true')
+        })
+
+        it("hides the whole email survey interface after clicking 'take survey' if no email", function () {
+          $('#take-survey').trigger('click')
+          expect($('#user-satisfaction-survey').hasClass('visible')).toBe(false)
+        })
+
+        it("records an event when clicking 'take survey' if no email", function () {
+          spyOn(surveys, 'trackEvent')
+          $('#take-survey').trigger('click')
+          expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'no_email_link', 'User taken survey via no email link')
+        })
       })
     })
   })


### PR DESCRIPTION
This has been tested in VoiceOver for OSX, and will be talked through with the Accessibility team next Monday.

* Allows users of assistive technology to use the survey email form by ensuring context is kept and focus is moved around when interacting
* Restyles survey based on @markhurrell 's designs
* Lints JavaScript with Standard
* Simplifies CSS to be closer to the GOV.UK Publishing Component structure
* Changes 'no thanks' to close with additional labelling to provide better context
* Persists the section title between views to keep context of what the form is for

URL

![screen shot 2017-06-02 at 15 20 54](https://cloud.githubusercontent.com/assets/2445413/26729939/3cfc47ca-47a7-11e7-87bf-25ebbfcd3be5.png)

Email

![screen shot 2017-06-02 at 15 21 06](https://cloud.githubusercontent.com/assets/2445413/26729940/3cfce554-47a7-11e7-8ee0-421310b8d226.png)
![screen shot 2017-06-02 at 15 21 10](https://cloud.githubusercontent.com/assets/2445413/26729938/3cfbd010-47a7-11e7-8a18-c60e9ec60a2f.png)
![screen shot 2017-06-02 at 15 21 14](https://cloud.githubusercontent.com/assets/2445413/26729941/3cfd79ec-47a7-11e7-84d3-d22e1af169ea.png)


Realise this a big diff so I'm willing to try and reduce the amount of changes if it's too hard to review as is.

Best reviewed commit by commit, to reduce whitespace updates you can use the 'w' flag: https://github.com/alphagov/static/pull/1066/files?w=1

Trello card here: https://trello.com/c/NYmzuNk0/69-2-govuk-survey-banner---make-accessible