### PR TITLE
Track total number of topic sections

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -95,7 +95,17 @@
       var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
       var browsePageSections = $('#subsection ul:visible').length ||
         $('#section ul').length;
-      return sidebarSections || sidebarTaxons || accordionSubsections || gridSections || browsePageSections;
+      var topicPageSections = $('.topics-page nav.index-list').length
+
+      var sectionCount =
+        sidebarSections ||
+        sidebarTaxons ||
+        accordionSubsections ||
+        gridSections ||
+        browsePageSections ||
+        topicPageSections;
+
+      return sectionCount;
     }
 
     function totalNumberOfSectionLinks() {

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -492,6 +492,62 @@ describe("GOVUK.StaticAnalytics", function() {
           expect(pageViewObject.dimension27).toEqual('2');
         });
       });
+
+      describe('on a sub topic page', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <main id="content" role="main" class="content topics-page">\
+                <div class="browse-container full-width">\
+                  <nav class="index-list with-title"">\
+                    <h1 id="getting-started">Getting started</h1>\
+                    <ul>\
+                      <li>\
+                        <a href="/corporation-tax">Corporation Tax</a>\
+                      </li>\
+                      <li>\
+                        <a href="/limited-company-formation">Set up a private limited company</a>\
+                      </li>\
+                      <li>\
+                        <a href="/running-a-limited-company">Running a limited company</a>\
+                      </li>\
+                    </ul>\
+                  </nav>\
+                  <nav class="index-list with-title"">\
+                    <ul>\
+                      <li>\
+                        <a href="/prepare-file-annual-accounts-for-limited-company">\
+                          Accounts and tax returns for private limited companies\
+                        </a>\
+                      </li\>\
+                      <li>\
+                        <a href="/first-company-accounts-and-return">\
+                          Your limited company first accounts and Company Tax Return\
+                        </a>\
+                      </li>\
+                      <li>\
+                        <a href="/corporation-tax-accounting-period">\
+                          Accounting periods for Corporation Tax\
+                        </a>\
+                      </li>\
+                    </ul>\
+                  </nav>\
+                </div>\
+              </main>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('2');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
We are adding tracking events to old navigation pages in order to track
how people use them. We have added tracking events when users click on
topic links, but we also need information on how many sections there are
on those pages, so that the custom dimension is reported accurately to
Google Analytics.

This commit makes sure we set the custom dimension 26 with the correct
number of topic sections.

This is related with the GitHub PR [1] and the Trello ticker [2].

- [1] https://github.com/alphagov/collections/pull/361
- [2] https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation