### PR TITLE
Fix subtopic page link count

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -121,7 +121,8 @@
       var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
       var browsePageLinks = $('#subsection ul a:visible').length ||
         $('#section ul a').length;
-      var topicPageLinks = $('.topics-page ul a').length;
+      var subTopicPageLinks = $('.topics-page .index-list ul a').length;
+      var topicPageLinks = $('.topics-page .topics ul a').length;
       var policyAreaLinks =
         $('section.document-block a').length +
         $('section .collection-list h2 a').length
@@ -134,6 +135,7 @@
         gridLinks ||
         leafLinks ||
         browsePageLinks ||
+        subTopicPageLinks ||
         topicPageLinks ||
         policyAreaLinks ||
         whitehallFinderPageLinks;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -541,6 +541,15 @@ describe("GOVUK.StaticAnalytics", function() {
           $('body').append('\
             <div class="test-fixture">\
               <main id="content" role="main" class="content topics-page">\
+                <header class="page-header group">\
+                  <ul>\
+                    <li>\
+                    <a href="/topic/business-tax/corporation-tax/email-signup">\
+                      Subscribe to email alerts\
+                    </a>\
+                    </li>\
+                  </ul>\
+                </header>\
                 <div class="browse-container full-width">\
                   <nav class="index-list with-title"">\
                     <h1 id="getting-started">Getting started</h1>\


### PR DESCRIPTION
This commit makes sure we don't count email subscription links on
subtopic pages. That means making the CSS selector more specific, and
the consequence of that is that we now need to treat topic pages
differently.

Trello: https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation