### PR TITLE
Remove conditions around dimension values

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -201,9 +201,6 @@
   }
 
   function abTestCustomDimensions() {
-    // This is the block of dimensions assigned to A/B tests
-    var minAbTestDimension = 40;
-    var maxAbTestDimension = 49;
     var $abMetas = $('meta[name^="govuk:ab-test"]');
     var customDimensions = {};
 
@@ -212,7 +209,7 @@
       var dimension = parseInt($meta.data('analytics-dimension'));
       var testNameAndBucket = $meta.attr('content');
 
-      if (dimension >= minAbTestDimension && dimension <= maxAbTestDimension) {
+      if(dimension) {
         customDimensions['dimension' + dimension] = testNameAndBucket;
       }
     });

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -106,21 +106,6 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(pageViewObject.dimension48).toEqual('name-of-other-test:name-of-other-ab-bucket');
       });
 
-      it('ignores dimensions outside of the A/B test range', function () {
-        $('head').append('\
-          <meta name="govuk:ab-test" content="name-of-test-dimension-too-low:some-bucket" data-analytics-dimension="39">\
-          <meta name="govuk:ab-test" content="name-of-valid-test:some-bucket" data-analytics-dimension="40">\
-          <meta name="govuk:ab-test" content="name-of-other-valid-test:some-bucket" data-analytics-dimension="49">\
-          <meta name="govuk:ab-test" content="name-of-test-dimension-too-high:some-bucket" data-analytics-dimension="50">\
-        ');
-
-        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
-        pageViewObject = getPageViewObject();
-
-        expect(Object.keys(pageViewObject).length).toEqual(2 + numberOfDimensionsWithDefaultValues);
-        expect(pageViewObject.dimension40).toEqual('name-of-valid-test:some-bucket');
-        expect(pageViewObject.dimension49).toEqual('name-of-other-valid-test:some-bucket');
-      });
 
       it('ignores A/B meta tags with invalid dimensions', function () {
         $('head').append('\


### PR DESCRIPTION
We no longer have a particular range of custom dimensions that can be
used for A/B tests. This was an old limitation that no longer exists and
is preventing new A/B tests with values outside that range to not report
correctly to Google Analytics.

Trello: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box