### PR TITLE
[DO NOT MERGE] Send state and language to GA

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -46,6 +46,7 @@
       'political-status': {dimension: 7},
       'analytics:organisations': {dimension: 9},
       'analytics:world-locations': {dimension: 10},
+      'withdrawn': {dimension: 12, defaultValue: 'current'},
       'schema-name': {dimension: 17},
       'rendering-application': {dimension: 20},
       'navigation-page-type': {dimension: 32, defaultValue: 'none'},
@@ -78,6 +79,8 @@
         customDimensions['dimension' + dimension.dimension] = value;
       }
     });
+
+    customDimensions['dimension23'] = $('main[id="content"]').attr('lang') || 'unknown';
 
     return customDimensions;
   }

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -9,6 +9,7 @@
 
   meta_tags["govuk:format"] = content_item_hash[:document_type] if content_item_hash[:document_type]
   meta_tags["govuk:schema-name"] = content_item_hash[:schema_name] if content_item_hash[:schema_name]
+  meta_tags["govuk:withdrawn"] = "withdrawn" if content_item_hash[:withdrawn_notice].present?
 
   organisations = []
   organisations += links_hash[:organisations] || []

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -150,16 +150,18 @@ describe('Ecommerce reporter for results pages', function() {
       dimension11: '1',
       dimension3: 'other',
       dimension4: '00000000-0000-0000-0000-000000000000',
+      dimension12: 'current',
+      dimension23: 'unknown',
+      dimension26: '0',
+      dimension27: '0',
       dimension32: 'none',
       dimension33: 'thing',
       dimension34: 'other',
+      dimension39: 'false',
       dimension56: 'other',
       dimension57: 'other',
       dimension58: 'other',
       dimension59: 'other',
-      dimension39: 'false',
-      dimension26: '0',
-      dimension27: '0',
     })
   });
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const numberOfDimensionsWithDefaultValues = 15;
+    const numberOfDimensionsWithDefaultValues = 17;
 
     var universalSetupArguments;
     var pageViewObject;
@@ -87,6 +87,11 @@ describe("GOVUK.StaticAnalytics", function() {
       });
 
       it('sets them as dimensions', function() {
+        $('body').append('\
+          <div class="test-fixture">\
+            <main role="main" id="content" class="document-collection" lang="fr"></main>\
+          </div>\
+        ');
         $('head').append('\
           <meta name="govuk:section" content="section">\
           <meta name="govuk:format" content="format">\
@@ -95,9 +100,9 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:political-status" content="historic">\
           <meta name="govuk:analytics:organisations" content="<D10>">\
           <meta name="govuk:analytics:world-locations" content="<W1>">\
+          <meta name="govuk:withdrawn" content="withdrawn">\
           <meta name="govuk:schema-name" content="schema-name">\
         ');
-
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
         pageViewObject = getPageViewObject();
 
@@ -108,7 +113,9 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(pageViewObject.dimension7).toEqual('historic');
         expect(pageViewObject.dimension9).toEqual('<D10>');
         expect(pageViewObject.dimension10).toEqual('<W1>');
+        expect(pageViewObject.dimension12).toEqual('withdrawn');
         expect(pageViewObject.dimension17).toEqual('schema-name');
+        expect(pageViewObject.dimension23).toEqual('fr');
       });
 
       it('ignores meta tags not set', function() {


### PR DESCRIPTION
For:
https://trello.com/c/zBBaVUGk/178-custom-dimension-publication-status
https://trello.com/c/cbycNx3y/201-custom-dimension-languages

## What this does

Sends the publishing state (withdrawn/not withdrawn) of the document and the language it's written in to Google Analytics. It will do this on every pageview event for publications, if it finds the state and/or the current language.

## Why 

The purpose is to gather more data about which documents are viewed the most when filtered by publishing state and language.