### PR TITLE
Track total number of document collection sections

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -96,6 +96,7 @@
       var browsePageSections = $('#subsection ul:visible').length ||
         $('#section ul').length;
       var topicPageSections = $('.topics-page nav.index-list').length
+      var documentCollectionSections = $('.document-collection .group-title').length;
 
       var sectionCount =
         sidebarSections ||
@@ -103,7 +104,8 @@
         accordionSubsections ||
         gridSections ||
         browsePageSections ||
-        topicPageSections;
+        topicPageSections ||
+        documentCollectionSections;
 
       return sectionCount;
     }

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -548,6 +548,51 @@ describe("GOVUK.StaticAnalytics", function() {
           expect(pageViewObject.dimension26).toEqual('2');
         });
       });
+
+      describe('on a document collection page', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <main role="main" id="content" class="document-collection">\
+                <h3 class="group-title" id="ancient-history">\
+                  Ancient history\
+                </h3>\
+                <ol class="group-document-list">\
+                  <li class="group-document-list-item">\
+                    <h3 class="group-document-list-item-title">\
+                      <a href="conditions-requirements-ancient-history">\
+                        GCSE (9 to 1) subject-level conditions and requirements for ancient history\
+                      </a>\
+                    </h3>\
+                  </li>\
+                </ol>\
+                <h3 class="group-title" id="ancient-languages">\
+                  Ancient languages\
+                </h3>\
+                <ol class="group-document-list">\
+                  <li class="group-document-list-item">\
+                    <h3 class="group-document-list-item-title">\
+                      <a href="/conditions-requirements-ancient-languages">\
+                        GCSE (9 to 1) subject-level conditions and requirements for ancient languages\
+                      </a>\
+                    </h3>\
+                  </li>\
+              </ol>\
+              </main>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('2');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
We are adding tracking events to old navigation pages in order to track
how people use them. We have added tracking events when users click on
document collection links, but we also need information on how many
sections there are on those pages, so that the custom dimension is
reported accurately to Google Analytics.

This commit makes sure we set the custom dimension 26 with the correct
number of document collection sections.

This is related with the GitHub PR [1] and the Trello ticker [2].

[1] - https://github.com/alphagov/government-frontend/pull/399
[2] - https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation