### PR TITLE
Change description of publish_special_routes rake task

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -1,5 +1,5 @@
 namespace :publishing_api do
-  desc "Publish special routes such as robots.txt"
+  desc "Publish special routes such as humans.txt"
   task :publish_special_routes do
     require 'gds_api/publishing_api/special_route_publisher'
 


### PR DESCRIPTION
This commit changes the description of the `publish_special_routes` rake task to not reference `robots.txt`, which is no longer published by this rake task.