### PR TITLE
Calculate how many links are on a finder

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -133,6 +133,7 @@
         $('.document-list .document-row h3 a').length;
       var documentCollectionLinks =
         $('.document-collection .group-document-list li a').length;
+      var finderLinks = $('.finder-frontend-content li.document a').length;
 
       // Document collections, being a content item, might have related links.
       // That means we need to check for links on it first, before we default
@@ -147,7 +148,8 @@
         subTopicPageLinks ||
         topicPageLinks ||
         policyAreaLinks ||
-        whitehallFinderPageLinks;
+        whitehallFinderPageLinks ||
+        finderLinks;
 
       return linksCount;
     }

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -775,6 +775,57 @@ describe("GOVUK.StaticAnalytics", function() {
           expect(pageViewObject.dimension27).toEqual('3');
         });
       });
+
+      describe('on a finder page', function() {
+        beforeEach(function() {
+          $('body').append('\
+            <div class="test-fixture">\
+              <main id="content" role="main" class="finder-frontend-content">\
+                <div id="finder-frontend">\
+                  <div class="filtering">\
+                    <div class="filtered-results">\
+                      <div id="js-results">\
+                        <ul>\
+                          <li class="document">\
+                            <h3>\
+                              <a href="/2012-olympic-and-paralympic-legacy">\
+                                2012 Olympic and Paralympic legacy\
+                              </a>\
+                            </h3>\
+                          </li>\
+                          <li class="document">\
+                            <h3>\
+                              <a href="/academies-and-free-schools">Academies and free schools</a></h3>\
+                          </li>\
+                          <li class="document">\
+                            <h3><a href="/government/policies/access-to-financial-services">Access to financial services</a></h3>\
+                          </li>\
+                        </ul>\
+                      </div>\
+                    </div>\
+                  </div>\
+                </div>\
+              </main>\
+            </div>\
+          ');
+        });
+
+        afterEach(function() {
+          $('.test-fixture').remove();
+        });
+
+        it('tracks the number of sections', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension26).toEqual('0');
+        });
+
+        it('tracks the total number of links', function() {
+          analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+          pageViewObject = getPageViewObject();
+          expect(pageViewObject.dimension27).toEqual('3');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This commit correctly sets dimension 27 with the number of links present
in a finder page such as `/government/policies`.

Trello: https://trello.com/c/vRtpDbnk/56-investigate-getting-nav-beta-analytics-tracking-onto-finder-template

Example on integration:

<img width="1121" alt="screen shot 2017-07-25 at 14 27 57" src="https://user-images.githubusercontent.com/416701/28574339-8c2b6ce6-7145-11e7-9e01-2b6f194d07e6.png">
