### PR TITLE
Fix print view of numbered lists

### DIFF
--- a/app/assets/stylesheets/helpers/_print-base.scss
+++ b/app/assets/stylesheets/helpers/_print-base.scss
@@ -53,7 +53,7 @@ p {
 ul,
 ol {
   @include core-14;
-  padding-left: 13pt;
+  padding-left: 26pt;
 }
 
 ul {


### PR DESCRIPTION
* Problem in print view when ordered lists have more than 9 items in them, only enough space on the left to display the last digit, so the numbering appears to reach 9 and then reset to 0
* Padding left increased to counter this problem, should now be good up to 999 items
* Issue documented here https://trello.com/c/CuYEun0D/110-content-list-print-view-content-list-numbering-10-issues

**Old**
<img width="401" alt="screen shot 2017-07-11 at 13 27 31" src="https://user-images.githubusercontent.com/861310/28068291-c579c858-663c-11e7-8832-e2abc7847bad.png">

**New**
<img width="494" alt="screen shot 2017-07-11 at 13 27 44" src="https://user-images.githubusercontent.com/861310/28068300-cf039fd4-663c-11e7-865a-29987ed59306.png">

