### PR TITLE
Overrides global styling from the wrapper template causing misalignment

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -305,6 +305,7 @@
     width: 100%;
     padding: 5px 4px 4px;
     border: 2px solid $white;
+    margin: 0; // TODO: Remove this when all applications are moved away from the 'wrapper' template
     margin-bottom: 1em;
   }
 


### PR DESCRIPTION
In the newer templates e.g. core_layout this is not a problem but with wrapper
we're seeing a slight misalignment, this patch overrides wrapper.

Before

![screen shot 2017-06-14 at 17 14 38](https://user-images.githubusercontent.com/2445413/27143073-fd397c3e-5124-11e7-80a0-d9ce38405f28.png)

After

![screen shot 2017-06-14 at 17 14 45](https://user-images.githubusercontent.com/2445413/27143074-fd53adac-5124-11e7-880a-69aec55ca2d0.png)

Offending code is here: https://github.com/alphagov/static/blob/9e8795b262c948a65b798029864cbe04f193262a/app/assets/stylesheets/helpers/_buttons.scss#L103

Spotted by @fofr 