### PR TITLE
Removing blurriness from organisation logos

### DIFF
--- a/app/assets/stylesheets/govuk-component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk-component/_organisation-logo.scss
@@ -91,7 +91,7 @@
 
     @include media(tablet) {
       padding-top: 35px;
-      background-size: auto 35px;
+      background-size: auto 34px;
     }
   }
 

--- a/app/assets/stylesheets/govuk-component/_organisation-logo.scss
+++ b/app/assets/stylesheets/govuk-component/_organisation-logo.scss
@@ -77,7 +77,7 @@
 
     @include media(tablet) {
       background: image-url('crests/#{$crest}_18px.png') no-repeat 6px 0;
-      background-size: auto 25px;
+      background-size: auto 26px;
 
       @include device-pixel-ratio() {
         background-image: image-url('crests/#{$crest}_18px_x2.png');


### PR DESCRIPTION
Organisation logos were blurry on low-dpi screens. Adjusted background-size of images by 1px to improve blurriness.

**Fixes #916**

**Before (low-dpi screen):**
![screen shot 2017-07-13 at 13 47 28](https://user-images.githubusercontent.com/29889908/28166989-e1d4f4dc-67d1-11e7-881d-e79c9ef1493e.png)

**After (low-dpi screen):**
![screen shot 2017-07-13 at 13 46 32](https://user-images.githubusercontent.com/29889908/28167007-ee8e67f8-67d1-11e7-83ad-2289f752fbd6.png)

**Before (hi-dpi screen)**
<img width="122" alt="screen shot 2017-07-13 at 13 49 09" src="https://user-images.githubusercontent.com/29889908/28167044-104ca0d0-67d2-11e7-90e1-3c4595d7124e.png">

**After (hi-dpi screen):**
<img width="131" alt="screen shot 2017-07-13 at 13 53 26" src="https://user-images.githubusercontent.com/29889908/28167199-aef48018-67d2-11e7-94a1-86387612a23d.png">

Issue on Trello here: https://trello.com/c/ChvtIxBx/126-organisation-logos-are-blurry


