### PR TITLE
Refactor how we calculate section and link counts

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -7,6 +7,7 @@
 //= require govuk/analytics/external-link-tracker
 //= require govuk/analytics/download-link-tracker
 
+//= require analytics/page-content
 //= require analytics/custom-dimensions
 //= require analytics/static-analytics
 //= require analytics/ecommerce

--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -84,75 +84,9 @@
 
   function customDimensionsFromDom() {
     return {
-      dimension26: totalNumberOfSections(),
-      dimension27: totalNumberOfSectionLinks()
+      dimension26: GOVUK.PageContent.getNumberOfSections(),
+      dimension27: GOVUK.PageContent.getNumberOfLinks()
     };
-
-    function totalNumberOfSections() {
-      var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
-      var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
-      var accordionSubsections = $('[data-track-count="accordionSection"]').length;
-      var gridSections = $('a[data-track-category="navGridLinkClicked"]').length;
-      var browsePageSections = $('#subsection ul:visible').length ||
-        $('#section ul').length;
-      var topicPageSections = $('.topics-page nav.index-list').length
-      var documentCollectionSections = $('.document-collection .group-title').length;
-      var policyAreaSections = $('.topic section h1.label').length;
-
-      // Document collections, being a content item, might have related links.
-      // That means we need to check for sections on it first, before we default
-      // to the sections on the side bar.
-      var sectionCount =
-        documentCollectionSections ||
-        sidebarSections ||
-        sidebarTaxons ||
-        accordionSubsections ||
-        gridSections ||
-        browsePageSections ||
-        topicPageSections ||
-        policyAreaSections;
-
-      return sectionCount;
-    }
-
-    function totalNumberOfSectionLinks() {
-      var relatedLinks = $('a[data-track-category="relatedLinkClicked"]').length;
-      var accordionLinks = $('a[data-track-category="navAccordionLinkClicked"]').length;
-      // Grid links are counted both as "sections" (see dimension 26), and as part of the total link count
-      var gridLinks = $('a[data-track-category="navGridLinkClicked"]').length
-        + $('a[data-track-category="navGridLeafLinkClicked"]').length;
-      var leafLinks = $('a[data-track-category="navLeafLinkClicked"]').length;
-      var browsePageLinks = $('#subsection ul a:visible').length ||
-        $('#section ul a').length;
-      var subTopicPageLinks = $('.topics-page .index-list ul a').length;
-      var topicPageLinks = $('.topics-page .topics ul a').length;
-      var policyAreaLinks =
-        $('section.document-block a').length +
-        $('section .collection-list h2 a').length
-      var whitehallFinderPageLinks =
-        $('.document-list .document-row h3 a').length;
-      var documentCollectionLinks =
-        $('.document-collection .group-document-list li a').length;
-      var finderLinks = $('.finder-frontend-content li.document a').length;
-
-      // Document collections, being a content item, might have related links.
-      // That means we need to check for links on it first, before we default
-      // to the sections on the side bar.
-      var linksCount =
-        documentCollectionLinks ||
-        relatedLinks ||
-        accordionLinks ||
-        gridLinks ||
-        leafLinks ||
-        browsePageLinks ||
-        subTopicPageLinks ||
-        topicPageLinks ||
-        policyAreaLinks ||
-        whitehallFinderPageLinks ||
-        finderLinks;
-
-      return linksCount;
-    }
   }
 
   function abTestCustomDimensions() {

--- a/app/assets/javascripts/analytics/page-content.js
+++ b/app/assets/javascripts/analytics/page-content.js
@@ -1,0 +1,120 @@
+(function () {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+  var PageContent = function () { }
+
+  PageContent.getNumberOfSections = function () {
+    switch(true) {
+      case isNavigationGridPage():
+        return $('a[data-track-category="navGridLinkClicked"]').length;
+      case isNavigationAccordionPage():
+        return $('[data-track-count="accordionSection"]').length;
+      case isDocumentCollectionPage():
+        return $('.document-collection .group-title').length;
+      case isMainstreamBrowsePage():
+        return $('#subsection ul:visible').length || $('#section ul').length;
+      case isTopicPage():
+        return $('.topics-page nav.index-list').length;
+      case isPolicyAreaPage():
+        return $('.topic section h1.label').length;
+      default:
+        // It's a content page, not a "finding" page
+        var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;
+        var sidebarTaxons = $('[data-track-count="sidebarTaxonSection"]').length;
+
+        return sidebarSections || sidebarTaxons;
+    }
+  };
+
+  PageContent.getNumberOfLinks = function () {
+    switch(true) {
+      case isNavigationGridPage():
+        return $('a[data-track-category="navGridLinkClicked"]').length
+          + $('a[data-track-category="navGridLeafLinkClicked"]').length;
+      case isNavigationAccordionPage():
+        return $('a[data-track-category="navAccordionLinkClicked"]').length;
+      case isNavigationLeafPage():
+        return $('a[data-track-category="navLeafLinkClicked"]').length;
+      case isDocumentCollectionPage():
+        return $('.document-collection .group-document-list li a').length;
+      case isMainstreamBrowsePage():
+        return $('#subsection ul a:visible').length ||
+          $('#section ul a').length;
+      case isTopicPage():
+        return $('.topics-page .index-list ul a').length ||
+          $('.topics-page .topics ul a').length;
+      case isPolicyAreaPage():
+        return $('section.document-block a').length +
+          $('section .collection-list h2 a').length;
+      case isWhitehallFinderPage():
+        return $('.document-list .document-row h3 a').length;
+      case isFinderPage():
+        return $('.finder-frontend-content li.document a').length;
+      default:
+        // It's a content page, not a "finding" page, count related links
+        return $('a[data-track-category="relatedLinkClicked"]').length;
+    }
+  };
+
+  function getRenderingApplication () {
+    return $('meta[name="govuk:rendering-application"]').attr('content');
+  };
+
+  function getFormat () {
+    return $('meta[name="govuk:format"]').attr('content');
+  };
+
+  function getNavigationPageType () {
+    return $('meta[name="govuk:navigation-page-type"]').attr('content');
+  };
+
+  function isNavigationGridPage () {
+    return getRenderingApplication() == 'collections' &&
+      getFormat() == 'taxon' &&
+      getNavigationPageType() == 'grid';
+  };
+
+  function isNavigationAccordionPage () {
+    return getRenderingApplication() == 'collections' &&
+      getFormat() == 'taxon' &&
+      getNavigationPageType() == 'accordion';
+  };
+
+  function isNavigationLeafPage () {
+    return getRenderingApplication() == 'collections' &&
+      getFormat() == 'taxon' &&
+      getNavigationPageType() == 'leaf';
+  };
+
+  function isMainstreamBrowsePage () {
+    return getRenderingApplication() == 'collections' &&
+      getFormat() == 'mainstream_browse_page'
+  };
+
+  function isTopicPage () {
+    return getRenderingApplication() == 'collections' &&
+      getFormat() == 'topic'
+  };
+
+  function isPolicyAreaPage () {
+    return getRenderingApplication() == 'whitehall' &&
+      getFormat() == 'placeholder_policy_area'
+  };
+
+  function isDocumentCollectionPage () {
+    return getRenderingApplication() == 'government-frontend' &&
+      getFormat() == 'document_collection'
+  };
+
+  function isFinderPage () {
+    return getRenderingApplication() == 'finder-frontend' &&
+      getFormat() == 'finder'
+  };
+
+  function isWhitehallFinderPage () {
+    return getRenderingApplication() == 'whitehall' &&
+      getFormat() == 'finder'
+  };
+
+  GOVUK.PageContent = PageContent;
+})();

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -216,6 +216,12 @@ describe("GOVUK.StaticAnalytics", function() {
       describe('when tracking the number of sections and links on a page', function() {
         describe('on a page with a normal sidebar', function() {
           beforeEach(function() {
+            $('head').append('\
+              <div class="test-meta-tags">\
+                <meta name="govuk:rendering-application" content="government-frontend">\
+                <meta name="govuk:format" content="transaction">\
+              </div>\
+            ')
             $('body').append('\
               <div class="test-fixture">\
                 <aside class="govuk-related-items">\
@@ -250,6 +256,7 @@ describe("GOVUK.StaticAnalytics", function() {
           });
 
           afterEach(function() {
+            $('.test-meta-tags').remove();
             $('.test-fixture').remove();
           });
 
@@ -268,6 +275,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
         describe('on a page with a taxon sidebar', function() {
           beforeEach(function() {
+            $('head').append('\
+              <div class="test-meta-tags">\
+                <meta name="govuk:rendering-application" content="government-frontend">\
+                <meta name="govuk:format" content="transaction">\
+              </div>\
+            ')
             $('body').append('\
               <div class="test-fixture">\
                 <aside class="govuk-taxonomy-sidebar">\
@@ -306,6 +319,7 @@ describe("GOVUK.StaticAnalytics", function() {
           });
 
           afterEach(function() {
+            $('.test-meta-tags').remove();
             $('.test-fixture').remove();
           });
 
@@ -324,6 +338,13 @@ describe("GOVUK.StaticAnalytics", function() {
 
         describe('on a page with an accordion', function() {
           beforeEach(function() {
+            $('head').append('\
+              <div class="test-meta-tags">\
+                <meta name="govuk:rendering-application" content="collections">\
+                <meta name="govuk:navigation-page-type" content="accordion">\
+                <meta name="govuk:format" content="taxon">\
+              </div>\
+            ')
             $('body').append('\
               <div class="test-fixture">\
                 <div class="accordion-with-descriptions">\
@@ -368,6 +389,7 @@ describe("GOVUK.StaticAnalytics", function() {
           });
 
           afterEach(function() {
+            $('.test-meta-tags').remove();
             $('.test-fixture').remove();
           });
 
@@ -384,8 +406,15 @@ describe("GOVUK.StaticAnalytics", function() {
           });
         });
 
-        describe('on a page with an grid', function() {
+        describe('on a page with a grid', function() {
           beforeEach(function() {
+            $('head').append('\
+              <div class="test-meta-tags">\
+                <meta name="govuk:rendering-application" content="collections">\
+                <meta name="govuk:navigation-page-type" content="grid">\
+                <meta name="govuk:format" content="taxon">\
+              </div>\
+            ')
             $('body').append('\
               <div class="test-fixture">\
                 <main class="taxon-page">\
@@ -433,6 +462,7 @@ describe("GOVUK.StaticAnalytics", function() {
           });
 
           afterEach(function() {
+            $('.test-meta-tags').remove();
             $('.test-fixture').remove();
           });
 
@@ -452,6 +482,13 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a navigation leaf page', function() {
         beforeEach(function() {
+            $('head').append('\
+              <div class="test-meta-tags">\
+                <meta name="govuk:rendering-application" content="collections">\
+                <meta name="govuk:navigation-page-type" content="leaf">\
+                <meta name="govuk:format" content="taxon">\
+              </div>\
+            ')
           $('body').append('\
               <div class="test-fixture">\
                 <div class="topic-content">\
@@ -477,6 +514,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -495,6 +533,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a topic page', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="collections">\
+              <meta name="govuk:format" content="topic">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <main id="content" role="main" class="content topics-page">\
@@ -520,6 +564,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -538,6 +583,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a sub topic page', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="collections">\
+              <meta name="govuk:format" content="topic">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <main id="content" role="main" class="content topics-page">\
@@ -591,6 +642,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -609,6 +661,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a policy area page', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="whitehall">\
+              <meta name="govuk:format" content="placeholder_policy_area">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <div class="topic classification topic">\
@@ -655,6 +713,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -673,6 +732,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a document collection page', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="government-frontend">\
+              <meta name="govuk:format" content="document_collection">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <main role="main" id="content" class="document-collection">\
@@ -713,6 +778,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -731,6 +797,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a whitehall finder page (e.g Announcements)', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="whitehall">\
+              <meta name="govuk:format" content="finder">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <ol class="document-list">\
@@ -760,6 +832,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 
@@ -778,6 +851,12 @@ describe("GOVUK.StaticAnalytics", function() {
 
       describe('on a finder page', function() {
         beforeEach(function() {
+          $('head').append('\
+            <div class="test-meta-tags">\
+              <meta name="govuk:rendering-application" content="finder-frontend">\
+              <meta name="govuk:format" content="finder">\
+            </div>\
+          ')
           $('body').append('\
             <div class="test-fixture">\
               <main id="content" role="main" class="finder-frontend-content">\
@@ -811,6 +890,7 @@ describe("GOVUK.StaticAnalytics", function() {
         });
 
         afterEach(function() {
+          $('.test-meta-tags').remove();
           $('.test-fixture').remove();
         });
 


### PR DESCRIPTION
This commit moves the logic of determining how many sections and links
are on a given page to a new module, which has more granular functions
to extract all the necessary bits from a page to make a decision.

This refactoring aims at making it clearer what the steps are. Ideally,
each rendering application would set these counts in a meta tag and this
code would only read from it, but it's a bit more complicated than that,
especially for JS-driven finders.

What do you think?