### PR TITLE
Track sections and links on policy area pages

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -97,6 +97,7 @@
         $('#section ul').length;
       var topicPageSections = $('.topics-page nav.index-list').length
       var documentCollectionSections = $('.document-collection .group-title').length;
+      var policyAreaSections = $('.topic section h1.label').length;
 
       var sectionCount =
         sidebarSections ||
@@ -105,7 +106,8 @@
         gridSections ||
         browsePageSections ||
         topicPageSections ||
-        documentCollectionSections;
+        documentCollectionSections ||
+        policyAreaSections;
 
       return sectionCount;
     }
@@ -120,6 +122,9 @@
       var browsePageLinks = $('#subsection ul a:visible').length ||
         $('#section ul a').length;
       var topicPageLinks = $('.topics-page ul a').length;
+      var policyAreaLinks =
+        $('section.document-block a').length +
+        $('section .collection-list h2 a').length
 
       var linksCount =
         relatedLinks ||
@@ -127,7 +132,8 @@
         gridLinks ||
         leafLinks ||
         browsePageLinks ||
-        topicPageLinks;
+        topicPageLinks ||
+        policyAreaLinks;
 
       return linksCount;
     }

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -598,6 +598,70 @@ describe("GOVUK.StaticAnalytics", function() {
         });
       });
 
+      describe('on a policy area page', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <div class="topic classification topic">\
+                <section id="announcements" class="document-block">\
+                  <h1 class="label">Announcements</h1>\
+                  <div class="content">\
+                    <ol class="document-list">\
+                      <li class="news_article document-row">\
+                        <h2>\
+                          <a href="/government/news/news1">\
+                            Announcement 1\
+                          </a>\
+                        </h2>\
+                      </li>\
+                      <li class="news_article document-row">\
+                        <h2>\
+                          <a href="/government/news/news2">\
+                            Announcement 2\
+                          </a>\
+                        </h2>\
+                      </li>\
+                    </ol>\
+                  </div>\
+                </section>\
+                <section class="detailed-guidance">\
+                  <h1 class="label">Detailed guides</h1>\
+                  <div class="content">\
+                    <ol class="collection-list one-column">\
+                      <li class="detailed_guide topic collection-item">\
+                        <div class="container">\
+                          <h2>\
+                            <a href="/guidance/how-to">\
+                              How to guidance\
+                            </a>\
+                          </h2>\
+                        </div>\
+                      </li>\
+                    </ol>\
+                  </div>\
+                </section>\
+              </div>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('2');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('3');
+        });
+      });
+
       describe('on a document collection page', function() {
         beforeEach(function() {
           $('body').append('\


### PR DESCRIPTION
This commit correctly sets the dimension26 and dimension27 with the
number of sections and links in any policty area page. This will then
be attached to page view events and sent to Google Analytics so we
can run reports.

Trello: https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation