### PR TITLE
Track number of links in topic pages

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -117,7 +117,17 @@
       var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
       var browsePageLinks = $('#subsection ul a:visible').length ||
         $('#section ul a').length;
-      return relatedLinks || accordionLinks || gridLinks || leafLinks || browsePageLinks;
+      var topicPageLinks = $('.topics-page ul a').length;
+
+      var linksCount =
+        relatedLinks ||
+        accordionLinks ||
+        gridLinks ||
+        leafLinks ||
+        browsePageLinks ||
+        topicPageLinks;
+
+      return linksCount;
     }
   }
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -493,6 +493,49 @@ describe("GOVUK.StaticAnalytics", function() {
         });
       });
 
+      describe('on a topic page', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <main id="content" role="main" class="content topics-page">\
+                <nav class="topics">\
+                  <ul>\
+                    <li>\
+                      <a href="/topic/business-tax/aggregates-levy">Aggregates Levy</a>\
+                    </li>\
+                    <li>\
+                      <a href="/topic/business-tax/air-passenger-duty">Air Passenger Duty</a>\
+                    </li>\
+                    <li>\
+                      <a href="/topic/business-tax/alcohol-duties">Alcohol duties</a>\
+                    </li>\
+                    <li>\
+                      <a href="/topic/business-tax/capital-allowances">Capital allowances</a>\
+                    </li>\
+                  </ul>\
+                </nav>\
+              </main>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('0');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('4');
+        });
+      });
+
       describe('on a sub topic page', function() {
         beforeEach(function() {
           $('body').append('\
@@ -546,6 +589,12 @@ describe("GOVUK.StaticAnalytics", function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
           pageViewObject = getPageViewObject();
           expect(pageViewObject.dimension26).toEqual('2');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('6');
         });
       });
     });


### PR DESCRIPTION
This commit correctly sets the dimension27 with the number of links in
any topic page. This will then be attached to page view events and sent
to Google Analytics so we can run reports.

Trello: https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation