### PR TITLE
Metadata font size increase

### DIFF
--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -1,5 +1,5 @@
 .govuk-metadata {
-  @include core-14;
+  @include core-16;
   @include responsive-bottom-margin;
   @extend %contain-floats;
 
@@ -9,13 +9,16 @@
   }
 
   dt {
-    float: left;
-    clear: left;
-    width: auto;
-    min-width: 120px;
+    margin-top: 0.5em;
+    line-height: normal;
 
     @include media(tablet) {
+      float: left;
+      clear: left;
+      width: calc(30% - 10px);
+      max-width: 10em;
       padding-right: $gutter-one-third;
+      margin-top: 0;
     }
   }
 
@@ -30,10 +33,10 @@
   }
 
   dd {
-    float: left;
-    width: 55%;
+   line-height: normal;
 
-    @include media(tablet) {
+   @include media(tablet) {
+      float: left;
       width: 70%;
     }
 

--- a/app/assets/stylesheets/govuk-component/_metadata.scss
+++ b/app/assets/stylesheets/govuk-component/_metadata.scss
@@ -15,8 +15,9 @@
     @include media(tablet) {
       float: left;
       clear: left;
-      width: calc(30% - 10px);
-      max-width: 10em;
+      width: 30%;
+      box-sizing: border-box;
+      max-width: 11em;
       padding-right: $gutter-one-third;
       margin-top: 0;
     }
@@ -33,9 +34,9 @@
   }
 
   dd {
-   line-height: normal;
+    line-height: normal;
 
-   @include media(tablet) {
+    @include media(tablet) {
       float: left;
       width: 70%;
     }


### PR DESCRIPTION
* Increase from 14px to 16px
* Rewritten slightly to use mobile first
* Width of dt and dd set at 30% and 70%, max width applied to prevent large gap between the two when in a wide space
* Fixed bug where elements collapsed to single column then back to two column before ending up as single column as screen width reduced

**Before, desktop:**

<img width="605" alt="screen shot 2017-07-04 at 16 22 51" src="https://user-images.githubusercontent.com/861310/27835942-13320bb8-60d5-11e7-8365-457b3a29dbb2.png">

**After, desktop:**

<img width="652" alt="screen shot 2017-07-04 at 16 23 46" src="https://user-images.githubusercontent.com/861310/27835959-2f01beb0-60d5-11e7-88af-f50cdc574001.png">

**Before, mobile:**

<img width="301" alt="screen shot 2017-07-04 at 16 24 33" src="https://user-images.githubusercontent.com/861310/27835997-65e1bf70-60d5-11e7-8739-e8c76970a465.png">

**After, mobile:**

<img width="302" alt="screen shot 2017-07-04 at 16 25 37" src="https://user-images.githubusercontent.com/861310/27836011-749b78c6-60d5-11e7-8c42-c1625ac13b0f.png">

https://trello.com/c/2pik3I0j/109-1-increase-font-size-in-metadata-component-in-static
