### PR TITLE
Send ga events for webchat less often

### DIFF
--- a/app/assets/javascripts/webchat.js.erb
+++ b/app/assets/javascripts/webchat.js.erb
@@ -43,18 +43,28 @@
         if (message.evt === 'opened') {
           webchat.$banner.addClass('open');
           webchat.$banner.attr('aria-hidden', false);
-          GOVUK.analytics.trackEvent('webchat', 'offered');
+          webchat.trackEvent('offered');
         } else if (message.evt === 'closed') {
           webchat.$banner.removeClass('open');
           webchat.$banner.attr('aria-hidden', true);
+          webchat.trackEvent('unavailable');
         } else if (message.evt === 'error') {
-          GOVUK.analytics.trackEvent('webchat', 'error');
+          webchat.trackEvent('error');
         }
+      }
+    },
+
+    lastTrackedEventState: null,
+    trackEvent: function (status) {
+      if (webchat.lastTrackedEventState !== status.toLowerCase()) {
+        GOVUK.analytics.trackEvent('webchat', status);
+        webchat.lastTrackedEventState = status.toLowerCase();
       }
     },
 
     init: function (){
       var insertionPoint;
+      webchat.lastTrackedEventState = null;
 
       // IE7 can’t access webchat
       if (window.sessionStorage && window.postMessage) {
@@ -86,11 +96,11 @@
           webchat.$banner.on('click', '.accept', function(e) {
             e.preventDefault();
             webchat.sendMessage({ evt: 'accept' });
-            GOVUK.analytics.trackEvent('webchat', 'accepted');
+            webchat.trackEvent('accepted');
           }).on('click', '.reject', function(e) {
             e.preventDefault();
             webchat.sendMessage({ evt: 'reject' });
-            GOVUK.analytics.trackEvent('webchat', 'rejected');
+            webchat.trackEvent('rejected');
           });
 
         }

--- a/spec/javascripts/hmrc-webchat-spec.js
+++ b/spec/javascripts/hmrc-webchat-spec.js
@@ -4,6 +4,8 @@ describe('HMRC webchat', function () {
   beforeEach(function() {
     spyOn(GOVUK.webchat, 'shouldOpen').and.returnValue(true);
     spyOn(GOVUK.webchat, 'validOrigin').and.returnValue(true);
+    spyOn(GOVUK.webchat, 'sendMessage');
+    spyOn(GOVUK.analytics, 'trackEvent');
     setFixtures(INSERTION_HOOK);
     GOVUK.webchat.init();
   });
@@ -32,6 +34,10 @@ describe('HMRC webchat', function () {
       expect($('.webchat-banner.open').length).toBe(1);
     });
 
+    it('sends an "offered" event to GA', function() {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'offered');
+    });
+
   });
 
   describe('if it receives a closed message', function(){
@@ -45,6 +51,58 @@ describe('HMRC webchat', function () {
       expect($('.webchat-banner:not(.open)').length).toBe(1);
     });
 
+    it('sends no event to GA', function() {
+      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith();
+    });
+
+  });
+
+  describe('if it receives an error message', function(){
+
+    beforeEach(function(done){
+      window.postMessage(JSON.stringify({evt: 'error'}), '*');
+      $(window).on('message',done);
+    });
+
+    it('sends an "error" event to GA', function() {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'error');
+    });
+
+  });
+
+  describe('interacting with the webchat banner', function() {
+    beforeEach(function(done){
+      window.postMessage(JSON.stringify({evt: 'opened'}), '*');
+      $(window).on('message',done);
+    });
+
+    describe('by clicking the accept button', function() {
+      beforeEach(function() {
+        GOVUK.webchat.$banner.find('.accept').click();
+      });
+
+      it('sends an "accepted" event to GA', function() {
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'accepted');
+      });
+
+      it('sends an "accept" message to the iframe', function() {
+        expect(GOVUK.webchat.sendMessage).toHaveBeenCalledWith({ evt: 'accept'});
+      });
+    });
+
+    describe('by clicking the reject button', function() {
+      beforeEach(function() {
+        GOVUK.webchat.$banner.find('.reject').click();
+      });
+
+      it('sends an "rejected" event to GA', function() {
+        expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'rejected');
+      });
+
+      it('sends an "reject" message to the iframe', function() {
+        expect(GOVUK.webchat.sendMessage).toHaveBeenCalledWith({ evt: 'reject'});
+      });
+    });
   });
 
 });

--- a/spec/javascripts/hmrc-webchat-spec.js
+++ b/spec/javascripts/hmrc-webchat-spec.js
@@ -51,8 +51,8 @@ describe('HMRC webchat', function () {
       expect($('.webchat-banner:not(.open)').length).toBe(1);
     });
 
-    it('sends no event to GA', function() {
-      expect(GOVUK.analytics.trackEvent).not.toHaveBeenCalledWith();
+    it('sends an "unavailable" event to GA', function() {
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'unavailable');
     });
 
   });
@@ -105,4 +105,38 @@ describe('HMRC webchat', function () {
     });
   });
 
+  describe('trackEvent', function () {
+    it('sends the supplied status as the action to GA with a category of "webchat"', function () {
+      GOVUK.webchat.trackEvent('chatting');
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('webchat', 'chatting');
+    });
+
+    it('does not send the status to GA again if the previous status was the same', function () {
+      GOVUK.webchat.trackEvent('chatting');
+      GOVUK.webchat.trackEvent('chatting');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(1);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('chatting');
+    });
+
+    it('sends the status to GA for each change in state (e.g. we only look at the previous state, we do not keep a full history)', function () {
+      GOVUK.webchat.trackEvent('chatting');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(1);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('chatting');
+      GOVUK.webchat.trackEvent('chatting');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(1);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('chatting');
+      GOVUK.webchat.trackEvent('listening');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(2);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('listening');
+      GOVUK.webchat.trackEvent('listening');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(2);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('listening');
+      GOVUK.webchat.trackEvent('chatting');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(3);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('chatting');
+      GOVUK.webchat.trackEvent('listening');
+      expect(GOVUK.analytics.trackEvent.calls.count()).toEqual(4);
+      expect(GOVUK.analytics.trackEvent.calls.mostRecent().args[1]).toEqual('listening');
+    });
+  });
 });


### PR DESCRIPTION
For: https://trello.com/c/nC2DtWRS/176-reduce-webchat-events-analytics

webchat.js polls the webchat iframe every second and when it detects that it is ready to be used it sends an "open" message.  Among other things this message causes an "offered" event to be send to GA.  This happens once a second while the webchat is available, which is flooding our GA hits.  This PR reduces the volume of hits by only sending the GA event when we detect a change in the status.  To this end we introduce an event for when we detect that the webchat system is closed (so we can track a state change from open to closed and backagain as advisors become available and unavailable.

This follows a pattern established in the new webchat system implemented in government-frontend (see: https://github.com/alphagov/government-frontend/pull/322).