### PR TITLE
Add ecommerce search results plugin

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -7,6 +7,7 @@
 //= require govuk/analytics/external-link-tracker
 //= require govuk/analytics/download-link-tracker
 
+//= require analytics/custom-dimensions
 //= require analytics/static-analytics
 //= require analytics/ecommerce
 //= require analytics/init

--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -8,5 +8,6 @@
 //= require govuk/analytics/download-link-tracker
 
 //= require analytics/static-analytics
+//= require analytics/ecommerce
 //= require analytics/init
 //= require analytics/scroll-tracker

--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -1,0 +1,132 @@
+(function () {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+  var CustomDimensions = function () { }
+
+  CustomDimensions.getAndExtendDefaultTrackingOptions = function (extraOptions) {
+    var trackingOptions = this.customDimensions();
+    return $.extend(trackingOptions, extraOptions);
+  };
+
+  CustomDimensions.customDimensions = function () {
+    var dimensions = $.extend(
+      {},
+      customDimensionsFromBrowser(),
+      customDimensionsFromMetaTags(),
+      customDimensionsFromDom(),
+      abTestCustomDimensions()
+    );
+
+    return $.each(dimensions, function (key, value) {
+      dimensions[key] = String(value);
+    });
+  };
+
+  function customDimensionsFromBrowser() {
+    var customDimensions = {
+      dimension15: window.httpStatusCode || 200,
+      dimension16: GOVUK.cookie('TLSversion') || 'unknown'
+    };
+
+    if (window.devicePixelRatio) {
+      customDimensions.dimension11 = window.devicePixelRatio;
+    }
+
+    return customDimensions;
+  }
+
+  function customDimensionsFromMetaTags() {
+    var dimensionMappings = {
+      'section': {dimension: 1},
+      'format': {dimension: 2},
+      'themes': {dimension: 3, defaultValue: 'other'},
+      'content-id': {dimension: 4, defaultValue: '00000000-0000-0000-0000-000000000000'},
+      'search-result-count': {dimension: 5},
+      'publishing-government': {dimension: 6},
+      'political-status': {dimension: 7},
+      'analytics:organisations': {dimension: 9},
+      'analytics:world-locations': {dimension: 10},
+      'schema-name': {dimension: 17},
+      'rendering-application': {dimension: 20},
+      'navigation-page-type': {dimension: 32, defaultValue: 'none'},
+      'user-journey-stage': {dimension: 33, defaultValue: 'thing'},
+      'navigation-document-type': {dimension: 34, defaultValue: 'other'},
+      'taxon-slug': {dimension: 56, defaultValue: 'other'},
+      'taxon-id': {dimension: 57, defaultValue: 'other'},
+      'taxon-slugs': {dimension: 58, defaultValue: 'other'},
+      'taxon-ids': {dimension: 59, defaultValue: 'other'},
+      'content-has-history': {dimension: 39, defaultValue: 'false'}
+    };
+
+    var $metas = $('meta[name^="govuk:"]');
+    var customDimensions = {};
+    var tags = {};
+
+    $metas.each(function () {
+      var $meta = $(this);
+      var key = $meta.attr('name').split('govuk:')[1];
+
+      var dimension = dimensionMappings[key];
+      if (dimension) {
+        tags[key] = $meta.attr('content');
+      }
+    });
+
+    $.each(dimensionMappings, function (key, dimension) {
+      var value = tags[key] || dimension.defaultValue;
+      if (typeof value !== 'undefined') {
+        customDimensions['dimension' + dimension.dimension] = value;
+      }
+    });
+
+    return customDimensions;
+  }
+
+  function customDimensionsFromDom() {
+    return {
+      dimension26: totalNumberOfSections(),
+      dimension27: totalNumberOfSectionLinks()
+    };
+
+    function totalNumberOfSections() {
+      var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
+      var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
+      var accordionSubsections = $('[data-track-count="accordionSection"]').length;
+      var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
+      var browsePageSections = $('#subsection ul:visible').length ||
+        $('#section ul').length;
+      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections || browsePageSections;
+    }
+
+    function totalNumberOfSectionLinks() {
+      var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
+      var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
+      // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
+      var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
+        + $('a[data-track-category="navGridLeafLinkClicked"]').length;
+      var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
+      var browsePageLinks = $('#subsection ul a:visible').length ||
+        $('#section ul a').length;
+      return relatedLinks || accordionLinks || gridLinks || leafLinks || browsePageLinks;
+    }
+  }
+
+  function abTestCustomDimensions() {
+    var $abMetas = $('meta[name^="govuk:ab-test"]');
+    var customDimensions = {};
+
+    $abMetas.each(function () {
+      var $meta = $(this);
+      var dimension = parseInt($meta.data('analytics-dimension'));
+      var testNameAndBucket = $meta.attr('content');
+
+      if(dimension) {
+        customDimensions['dimension' + dimension] = testNameAndBucket;
+      }
+    });
+
+    return customDimensions;
+  }
+
+  GOVUK.CustomDimensions = CustomDimensions;
+})();

--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -41,7 +41,9 @@
         });
 
         ga('ec:setAction', 'click', {list: 'Site search results'});
-        ga('send', 'event', 'UX', 'click', 'Results');
+        ga('send', 'event', 'UX', 'click', 'Results',
+          GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions({})
+        );
       })
     }
   }
@@ -49,7 +51,6 @@
   Ecommerce.ecLoaded = false;
   Ecommerce.start = function (element) {
     element = element || $('[data-analytics-ecommerce]');
-
     if(element.length > 0) {
       if(!Ecommerce.ecLoaded) {
         ga('require', 'ec');

--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -1,0 +1,65 @@
+(function () {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  var Ecommerce = function (config) {
+    this.init = function (element) {
+      this.forEachEcommerceRow(element, this._sendImpression);
+      this.forEachEcommerceRow(element, this._trackProductClick);
+    }
+
+    this.forEachEcommerceRow = function (element, fct) {
+      var ecommerceRowCss = '[data-ecommerce-row]';
+      var ecommerceRows = element.find(ecommerceRowCss);
+      var startPosition = parseInt(element.data('ecommerce-start-index'));
+
+      ecommerceRows.each(function(index, ecommerceRow) {
+        var $ecommerceRow = $(ecommerceRow);
+
+        var contentId = $ecommerceRow.attr('data-ecommerce-content-id'),
+          path = $ecommerceRow.attr('data-ecommerce-path');
+
+        fct($ecommerceRow, contentId, path, index + startPosition);
+      });
+    }
+
+    this._sendImpression = function (_row, contentId, path, position) {
+      // We only send the id to GA as additional product data is linked when it is uploaded.
+      // This approach is taken to avoid the GA data packet exceeding the 8k limit
+      ga('ec:addImpression', {
+        id: contentId || path,
+        position: position,
+        list: 'Site search results'
+      });
+    }
+
+    this._trackProductClick = function (row, contentId, path, position) {
+      row.click(function(event) {
+        ga('ec:addProduct', {
+          id: contentId || path,
+          position: position
+        });
+
+        ga('ec:setAction', 'click', {list: 'Site search results'});
+        ga('send', 'event', 'UX', 'click', 'Results');
+      })
+    }
+  }
+
+  Ecommerce.ecLoaded = false;
+  Ecommerce.start = function (element) {
+    element = element || $('[data-analytics-ecommerce]');
+
+    if(element.length > 0) {
+      if(!Ecommerce.ecLoaded) {
+        ga('require', 'ec');
+        Ecommerce.ecLoaded = true;
+      }
+      var ecommerce = new Ecommerce();
+      ecommerce.init(element);
+    }
+  }
+
+  window.GOVUK.Ecommerce = Ecommerce;
+  window.GOVUK.StaticAnalytics.beforeTrackPage = Ecommerce.start;
+})()

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -28,9 +28,7 @@
   };
 
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
-    if(StaticAnalytics.beforeTrackPage) {
-      StaticAnalytics.beforeTrackPage();
-    }
+    GOVUK.Ecommerce.start();
     var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
   };

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -1,7 +1,6 @@
 (function () {
   "use strict";
   window.GOVUK = window.GOVUK || {};
-
   var StaticAnalytics = function (config) {
 
     // Create universal tracker
@@ -29,6 +28,9 @@
   };
 
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
+    if(StaticAnalytics.beforeTrackPage) {
+      StaticAnalytics.beforeTrackPage();
+    }
     var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
   };

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -31,12 +31,12 @@
     if(StaticAnalytics.beforeTrackPage) {
       StaticAnalytics.beforeTrackPage();
     }
-    var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
+    var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
   };
 
   StaticAnalytics.prototype.trackEvent = function (category, action, options) {
-    var trackingOptions = this.getAndExtendDefaultTrackingOptions(options);
+    var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackEvent(category, action, trackingOptions);
   };
 
@@ -49,26 +49,12 @@
   };
 
   StaticAnalytics.prototype.trackShare = function (network) {
-    var trackingOptions = this.getAndExtendDefaultTrackingOptions();
+    var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions();
     this.analytics.trackShare(network, trackingOptions);
   };
 
   StaticAnalytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain) {
     this.analytics.addLinkedTrackerDomain(trackerId, name, domain);
-  };
-
-  StaticAnalytics.prototype.customDimensions = function () {
-    var dimensions = $.extend(
-      {},
-      customDimensionsFromBrowser(),
-      customDimensionsFromMetaTags(),
-      customDimensionsFromDom(),
-      abTestCustomDimensions()
-    );
-
-    return $.each(dimensions, function (key, value) {
-      dimensions[key] = String(value);
-    });
   };
 
   StaticAnalytics.prototype.setOptionsForNextPageview = function (options) {
@@ -107,117 +93,6 @@
       return null;
     }
   };
-
-  StaticAnalytics.prototype.getAndExtendDefaultTrackingOptions = function (extraOptions) {
-    var trackingOptions = this.customDimensions();
-    return $.extend(trackingOptions, extraOptions);
-  };
-
-  function customDimensionsFromBrowser() {
-    var customDimensions = {
-      dimension15: window.httpStatusCode || 200,
-      dimension16: GOVUK.cookie('TLSversion') || 'unknown'
-    };
-
-    if (window.devicePixelRatio) {
-      customDimensions.dimension11 = window.devicePixelRatio;
-    }
-
-    return customDimensions;
-  }
-
-  function customDimensionsFromMetaTags() {
-    var dimensionMappings = {
-      'section': {dimension: 1},
-      'format': {dimension: 2},
-      'themes': {dimension: 3, defaultValue: 'other'},
-      'content-id': {dimension: 4, defaultValue: '00000000-0000-0000-0000-000000000000'},
-      'search-result-count': {dimension: 5},
-      'publishing-government': {dimension: 6},
-      'political-status': {dimension: 7},
-      'analytics:organisations': {dimension: 9},
-      'analytics:world-locations': {dimension: 10},
-      'schema-name': {dimension: 17},
-      'rendering-application': {dimension: 20},
-      'navigation-page-type': {dimension: 32, defaultValue: 'none'},
-      'user-journey-stage': {dimension: 33, defaultValue: 'thing'},
-      'navigation-document-type': {dimension: 34, defaultValue: 'other'},
-      'taxon-slug': {dimension: 56, defaultValue: 'other'},
-      'taxon-id': {dimension: 57, defaultValue: 'other'},
-      'taxon-slugs': {dimension: 58, defaultValue: 'other'},
-      'taxon-ids': {dimension: 59, defaultValue: 'other'},
-      'content-has-history': {dimension: 39, defaultValue: 'false'}
-    };
-
-    var $metas = $('meta[name^="govuk:"]');
-    var customDimensions = {};
-    var tags = {};
-
-    $metas.each(function () {
-      var $meta = $(this);
-      var key = $meta.attr('name').split('govuk:')[1];
-
-      var dimension = dimensionMappings[key];
-      if (dimension) {
-        tags[key] = $meta.attr('content');
-      }
-    });
-
-    $.each(dimensionMappings, function (key, dimension) {
-      var value = tags[key] || dimension.defaultValue;
-      if (typeof value !== 'undefined') {
-        customDimensions['dimension' + dimension.dimension] = value;
-      }
-    });
-
-    return customDimensions;
-  }
-
-  function customDimensionsFromDom() {
-    return {
-      dimension26: totalNumberOfSections(),
-      dimension27: totalNumberOfSectionLinks()
-    };
-
-    function totalNumberOfSections() {
-      var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
-      var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
-      var accordionSubsections = $('[data-track-count="accordionSection"]').length;
-      var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
-      var browsePageSections = $('#subsection ul:visible').length ||
-        $('#section ul').length;
-      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections || browsePageSections;
-    }
-
-    function totalNumberOfSectionLinks() {
-      var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
-      var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
-      // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
-      var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
-        + $('a[data-track-category="navGridLeafLinkClicked"]').length;
-      var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
-      var browsePageLinks = $('#subsection ul a:visible').length ||
-        $('#section ul a').length;
-      return relatedLinks || accordionLinks || gridLinks || leafLinks || browsePageLinks;
-    }
-  }
-
-  function abTestCustomDimensions() {
-    var $abMetas = $('meta[name^="govuk:ab-test"]');
-    var customDimensions = {};
-
-    $abMetas.each(function () {
-      var $meta = $(this);
-      var dimension = parseInt($meta.data('analytics-dimension'));
-      var testNameAndBucket = $meta.attr('content');
-
-      if(dimension) {
-        customDimensions['dimension' + dimension] = testNameAndBucket;
-      }
-    });
-
-    return customDimensions;
-  }
 
   function getOptionsFromCookie() {
     try {

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -1,0 +1,151 @@
+describe('Ecommerce reporter for results pages', function() {
+  "use strict";
+
+  var ecommerce,
+      element;
+
+  beforeEach(function() {
+    ecommerce = new GOVUK.Ecommerce();
+    spyOn(window, 'ga')
+  });
+
+  it('tracks ecommerce rows', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      position: 1,
+      list: 'Site search results'
+    });
+  });
+
+  it('falls back to the path if the content id is not set', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id=""\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: '/path/to/page',
+      position: 1,
+      list: 'Site search results'
+    });
+  });
+
+  it('falls back to the path if the content id is not present', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: '/path/to/page',
+      position: 1,
+      list: 'Site search results'
+    });
+  });
+
+  it('will use the pagination offset start value', function() {
+    element = $('\
+      <div data-ecommerce-start-index="21">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      position: 21,
+      list: 'Site search results'
+    });
+  });
+
+  it('will send data for multiple rows', function(){
+    element = $('\
+      <div data-ecommerce-start-index="1">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </div>\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/a/different/page"\
+          data-ecommerce-content-id="BBBB-2222"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      position: 1,
+      list: 'Site search results'
+    });
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'BBBB-2222',
+      position: 2,
+      list: 'Site search results'
+    });
+  });
+
+  it('tracks clicks on search results', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1">\
+        <a \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </a>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+    element.find('[data-ecommerce-row]').click()
+
+    expect(ga).toHaveBeenCalledWith('ec:addProduct', {
+      id: 'AAAA-1111',
+      position: 1
+    });
+    expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Site search results'})
+    expect(ga).toHaveBeenCalledWith('send', 'event', 'UX', 'click', 'Results')
+  });
+
+  it('will only require the ec library once', function() {
+    GOVUK.Ecommerce.ecLoaded = false;
+    GOVUK.Ecommerce.start($('<div></div>'));
+    GOVUK.Ecommerce.start($('<div></div>'));
+
+    expect(ga).toHaveBeenCalledWith('require', 'ec');
+    expect(ga.calls.count()).toEqual(1);
+  });
+});

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -130,14 +130,30 @@ describe('Ecommerce reporter for results pages', function() {
     ');
 
     ecommerce.init(element);
-    element.find('[data-ecommerce-row]').click()
+    element.find('[data-ecommerce-row]').click();
 
     expect(ga).toHaveBeenCalledWith('ec:addProduct', {
       id: 'AAAA-1111',
       position: 1
     });
     expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Site search results'})
-    expect(ga).toHaveBeenCalledWith('send', 'event', 'UX', 'click', 'Results')
+    expect(ga).toHaveBeenCalledWith('send', 'event', 'UX', 'click', 'Results', {
+      dimension15: '200',
+      dimension16: 'unknown',
+      dimension11: '1',
+      dimension3: 'other',
+      dimension4: '00000000-0000-0000-0000-000000000000',
+      dimension32: 'none',
+      dimension33: 'thing',
+      dimension34: 'other',
+      dimension56: 'other',
+      dimension57: 'other',
+      dimension58: 'other',
+      dimension59: 'other',
+      dimension39: 'false',
+      dimension26: '0',
+      dimension27: '0',
+    })
   });
 
   it('will only require the ec library once', function() {

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -11,7 +11,7 @@ describe('Ecommerce reporter for results pages', function() {
 
   it('tracks ecommerce rows', function() {
     element = $('\
-      <div data-ecommerce-start-index="1">\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
         <div \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -25,13 +25,14 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
       position: 1,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
   });
 
   it('falls back to the path if the content id is not set', function() {
     element = $('\
-      <div data-ecommerce-start-index="1">\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
         <div \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -45,13 +46,14 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: '/path/to/page',
       position: 1,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
   });
 
   it('falls back to the path if the content id is not present', function() {
     element = $('\
-      <div data-ecommerce-start-index="1">\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
         <div \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -64,13 +66,14 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: '/path/to/page',
       position: 1,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
   });
 
   it('will use the pagination offset start value', function() {
     element = $('\
-      <div data-ecommerce-start-index="21">\
+      <div data-ecommerce-start-index="21" data-search-query="search query">\
         <div \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -84,13 +87,14 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
       position: 21,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
   });
 
   it('will send data for multiple rows', function(){
     element = $('\
-      <div data-ecommerce-start-index="1">\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
         <div \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -109,18 +113,20 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
       position: 1,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'BBBB-2222',
       position: 2,
-      list: 'Site search results'
+      list: 'Site search results',
+      dimension71: 'search query'
     });
   });
 
   it('tracks clicks on search results', function() {
     element = $('\
-      <div data-ecommerce-start-index="1">\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
         <a \
           data-ecommerce-row\
           data-ecommerce-path="/path/to/page"\
@@ -134,7 +140,8 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addProduct', {
       id: 'AAAA-1111',
-      position: 1
+      position: 1,
+      dimension71: 'search query'
     });
     expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Site search results'})
     expect(ga).toHaveBeenCalledWith('send', 'event', 'UX', 'click', 'Results', {
@@ -158,8 +165,8 @@ describe('Ecommerce reporter for results pages', function() {
 
   it('will only require the ec library once', function() {
     GOVUK.Ecommerce.ecLoaded = false;
-    GOVUK.Ecommerce.start($('<div></div>'));
-    GOVUK.Ecommerce.start($('<div></div>'));
+    GOVUK.Ecommerce.start($('<div data-search-query="search query"></div>'));
+    GOVUK.Ecommerce.start($('<div data-search-query="search query"></div>'));
 
     expect(ga).toHaveBeenCalledWith('require', 'ec');
     expect(ga.calls.count()).toEqual(1);

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -49,6 +49,43 @@ describe("GOVUK.StaticAnalytics", function() {
       expect(GOVUK.analyticsPlugins.error).toHaveBeenCalled();
     });
 
+    describe('when ecommerce results are present', function() {
+      beforeEach(function() {
+        window.ga.calls.reset();
+      });
+
+      afterEach(function() {
+        $('.test-fixture').remove();
+      });
+
+      it('sends the ecommerce fields', function() {
+        $('body').append('\
+          <div class="test-fixture">\
+            <div data-analytics-ecommerce data-ecommerce-start-index="1">\
+             <div \
+               data-ecommerce-row\
+               data-ecommerce-path="/path/to/page"\
+               data-ecommerce-content-id="static-analytics-test"\
+             </div>\
+           </div>\
+          </div>\
+        ')
+        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+        pageViewObject = getPageViewObject();
+
+        universalSetupArguments = window.ga.calls.allArgs();
+
+        expect(universalSetupArguments[3][0]).toEqual("ec:addImpression")
+        expect(universalSetupArguments[3][1]).toEqual({
+          id: "static-analytics-test",
+          position: 1,
+          list: "Site search results"
+        })
+        expect(universalSetupArguments[4][0]).toEqual("send")
+        expect(universalSetupArguments[4][1]).toEqual("pageview")
+      })
+    })
+
     describe('when there are govuk: meta tags', function() {
       beforeEach(function() {
         window.ga.calls.reset();

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -61,7 +61,7 @@ describe("GOVUK.StaticAnalytics", function() {
       it('sends the ecommerce fields', function() {
         $('body').append('\
           <div class="test-fixture">\
-            <div data-analytics-ecommerce data-ecommerce-start-index="1">\
+            <div data-analytics-ecommerce data-ecommerce-start-index="1" data-search-query="search query">\
              <div \
                data-ecommerce-row\
                data-ecommerce-path="/path/to/page"\
@@ -71,20 +71,11 @@ describe("GOVUK.StaticAnalytics", function() {
           </div>\
         ')
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        pageViewObject = getPageViewObject();
 
-        universalSetupArguments = window.ga.calls.allArgs();
-
-        expect(universalSetupArguments[3][0]).toEqual("ec:addImpression")
-        expect(universalSetupArguments[3][1]).toEqual({
-          id: "static-analytics-test",
-          position: 1,
-          list: "Site search results"
-        })
-        expect(universalSetupArguments[4][0]).toEqual("send")
-        expect(universalSetupArguments[4][1]).toEqual("pageview")
-      })
-    })
+        expect(universalSetupArguments[3][0]).toEqual("send");
+        expect(universalSetupArguments[3][1]).toEqual("pageview");
+      });
+    });
 
     describe('when there are govuk: meta tags', function() {
       beforeEach(function() {


### PR DESCRIPTION
We want to start using the Ecommerce tooling to track search results that are not clicked on a page. 

In order to minimise the number of data requests that we send to GA we need to setup the ecommerce data prior to performing the pageview event.

https://trello.com/c/WlBZo8Sl/118-move-ecommerce-ga-to-use-govukfrontendtoolkit