### PR TITLE
Add Bing site verification page

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -52,6 +52,14 @@ namespace :publishing_api do
                       See https://support.google.com/webmasters/answer/35658",
       },
       {
+        base_path: "/BingSiteAuth.xml",
+        content_id: "d793dba8-4ff7-4a3f-a6d3-54f52b7bd259",
+        title: "Bing site verification",
+        description: "This file allows Bing to verify ownership of a site.
+                      It should not be removed as that can cause the site to become unverified
+                      See https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6",
+      },
+      {
         base_path: "/apple-touch-icon.png",
         content_id: "cdc36458-74d4-42a7-86c8-221e03877dfc",
         title: "Crest for Apple iOS bookmarks",

--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<users>
+	<user>66F6ADB7C4481C94247D1E08FA04C6A4</user>
+</users>


### PR DESCRIPTION
Add XML file to public pages and special routes.

The file specifies a verification code generated by Tara Stockford for https://www.gov.uk. It will verify our ownership of the site in Bing Webmaster Tools: https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6

This will help us to improve user journeys from Bing to GOV.UK.

https://trello.com/c/gBIgYRaV/174-set-up-bing-webmaster-tools