### PR TITLE
Fixing misaligned warning sign on mobile

### DIFF
--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -303,7 +303,7 @@ article {
     margin-bottom: 1.5em;
     padding-bottom: 1em;
 
-    p:first-child {
+    .get-started-intro > p:first-child {
       margin-top: 0;
     }
 


### PR DESCRIPTION
Fixes #1061 . Previously, the warning sign on transaction pages was misaligned on mobile due to the default margin being overridden by a separate style. It looks like this separate style was being wrongly applied to multiple elements when it should have just been applied to the first paragraph of any transaction page, to reduce the distance between the first heading and p.

This fix makes the CSS selector more specific to make sure this selector only applies as described above, and no longer effects warning signs.

## **Before:**
**Icon looks partially hidden. Looking more closely, we can see a margin-top: 0 is causing this.**


<img width="527" alt="screen shot 2017-07-14 at 11 41 13" src="https://user-images.githubusercontent.com/29889908/28209244-9dbf34b6-6889-11e7-89a6-fea6f5bccfdf.png">
<img width="415" alt="screen shot 2017-07-14 at 11 42 35" src="https://user-images.githubusercontent.com/29889908/28209253-a2bdf5ba-6889-11e7-9c5a-2280867358b8.png">

## **After:**
**The icon is now not hidden as the margin-top: 0 is no longer being applied.**


<img width="416" alt="screen shot 2017-07-14 at 11 45 05" src="https://user-images.githubusercontent.com/29889908/28209315-e744dffa-6889-11e7-80d8-3c2a252573a1.png">

**We can also see that the margin-top: 0 is still being correctly applied to the first line of the page directly beneath the heading:**


<img width="417" alt="screen shot 2017-07-14 at 11 46 13" src="https://user-images.githubusercontent.com/29889908/28209347-0f3074ca-688a-11e7-8e57-e18dba71b240.png">
