### PR TITLE
Add limiting to how many times a user can be shown a survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -265,7 +265,7 @@
     isSurveyToBeDisplayed: function (survey) {
       if (GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
         return false
-      } else if (userSurveys.surveySeenTooManyTimes(survey)) {
+      } else if (userSurveys.surveyHasBeenSeenTooManyTimes(survey)) {
         return false
       } else {
         return userSurveys.randomNumberMatches(survey.frequency)
@@ -330,8 +330,17 @@
       return $(notificationIds.join(', ')).length > 0
     },
 
-    surveySeenTooManyTimes: function (survey) {
-      return (userSurveys.surveySeenCount(survey) >= SURVEY_SEEN_TOO_MANY_TIMES_LIMIT)
+    surveyHasBeenSeenTooManyTimes: function (survey) {
+      return (userSurveys.surveySeenCount(survey) >= userSurveys.surveySeenTooManyTimesLimit(survey))
+    },
+
+    surveySeenTooManyTimesLimit: function (survey) {
+      var limit = parseInt(survey.seenTooManyTimesLimit, 10)
+      if (isNaN(limit) || limit < 1) {
+        return SURVEY_SEEN_TOO_MANY_TIMES_LIMIT
+      } else {
+        return limit
+      }
     },
 
     surveySeenCount: function (survey) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -350,7 +350,12 @@
     },
 
     surveySeenTooManyTimesLimit: function (survey) {
-      return extractNumber(survey.seenTooManyTimesLimit, SURVEY_SEEN_TOO_MANY_TIMES_LIMIT, 1)
+      var limitValue = survey.seenTooManyTimesLimit
+      if (String(limitValue).toLowerCase() === 'unlimited') {
+        return Infinity
+      } else {
+        return extractNumber(limitValue, SURVEY_SEEN_TOO_MANY_TIMES_LIMIT, 1)
+      }
     },
 
     surveySeenCount: function (survey) {

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -53,6 +53,7 @@
     '  Sorry, we’re unable to send you an email right now.  Please try again later.' +
     '</div>'
   )
+  var SURVEY_SEEN_TOO_MANY_TIMES_LIMIT = 2
 
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
@@ -134,6 +135,7 @@
       } else {
         return
       }
+      userSurveys.incrementSurveySeenCounter(survey)
       userSurveys.trackEvent(survey.identifier, 'banner_shown', 'Banner has been shown')
     },
 
@@ -263,10 +265,10 @@
     isSurveyToBeDisplayed: function (survey) {
       if (GOVUK.cookie(userSurveys.surveyTakenCookieName(survey)) === 'true') {
         return false
-      } else if (userSurveys.randomNumberMatches(survey.frequency)) {
-        return true
-      } else {
+      } else if (userSurveys.surveySeenTooManyTimes(survey)) {
         return false
+      } else {
+        return userSurveys.randomNumberMatches(survey.frequency)
       }
     },
 
@@ -306,6 +308,10 @@
       window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 4 })
     },
 
+    incrementSurveySeenCounter: function (survey) {
+      window.GOVUK.cookie(userSurveys.surveySeenCookieName(survey), userSurveys.surveySeenCount(survey) + 1)
+    },
+
     hideSurvey: function (_survey) {
       $('#user-satisfaction-survey').removeClass('visible').attr('aria-hidden', 'true')
     },
@@ -324,17 +330,38 @@
       return $(notificationIds.join(', ')).length > 0
     },
 
+    surveySeenTooManyTimes: function (survey) {
+      return (userSurveys.surveySeenCount(survey) >= SURVEY_SEEN_TOO_MANY_TIMES_LIMIT)
+    },
+
+    surveySeenCount: function (survey) {
+      var seenCookieName = userSurveys.surveySeenCookieName(survey)
+      var seenCount = parseInt(GOVUK.cookie(seenCookieName), 10)
+      if (isNaN(seenCount) || seenCount < 0) {
+        return 0
+      } else {
+        return seenCount
+      }
+    },
+
     surveyTakenCookieName: function (survey) {
-      // user_satisfaction_survey => takenUserSatisfactionSurvey
-      var cookieStr = 'taken_' + survey.identifier
-      var cookieStub = cookieStr.replace(/(\_\w)/g, function (m) {
-        return m.charAt(1).toUpperCase()
-      })
-      return 'govuk_' + cookieStub
+      return generateCookieName('taken_' + survey.identifier)
+    },
+
+    surveySeenCookieName: function (survey) {
+      return generateCookieName('survey_seen_' + survey.identifier)
     },
 
     currentTime: function () { return new Date().getTime() },
     currentPath: function () { return window.location.pathname }
+  }
+
+  var generateCookieName = function (cookieName) {
+      // taken_user_satisfaction_survey => takenUserSatisfactionSurvey
+    var cookieStub = cookieName.replace(/(\_\w)/g, function (m) {
+      return m.charAt(1).toUpperCase()
+    })
+    return 'govuk_' + cookieStub
   }
 
   window.GOVUK.userSurveys = userSurveys

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -309,7 +309,22 @@
     },
 
     incrementSurveySeenCounter: function (survey) {
-      window.GOVUK.cookie(userSurveys.surveySeenCookieName(survey), userSurveys.surveySeenCount(survey) + 1)
+      var cookieName = userSurveys.surveySeenCookieName(survey)
+      var seenCount = (userSurveys.surveySeenCount(survey) + 1)
+      var cooloff = userSurveys.seenTooManyTimesCooloff(survey)
+      if (cooloff) {
+        window.GOVUK.cookie(cookieName, seenCount, { days: cooloff })
+      } else {
+        window.GOVUK.cookie(cookieName, seenCount)
+      }
+    },
+
+    seenTooManyTimesCooloff: function (survey) {
+      if (survey.seenTooManyTimesCooloff) {
+        return extractNumber(survey.seenTooManyTimesCooloff, undefined, 1)
+      } else {
+        return undefined
+      }
     },
 
     hideSurvey: function (_survey) {
@@ -335,22 +350,11 @@
     },
 
     surveySeenTooManyTimesLimit: function (survey) {
-      var limit = parseInt(survey.seenTooManyTimesLimit, 10)
-      if (isNaN(limit) || limit < 1) {
-        return SURVEY_SEEN_TOO_MANY_TIMES_LIMIT
-      } else {
-        return limit
-      }
+      return extractNumber(survey.seenTooManyTimesLimit, SURVEY_SEEN_TOO_MANY_TIMES_LIMIT, 1)
     },
 
     surveySeenCount: function (survey) {
-      var seenCookieName = userSurveys.surveySeenCookieName(survey)
-      var seenCount = parseInt(GOVUK.cookie(seenCookieName), 10)
-      if (isNaN(seenCount) || seenCount < 0) {
-        return 0
-      } else {
-        return seenCount
-      }
+      return extractNumber(GOVUK.cookie(userSurveys.surveySeenCookieName(survey)), 0, 0)
     },
 
     surveyTakenCookieName: function (survey) {
@@ -371,6 +375,15 @@
       return m.charAt(1).toUpperCase()
     })
     return 'govuk_' + cookieStub
+  }
+
+  var extractNumber = function (value, defaultValue, limit) {
+    var parsedValue = parseInt(value, 10)
+    if (isNaN(parsedValue) || (parsedValue < limit)) {
+      return defaultValue
+    } else {
+      return parsedValue
+    }
   }
 
   window.GOVUK.userSurveys = userSurveys

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -305,7 +305,7 @@
     },
 
     setSurveyTakenCookie: function (survey) {
-      window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 4 })
+      window.GOVUK.cookie(userSurveys.surveyTakenCookieName(survey), true, { days: 30 * 3 })
     },
 
     incrementSurveySeenCounter: function (survey) {

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -8,6 +8,8 @@ This can easily be done by adding an entry to `GOVUK.userSurveys.smallSurveys` i
 
 There are sections of the site that should not show any surveys and these can be controlled via the `GOVUK.userSurveys.pathInBlacklist` function in `app/assets/javascripts/surveys.js`.  They are also never shown on "done" pages which can be controlled via the `GOVUK.userSurveys.userCompletedTransaction` function in the same file.
 
+Once a user takes the survey (clicks the link or fills in their email address and submits the form) we set a cookie to say they've taken it (we don't know they've actually taken it, but we assume their interaction means they have).  This cookie is used to make sure we don't show that survey to the user again for ~4 months (120 days).  We also record a session cookie that counts how many times the user has been shown a given survey and if they have already seen it two times we don't show it to them again.
+
 ## Example
 
 ```javascript

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -136,7 +136,7 @@ Not providing the `activeWhen` argument has the same effect as setting it to `re
 The survey will only be considered "active" between these dates and times. Where an explicit time is not provided (e.g. startTime) note that JavaScript will assume 00:00:00.000 i.e. just after midnight.
 
 ### `surveySeenTooManyTimesLimit` - OPTIONAL (default: 2)
-We record how many times a given survey is shown to a user and won't show it again if they've seen it too many times.  The default for that limit is 2 (e.g. we show it 2 times, but not 3 or more) but you can change that by adding a custom value here.  Anything that's not a number is ignored.
+We record how many times a given survey is shown to a user and won't show it again if they've seen it too many times.  The default for that limit is 2 (e.g. we show it 2 times, but not 3 or more) but you can change that by adding a custom value here.  The custom value should be a positive integer or the string `unlimited` (this means the survey should always show regardless of how many times it's been shown).  Any other value is ignored and treated as the default of 2.
 
 ## Testing Surveys
 If you need to force a particular survey to display – for example for testing – you can call  e.g. `GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.defaultSurvey)` or `GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.smallSurveys[0])` from your browser console.

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -8,7 +8,7 @@ This can easily be done by adding an entry to `GOVUK.userSurveys.smallSurveys` i
 
 There are sections of the site that should not show any surveys and these can be controlled via the `GOVUK.userSurveys.pathInBlacklist` function in `app/assets/javascripts/surveys.js`.  They are also never shown on "done" pages which can be controlled via the `GOVUK.userSurveys.userCompletedTransaction` function in the same file.
 
-Once a user takes the survey (clicks the link or fills in their email address and submits the form) we set a cookie to say they've taken it (we don't know they've actually taken it, but we assume their interaction means they have).  This cookie is used to make sure we don't show that survey to the user again for ~4 months (120 days).  We also record a session cookie that counts how many times the user has been shown a given survey and if they have already seen it two (this number is configurable) times we don't show it to them again.
+Once a user takes the survey (clicks the link or fills in their email address and submits the form) we set a cookie to say they've taken it (we don't know they've actually taken it, but we assume their interaction means they have).  This cookie is used to make sure we don't show that survey to the user again for ~3 months (90 days).  We also record a session cookie that counts how many times the user has been shown a given survey and if they have already seen it two (this number is configurable) times we don't show it to them again.
 
 ## Example
 

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -8,7 +8,7 @@ This can easily be done by adding an entry to `GOVUK.userSurveys.smallSurveys` i
 
 There are sections of the site that should not show any surveys and these can be controlled via the `GOVUK.userSurveys.pathInBlacklist` function in `app/assets/javascripts/surveys.js`.  They are also never shown on "done" pages which can be controlled via the `GOVUK.userSurveys.userCompletedTransaction` function in the same file.
 
-Once a user takes the survey (clicks the link or fills in their email address and submits the form) we set a cookie to say they've taken it (we don't know they've actually taken it, but we assume their interaction means they have).  This cookie is used to make sure we don't show that survey to the user again for ~4 months (120 days).  We also record a session cookie that counts how many times the user has been shown a given survey and if they have already seen it two times we don't show it to them again.
+Once a user takes the survey (clicks the link or fills in their email address and submits the form) we set a cookie to say they've taken it (we don't know they've actually taken it, but we assume their interaction means they have).  This cookie is used to make sure we don't show that survey to the user again for ~4 months (120 days).  We also record a session cookie that counts how many times the user has been shown a given survey and if they have already seen it two (this number is configurable) times we don't show it to them again.
 
 ## Example
 
@@ -134,6 +134,9 @@ Not providing the `activeWhen` argument has the same effect as setting it to `re
 
 ### `startTime` and `endTime`
 The survey will only be considered "active" between these dates and times. Where an explicit time is not provided (e.g. startTime) note that JavaScript will assume 00:00:00.000 i.e. just after midnight.
+
+### `surveySeenTooManyTimesLimit` - OPTIONAL (default: 2)
+We record how many times a given survey is shown to a user and won't show it again if they've seen it too many times.  The default for that limit is 2 (e.g. we show it 2 times, but not 3 or more) but you can change that by adding a custom value here.  Anything that's not a number is ignored.
 
 ## Testing Surveys
 If you need to force a particular survey to display – for example for testing – you can call  e.g. `GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.defaultSurvey)` or `GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.smallSurveys[0])` from your browser console.

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -547,6 +547,15 @@ describe('Surveys', function () {
         expect(surveys.surveyHasBeenSeenTooManyTimes(smallSurvey)).toBeTruthy()
       })
     })
+
+    describe("for unlimited surveys", function () {
+      var unlimitedSurvey = { identifier: 'unlimited_survey', seenTooManyTimesLimit: 'unlimited' }
+
+      it('returns false', function () {
+        GOVUK.cookie(surveys.surveySeenCookieName(unlimitedSurvey), 2000)
+        expect(surveys.surveyHasBeenSeenTooManyTimes(unlimitedSurvey)).toBeFalsy()
+      })
+    })
   })
 
   describe("surveySeenTooManyTimesLimit", function () {
@@ -568,6 +577,14 @@ describe('Surveys', function () {
     it("returns the default limit (2) if the survey is configured with a limit that is less than 1", function () {
       var survey = { identifier: 'no_configured_limit', seenTooManyTimesLimit: 0 }
       expect(surveys.surveySeenTooManyTimesLimit(survey)).toBe(2)
+    })
+
+    it("returns Infinity if the survey is configured with a limit that is the string \"unlimited\"", function () {
+      var survey = { identifier: 'no_configured_limit', seenTooManyTimesLimit: 'unlimited' }
+      expect(surveys.surveySeenTooManyTimesLimit(survey)).toBe(Infinity)
+
+      survey.seenTooManyTimesLimit = 'UNLIMITED'
+      expect(surveys.surveySeenTooManyTimesLimit(survey)).toBe(Infinity)
     })
   })
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -88,14 +88,6 @@ describe('Surveys', function () {
       GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey), null)
       surveys.displaySurvey(defaultSurvey)
       expect(GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey))).toBe('1')
-
-      GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey), 10)
-      surveys.displaySurvey(defaultSurvey)
-      expect(GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey))).toBe('11')
-
-      GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey), 'a few times')
-      surveys.displaySurvey(defaultSurvey)
-      expect(GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey))).toBe('1')
     })
 
     describe("for a 'url' survey", function () {
@@ -658,6 +650,60 @@ describe('Surveys', function () {
 
         var activeSurveys = surveys.getActiveSurveys([testSurvey])
         expect(activeSurveys).toContain(testSurvey)
+      })
+    })
+  })
+
+  describe("incrementSurveySeenCounter", function () {
+    it("sets the value of the cookie to 1 if it's not set", function () {
+      var survey = { identifier: 'my_survey' }
+      var cookieName = surveys.surveySeenCookieName(survey)
+      GOVUK.cookie(cookieName, null)
+      surveys.incrementSurveySeenCounter(survey)
+      expect(GOVUK.cookie(cookieName)).toBe('1')
+    })
+
+    it("increments the value of the cookie by 1 if it's already set", function () {
+      var survey = { identifier: 'my_survey' }
+      var cookieName = surveys.surveySeenCookieName(survey)
+      GOVUK.cookie(cookieName, 3)
+      surveys.incrementSurveySeenCounter(survey)
+      expect(GOVUK.cookie(cookieName)).toBe('4')
+    })
+
+    it("sets the value of the cookie to 1 if it's set to something that's not a number", function () {
+      var survey = { identifier: 'my_survey' }
+      var cookieName = surveys.surveySeenCookieName(survey)
+      GOVUK.cookie(cookieName, 'a couple of times')
+      surveys.incrementSurveySeenCounter(survey)
+      expect(GOVUK.cookie(cookieName)).toBe('1')
+    })
+
+    it("sets the value of the cookie to 1 if it's set to a number less than 1", function () {
+      var survey = { identifier: 'my_survey' }
+      var cookieName = surveys.surveySeenCookieName(survey)
+      GOVUK.cookie(cookieName, -1)
+      surveys.incrementSurveySeenCounter(survey)
+      expect(GOVUK.cookie(cookieName)).toBe('1')
+    })
+
+    describe("for surveys with no seenTooManyTimesCooloff", function () {
+      it("sets the cookie to session scope", function () {
+        var survey = { identifier: 'my_survey' }
+        var cookieName = surveys.surveySeenCookieName(survey)
+        spyOn(GOVUK, 'cookie')
+        surveys.incrementSurveySeenCounter(survey)
+        expect(GOVUK.cookie).toHaveBeenCalledWith(cookieName, 1)
+      })
+    })
+
+    describe("for surveys with a seenTooManyTimesCooloff", function () {
+      it("sets the cookie to expire in that many days", function () {
+        var survey = { identifier: 'my_survey', seenTooManyTimesCooloff: 10 }
+        var cookieName = surveys.surveySeenCookieName(survey)
+        spyOn(GOVUK, 'cookie')
+        surveys.incrementSurveySeenCounter(survey)
+        expect(GOVUK.cookie).toHaveBeenCalledWith(cookieName, 1, { days: 10 })
       })
     })
   })


### PR DESCRIPTION
For: https://trello.com/c/WaguHidO/184-adding-a-display-limit-to-the-govuk-survey-banner

We want to increase the frequency that some surveys appear, but we don't want to annoy frequent visitors to GOV.UK who show no interest in the survey.  To this end we:

1. introduce a surveySeen cookie for each survey that tracks how many times it has been presented to the user
2. don't show the survey to a user if it has been shown already to that user twice
3. allow a survey to configure the limit for how many times it considers too many (default is 2)
4. allow a survey to configure the number of days to persist the cookie that counts how many times it has been seen (default is to use a session cookie)

We also reduce the number of days for the "I've taken this survey don't show it again" cookie from 120 days (~4 months) to 90 days (~3 months).