### PR TITLE
Track number of links on Whitehall finder pages

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -125,6 +125,8 @@
       var policyAreaLinks =
         $('section.document-block a').length +
         $('section .collection-list h2 a').length
+      var whitehallFinderPageLinks =
+        $('.document-list .document-row h3 a').length;
 
       var linksCount =
         relatedLinks ||
@@ -133,7 +135,8 @@
         leafLinks ||
         browsePageLinks ||
         topicPageLinks ||
-        policyAreaLinks;
+        policyAreaLinks ||
+        whitehallFinderPageLinks;
 
       return linksCount;
     }

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -706,6 +706,53 @@ describe("GOVUK.StaticAnalytics", function() {
           expect(pageViewObject.dimension26).toEqual('2');
         });
       });
+
+      describe('on a whitehall finder page (e.g Announcements)', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <ol class="document-list">\
+                <li class="document-row">\
+                  <h3>\
+                    <a href="/government/news/news-article-1">\
+                      Creative sector receives record boost of £700 million pounds\
+                    </a>\
+                  </h3>\
+                </li>\
+                <li class="document-row">\
+                  <h3>\
+                    <a href="/government/news/news-article-2">\
+                      Dangerous occurrence at Broad Oak level crossing\
+                    </a>\
+                  </h3>\
+                </li>\
+                <li class="document-row">\
+                  <h3>\
+                    <a href="/government/news/news-article-3">\
+                      Outbreaks of Koi herpesvirus (KHV) disease in 2017\
+                    </a>\
+                  </h3>\
+                </li>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('0');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('3');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This commit correctly sets the dimension 27 value with the number of
links present in a Whitehall finder page. Those finders show
announcements, statistics, consultations and publications.

Trello: https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation