### PR TITLE
Remove leading period from custom survey postscripts

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -114,7 +114,7 @@
         templateArgs: {
           title: 'Are you a government publisher?',
           surveyCta: 'Answer a couple of questions about the publishing guidance.',
-          surveyCtaPostscript: 'This will open in a new tab'
+          surveyCtaPostscript: 'This will open in a new tab.'
         },
         activeWhen: function () {
           function pathMatches () {
@@ -144,7 +144,7 @@
         templateArgs: {
           title: 'Help improve GOV.UK.',
           surveyCta: 'Answer some questions about yourself to join the research community.',
-          surveyCtaPostscript: '. This link opens in a new tab.'
+          surveyCtaPostscript: 'This link opens in a new tab.'
         },
         activeWhen: function () {
           function pathMatches () {
@@ -167,7 +167,7 @@
         templateArgs: {
           title: 'Help improve GOV.UK.',
           surveyCta: 'Answer some questions about yourself to join the research community.',
-          surveyCtaPostscript: '. This link opens in a new tab.'
+          surveyCtaPostscript: 'This link opens in a new tab.'
         },
         activeWhen: function () {
           function pathMatches () {


### PR DESCRIPTION
The custom call to action already ends with a period so we don't need
to add one to the postscript.  Even if we wanted to have the period out
side the all to action text, there's a big gap between it and the
postscript text when they're actually rendered so we shouldn't
do it this way.

## Before

<img width="2004" alt="banners and alerts" src="https://user-images.githubusercontent.com/608/28518123-bf6025e4-705e-11e7-892f-980dd5b9cdb8.png">

## After

<img width="1968" alt="complain about a school or childminder - gov uk" src="https://user-images.githubusercontent.com/608/28518159-de82a960-705e-11e7-8127-06f67e20f6f4.png">
