### PR TITLE
Fix for sticky contents link overlap issue

### DIFF
--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -46,7 +46,7 @@
         setInterval(checkScroll, _interval);
         checkResize();
         checkScroll();
-        $element.addClass('govuk-sticky-element');
+        $element.addClass('enabled');
       }
 
       function onResize () {
@@ -98,21 +98,21 @@
       }
 
       function stickToWindow () {
-        $element.addClass('govuk-sticky-element--stuck-to-window');
-        $element.removeClass('govuk-sticky-element--stuck-to-parent');
+        $element.addClass('enabled--stuck-to-window');
+        $element.removeClass('enabled--stuck-to-parent');
       }
 
       function stickToParent () {
-        $element.addClass('govuk-sticky-element--stuck-to-parent');
-        $element.removeClass('govuk-sticky-element--stuck-to-window');
+        $element.addClass('enabled--stuck-to-parent');
+        $element.removeClass('enabled--stuck-to-window');
       }
 
       function show () {
-        $element.removeClass('govuk-sticky-element--hidden');
+        $element.removeClass('enabled--hidden');
       }
 
       function hide () {
-        $element.addClass('govuk-sticky-element--hidden');
+        $element.addClass('enabled--hidden');
       }
     };
   };

--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -99,11 +99,9 @@
 
       function stickToWindow () {
         $element.addClass('govuk-sticky-element--stuck-to-window');
-        $element.removeClass('govuk-sticky-element--stuck-to-parent');
       }
 
       function stickToParent () {
-        $element.addClass('govuk-sticky-element--stuck-to-parent');
         $element.removeClass('govuk-sticky-element--stuck-to-window');
       }
 

--- a/app/assets/javascripts/modules/sticky-element-container.js
+++ b/app/assets/javascripts/modules/sticky-element-container.js
@@ -46,7 +46,7 @@
         setInterval(checkScroll, _interval);
         checkResize();
         checkScroll();
-        $element.addClass('enabled');
+        $element.addClass('govuk-sticky-element--enabled');
       }
 
       function onResize () {
@@ -98,21 +98,21 @@
       }
 
       function stickToWindow () {
-        $element.addClass('enabled--stuck-to-window');
-        $element.removeClass('enabled--stuck-to-parent');
+        $element.addClass('govuk-sticky-element--stuck-to-window');
+        $element.removeClass('govuk-sticky-element--stuck-to-parent');
       }
 
       function stickToParent () {
-        $element.addClass('enabled--stuck-to-parent');
-        $element.removeClass('enabled--stuck-to-window');
+        $element.addClass('govuk-sticky-element--stuck-to-parent');
+        $element.removeClass('govuk-sticky-element--stuck-to-window');
       }
 
       function show () {
-        $element.removeClass('enabled--hidden');
+        $element.removeClass('govuk-sticky-element--hidden');
       }
 
       function hide () {
-        $element.addClass('enabled--hidden');
+        $element.addClass('govuk-sticky-element--hidden');
       }
     };
   };

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication-print.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication-print.scss
@@ -1,5 +1,5 @@
 .govuk-govspeak-html-publication {
-  .sticky-element {
+  .govuk-sticky-element {
     display: none;
   }
 }

--- a/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak-html-publication.scss
@@ -195,7 +195,7 @@
     // scss-lint:enable QualifyingElement
   }
 
-  .sticky-element {
+  .govuk-sticky-element {
     clear: both;
   }
 }

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -1,8 +1,8 @@
-.sticky-element {
+.govuk-sticky-element {
   position: absolute;
   bottom: 0;
 
-  &.govuk-sticky-element {
+  &.enabled {
     @include transition (opacity, .3s, ease);
     opacity: 1;
 

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -2,6 +2,16 @@
   position: absolute;
   bottom: 0;
 
+  &--stuck-to-parent {
+    bottom: 0;
+    position: absolute;
+  }
+
+  &--stuck-to-window {
+    bottom: 0;
+    position: fixed;
+  }
+
   &--enabled {
     @include transition (opacity, .3s, ease);
     opacity: 1;
@@ -21,15 +31,4 @@
       left: -9999em;
     }
   }
-
-  &--stuck-to-parent {
-    bottom: 0;
-    position: absolute;
-  }
-
-  &--stuck-to-window {
-    bottom: 0;
-    position: fixed;
-  }
-
 }

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -2,33 +2,34 @@
   position: absolute;
   bottom: 0;
 
-  &.enabled {
+  &--enabled {
     @include transition (opacity, .3s, ease);
     opacity: 1;
-
-    &--hidden {
-      opacity: 0;
-      pointer-events: none;
-
-      @include ie-lte(8) {
-        // XXX: Would be nice to `@include .visuallyhidden`.
-        position: absolute;
-        left: -9999em;
-      }
-    }
-
-    &--stuck-to-parent {
-      bottom: 0;
-      position: absolute;
-    }
-
-    &--stuck-to-window {
-      bottom: 0;
-      position: fixed;
-    }
 
     @include media(mobile) {
       position: static;
     }
   }
+
+  &--hidden {
+    opacity: 0;
+    pointer-events: none;
+
+    @include ie-lte(8) {
+      // XXX: Would be nice to `@include .visuallyhidden`.
+      position: absolute;
+      left: -9999em;
+    }
+  }
+
+  &--stuck-to-parent {
+    bottom: 0;
+    position: absolute;
+  }
+
+  &--stuck-to-window {
+    bottom: 0;
+    position: fixed;
+  }
+
 }

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -1,11 +1,6 @@
-.govuk-sticky-element {
+.js-enabled .govuk-sticky-element {
   position: absolute;
   bottom: 0;
-
-  &--stuck-to-parent {
-    bottom: 0;
-    position: absolute;
-  }
 
   &--stuck-to-window {
     bottom: 0;
@@ -31,4 +26,5 @@
       left: -9999em;
     }
   }
+
 }

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -1,29 +1,34 @@
-.govuk-sticky-element {
-  @include transition (opacity, .3s, ease);
-  opacity: 1;
+.sticky-element {
+  position: absolute;
+  bottom: 0;
 
-  &--hidden {
-    opacity: 0;
-    pointer-events: none;
+  &.govuk-sticky-element {
+    @include transition (opacity, .3s, ease);
+    opacity: 1;
 
-    @include ie-lte(8) {
-      // XXX: Would be nice to `@include .visuallyhidden`.
-      position: absolute;
-      left: -9999em;
+    &--hidden {
+      opacity: 0;
+      pointer-events: none;
+
+      @include ie-lte(8) {
+        // XXX: Would be nice to `@include .visuallyhidden`.
+        position: absolute;
+        left: -9999em;
+      }
     }
-  }
 
-  &--stuck-to-parent {
-    bottom: 0;
-    position: absolute;
-  }
+    &--stuck-to-parent {
+      bottom: 0;
+      position: absolute;
+    }
 
-  &--stuck-to-window {
-    bottom: 0;
-    position: fixed;
-  }
+    &--stuck-to-window {
+      bottom: 0;
+      position: fixed;
+    }
 
-  @include media(mobile) {
-    position: static;
+    @include media(mobile) {
+      position: static;
+    }
   }
 }

--- a/app/views/govuk_component/govspeak_html_publication.raw.html.erb
+++ b/app/views/govuk_component/govspeak_html_publication.raw.html.erb
@@ -14,7 +14,7 @@
 >
   <%= render file: 'govuk_component/govspeak.raw', locals: govspeak_locals %>
   <% if sticky_footer_html %>
-    <div data-sticky-element class="sticky-element">
+    <div data-sticky-element class="govuk-sticky-element">
       <%= raw sticky_footer_html %>
     </div>
   <% end %>

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -35,7 +35,7 @@ describe('A sticky-element-container module', function () {
       it('hides the element, when scrolled at the top', function () {
         instance.start($element);
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(true);
+        expect($footer.hasClass('enabled--hidden')).toBe(true);
       });
 
       it('shows the element, stuck to the window, when scrolled in the middle', function () {
@@ -46,9 +46,9 @@ describe('A sticky-element-container module', function () {
         };
         instance.start($element);
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
+        expect($footer.hasClass('enabled--hidden')).toBe(false);
+        expect($footer.hasClass('enabled--stuck-to-window')).toBe(true);
+        expect($footer.hasClass('enabled--stuck-to-parent')).toBe(false);
       });
 
       it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
@@ -59,9 +59,9 @@ describe('A sticky-element-container module', function () {
         };
         instance.start($element);
 
-        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(true);
+        expect($footer.hasClass('enabled--hidden')).toBe(false);
+        expect($footer.hasClass('enabled--stuck-to-window')).toBe(false);
+        expect($footer.hasClass('enabled--stuck-to-parent')).toBe(true);
       });
     });
   });

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -35,7 +35,7 @@ describe('A sticky-element-container module', function () {
       it('hides the element, when scrolled at the top', function () {
         instance.start($element);
 
-        expect($footer.hasClass('enabled--hidden')).toBe(true);
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(true);
       });
 
       it('shows the element, stuck to the window, when scrolled in the middle', function () {
@@ -46,9 +46,9 @@ describe('A sticky-element-container module', function () {
         };
         instance.start($element);
 
-        expect($footer.hasClass('enabled--hidden')).toBe(false);
-        expect($footer.hasClass('enabled--stuck-to-window')).toBe(true);
-        expect($footer.hasClass('enabled--stuck-to-parent')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
       });
 
       it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
@@ -59,9 +59,9 @@ describe('A sticky-element-container module', function () {
         };
         instance.start($element);
 
-        expect($footer.hasClass('enabled--hidden')).toBe(false);
-        expect($footer.hasClass('enabled--stuck-to-window')).toBe(false);
-        expect($footer.hasClass('enabled--stuck-to-parent')).toBe(true);
+        expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
+        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(true);
       });
     });
   });

--- a/spec/javascripts/modules/sticky-element-container.spec.js
+++ b/spec/javascripts/modules/sticky-element-container.spec.js
@@ -48,7 +48,6 @@ describe('A sticky-element-container module', function () {
 
         expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
         expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(true);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(false);
       });
 
       it('shows the element, stuck to the parent, when scrolled at the bottom', function () {
@@ -61,7 +60,6 @@ describe('A sticky-element-container module', function () {
 
         expect($footer.hasClass('govuk-sticky-element--hidden')).toBe(false);
         expect($footer.hasClass('govuk-sticky-element--stuck-to-window')).toBe(false);
-        expect($footer.hasClass('govuk-sticky-element--stuck-to-parent')).toBe(true);
       });
     });
   });


### PR DESCRIPTION
* At foot of page was possible to get 'Contents' fixed position link to briefly overlap content below it
* Problem was due to height of parent element including height of Contents link, then changing after it was set to position fixed
* Fixed by defaulting Contents link to position absolute so it never adds any height to the parent

Relates to https://github.com/alphagov/government-frontend/pull/367