### PR TITLE
Track document collection links and sections

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -99,14 +99,17 @@
       var documentCollectionSections = $('.document-collection .group-title').length;
       var policyAreaSections = $('.topic section h1.label').length;
 
+      // Document collections, being a content item, might have related links.
+      // That means we need to check for sections on it first, before we default
+      // to the sections on the side bar.
       var sectionCount =
+        documentCollectionSections ||
         sidebarSections ||
         sidebarTaxons ||
         accordionSubsections ||
         gridSections ||
         browsePageSections ||
         topicPageSections ||
-        documentCollectionSections ||
         policyAreaSections;
 
       return sectionCount;
@@ -127,8 +130,14 @@
         $('section .collection-list h2 a').length
       var whitehallFinderPageLinks =
         $('.document-list .document-row h3 a').length;
+      var documentCollectionLinks =
+        $('.document-collection .group-document-list li a').length;
 
+      // Document collections, being a content item, might have related links.
+      // That means we need to check for links on it first, before we default
+      // to the sections on the side bar.
       var linksCount =
+        documentCollectionLinks ||
         relatedLinks ||
         accordionLinks ||
         gridLinks ||

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -690,6 +690,13 @@ describe("GOVUK.StaticAnalytics", function() {
                       </a>\
                     </h3>\
                   </li>\
+                  <li class="group-document-list-item">\
+                    <h3 class="group-document-list-item-title">\
+                      <a href="/guidance-for-ancient-languages">\
+                        GCSE (9 to 1) subject-level guidance for ancient languages\
+                      </a>\
+                    </h3>\
+                  </li>\
               </ol>\
               </main>\
             </div>\
@@ -704,6 +711,12 @@ describe("GOVUK.StaticAnalytics", function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
           pageViewObject = getPageViewObject();
           expect(pageViewObject.dimension26).toEqual('2');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('3');
         });
       });
 


### PR DESCRIPTION
This commit makes sure we track how many links there are on a document
collection. It also makes sure we track the number of sections
accurately, by first checking if we are in a document collection page.
Since document collections are content items and therefore might have
related links, the order in which we check for these counts matter.

Trello: https://trello.com/c/5YQVnGVr/32-add-total-links-total-sections-counting-to-whitehall-navigation