### PR TITLE
Make the default survey appear 1 in 6 times

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -60,7 +60,7 @@
     defaultSurvey: {
       url: 'https://www.smartsurvey.co.uk/s/gov_uk',
       identifier: 'user_satisfaction_survey',
-      frequency: 10,
+      frequency: 6,
       surveyType: 'email'
     },
     smallSurveys: [


### PR DESCRIPTION
For: https://trello.com/c/WrsJq0E1/185-change-govuk-survey-banner-frequency-to-1-in-6-pageviews

Now that we have functionality to stop showing a survey over and over to
a user who has not interacted with it (see #1075) we can be bolder about how often
we show the default survey.  This should mean we get more results and
better data about what people think of the platform.