### PR TITLE
Add button component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -15,7 +15,7 @@
   background-repeat: no-repeat;
 
   @include media-down(mobile) {
-    background-position: 110% 50%;
+    background-position: center right -.35em;
   }
 
   @include ie(7) {

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -1,5 +1,11 @@
 .pub-c-button {
   @include button;
+
+  @media(max-width: 425px) {
+    box-sizing: border-box;
+    width: 100%;
+    text-align: center;
+  }
 }
 
 .pub-c-button--start {

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -1,3 +1,4 @@
+%pub-c-button,
 .pub-c-button {
   @include button;
 
@@ -8,6 +9,7 @@
   }
 }
 
+%pub-c-button--start,
 .pub-c-button--start {
   @include bold-24($line-height: (24 / 20));
   display: inline-block;

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -11,11 +11,13 @@
 .pub-c-button--start {
   @include bold-24($line-height: (24 / 20));
   display: inline-block;
-  padding: 0.60em 1.7em 0.45em 0.67em;
+  padding: 0.6em 1.7em 0.45em 0.67em;
+
   @include media(tablet) {
     padding-top: 0.3em;
     padding-bottom: 0.15em;
   }
+
   background-image: image-url("icon-pointer.png");
   background-position: 100% 50%;
   background-repeat: no-repeat;
@@ -30,8 +32,10 @@
   }
 }
 
+// scss-lint:disable SelectorFormat
 .pub-c-button__info-text {
   display: block;
   margin-top: .5em;
   max-width: 14em;
 }
+// scss-lint:enable SelectorFormat

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -3,9 +3,13 @@
 }
 
 .pub-c-button--start {
-  @include bold-24($line-height: (16 / 24));
+  @include bold-24($line-height: (24 / 20));
   display: inline-block;
   padding: 0.60em 1.7em 0.45em 0.67em;
+  @include media(tablet) {
+    padding-top: 0.3em;
+    padding-bottom: 0.15em;
+  }
   background-image: image-url("icon-pointer.png");
   background-position: 100% 50%;
   background-repeat: no-repeat;

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -1,0 +1,37 @@
+.pub-c-button {
+  @include button;
+}
+
+.pub-c-button--start {
+  @include bold-24($line-height: (16 / 24));
+  display: inline-block;
+  padding: 0.60em 1.7em 0.45em 0.67em;
+  background-image: image-url("icon-pointer.png");
+  background-position: 100% 50%;
+  background-repeat: no-repeat;
+
+  @include media-down(mobile) {
+    background-position: 110% 50%;
+  }
+
+  @include ie(7) {
+    padding: 0.45em 1.7em 0.62em 0.67em;
+  }
+
+  @include ie(6) {
+    background-image: image-url('icon-pointer-indexed.png');
+    /* IE6 adds its own side padding so requires no extra */
+    padding: 0.45em 0.5em 0.62em 0em;
+  }
+
+  @include device-pixel-ratio() {
+    background-image: image-url("icon-pointer-2x.png");
+    background-size: 30px 19px;
+  }
+}
+
+.pub-c-button__info-text {
+  display: block;
+  margin-top: .5em;
+  max-width: 14em;
+}

--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -24,16 +24,6 @@
     background-position: center right -.35em;
   }
 
-  @include ie(7) {
-    padding: 0.45em 1.7em 0.62em 0.67em;
-  }
-
-  @include ie(6) {
-    background-image: image-url('icon-pointer-indexed.png');
-    /* IE6 adds its own side padding so requires no extra */
-    padding: 0.45em 0.5em 0.62em 0em;
-  }
-
   @include device-pixel-ratio() {
     background-image: image-url("icon-pointer-2x.png");
     background-size: 30px 19px;

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -23,3 +23,4 @@
 @import "organisation-logo";
 @import "taxonomy-sidebar";
 @import "search";
+@import "button";

--- a/app/assets/stylesheets/govuk-component/_govspeak.scss
+++ b/app/assets/stylesheets/govuk-component/_govspeak.scss
@@ -1,5 +1,6 @@
 @import "govspeak/advisory";
 @import "govspeak/attachment";
+@import "govspeak/button";
 @import "govspeak/call-to-action";
 @import "govspeak/charts";
 @import "govspeak/contact";

--- a/app/assets/stylesheets/govuk-component/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_button.scss
@@ -1,0 +1,9 @@
+.govuk-govspeak {
+  .button {
+    @extend .pub-c-button;
+  }
+
+  .button-start {
+    @extend .pub-c-button--start;
+  }
+}

--- a/app/assets/stylesheets/govuk-component/govspeak/_button.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_button.scss
@@ -1,9 +1,9 @@
 .govuk-govspeak {
   .button {
-    @extend .pub-c-button;
+    @extend %pub-c-button;
   }
 
   .button-start {
-    @extend .pub-c-button--start;
+    @extend %pub-c-button--start;
   }
 }

--- a/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
+++ b/app/assets/stylesheets/govuk-component/govspeak/_typography.scss
@@ -66,12 +66,6 @@
     text-decoration: underline;
   }
 
-  // Buttons
-
-  .button {
-    text-decoration: none;
-  }
-
   // Lists
 
   ol,

--- a/app/views/govuk_component/button.raw.html.erb
+++ b/app/views/govuk_component/button.raw.html.erb
@@ -1,0 +1,26 @@
+<%
+  start ||= false
+  href ||= false
+  info_text ||= false
+  text ||= ""
+  tag_name = href ? "a" : "button"
+%>
+<<%= tag_name %>
+  class="
+    pub-c-button
+    <% if start == true %>
+      pub-c-button--start
+    <% end %>
+  "
+  <% if href %>
+    href="<%= href.try(:html_safe) %>"
+    role="button"
+  <% end %>
+>
+  <%= text %>
+</<%= tag_name %>>
+<% if info_text %>
+  <span class="pub-c-button__info-text">
+    <%= info_text.try(:html_safe) %>
+  </span>
+<% end %>

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -11,7 +11,13 @@ body: |
   Global button styles seen at `app/assets/stylesheets/helpers/_buttons.scss`
   should be considered deprecated with this component replacing any instances.
 
-  govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.m
+  govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.md
+
+  This component is also extended for use in govspeak (http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/button).
+
+  These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
+  via our components within the generated [govspeak](https://github.com/alphagov/govspeak).
+  (This is a challenge to the reader :))
 accessibility_criteria: |
   The button must:
 

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -1,0 +1,38 @@
+name: "Button"
+description: "Use buttons to move though a transaction, aim to use only one button per page."
+body: |
+  Button text should be short and describe the action the button performs.
+
+  GOV.UK Elements has more information on how buttons should be used https://govuk-elements.herokuapp.com/buttons/
+
+  Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky,
+  in time this component will be a wrapper for the GOV.UK Frontend projects button component.
+
+  Global button styles seen at `app/assets/stylesheets/helpers/_buttons.scss`
+  should be considered deprecated with this component replacing any instances.
+
+  govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.m
+
+  FIXME: Should link_button be allowed?
+fixtures:
+  default:
+    text: "Submit"
+  link_button:
+    text: "I'm really a link sssh"
+    href: "#"
+  start_now_button:
+    text: "Start now"
+    href: "#"
+    start: true
+  start_now_button_with_info_text:
+    text: "Start now"
+    href: "#"
+    start: true
+    info_text: "Sometimes you want to explain where a user is going to."
+  extreme_text:
+    text: "I'm a button with lots of text to test how the component scales at extremes."
+    href: "#"
+  extreme_text_start_now_button:
+    text: "I'm a start now button with lots of text to test how the component scales at extremes."
+    start: true
+    href: "#"

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -12,6 +12,16 @@ body: |
   should be considered deprecated with this component replacing any instances.
 
   govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.m
+accessibility_criteria: |
+  The button must:
+
+  - accept focus
+  - be focusable with a keyboard
+  - indicate when it has focus
+  - activate when focused and space is pressed
+  - activate when focused and enter is pressed
+  - have a role of button
+  - have an accessible label
 fixtures:
   default:
     text: "Submit"

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -3,7 +3,7 @@ description: "Use buttons to move though a transaction, aim to use only one butt
 body: |
   Button text should be short and describe the action the button performs.
 
-  GOV.UK Elements has more information on how buttons should be used https://govuk-elements.herokuapp.com/buttons/
+  [GOV.UK Elements has more information](https://govuk-elements.herokuapp.com/buttons/) on how buttons should be used.
 
   Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky,
   in time this component will be a wrapper for the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project's button component.
@@ -11,13 +11,13 @@ body: |
   Global button styles seen at `app/assets/stylesheets/helpers/_buttons.scss`
   should be considered deprecated with this component replacing any instances.
 
-  govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.md
+  govuk-* namespace replaced with pub-c-* otherwise we will conflict with [GOV.UK Frontend's namespace](https://github.com/alphagov/govuk-frontend/blob/master/docs/components.md)
 
-  This component is also extended for use in govspeak (http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/button).
+  This component is also [extended for use in govspeak](http://govuk-component-guide.herokuapp.com/components/govspeak/fixtures/button).
 
   These instances of buttons are added by Content Designers, ideally this duplication would not exist but we currently don't have shared markup
   via our components within the generated [govspeak](https://github.com/alphagov/govspeak).
-  (This is a challenge to the reader :))
+  (This is a challenge to the reader)
 accessibility_criteria: |
   The button must:
 

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -6,14 +6,12 @@ body: |
   GOV.UK Elements has more information on how buttons should be used https://govuk-elements.herokuapp.com/buttons/
 
   Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky,
-  in time this component will be a wrapper for the GOV.UK Frontend projects button component.
+  in time this component will be a wrapper for the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project's button component.
 
   Global button styles seen at `app/assets/stylesheets/helpers/_buttons.scss`
   should be considered deprecated with this component replacing any instances.
 
   govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.m
-
-  FIXME: Should link_button be allowed?
 fixtures:
   default:
     text: "Submit"

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -591,3 +591,8 @@ fixtures:
       <div class="summary">
         <p>This is a summary</p>
       </div>
+  button:
+    content: |
+      <a href="#" class="button button-start" role="button">
+        Start now
+      </a>

--- a/test/govuk_component/button_test.rb
+++ b/test/govuk_component/button_test.rb
@@ -12,6 +12,13 @@ class ButtonTestCase < ComponentTestCase
     end
   end
 
+  test "renders the correct defaults" do
+    render_component(text: "Submit")
+    assert_select ".pub-c-button", text: "Submit"
+    assert_select ".pub-c-button--start", false
+    assert_select ".pub-c-button__info-text", false
+  end
+
   test "renders text correctly" do
     render_component(text: "Submit")
     assert_select ".pub-c-button", text: "Submit"

--- a/test/govuk_component/button_test.rb
+++ b/test/govuk_component/button_test.rb
@@ -1,0 +1,43 @@
+require 'govuk_component_test_helper'
+
+class ButtonTestCase < ComponentTestCase
+  def component_name
+    "button"
+  end
+
+  test "no error if no parameters passed in" do
+    assert_nothing_raised do
+      render_component({})
+      assert_select ".pub-c-button"
+    end
+  end
+
+  test "renders text correctly" do
+    render_component(text: "Submit")
+    assert_select ".pub-c-button", text: "Submit"
+  end
+
+  test "renders start now button" do
+    render_component(text: "Start now", href: "#", start: true)
+    assert_select ".pub-c-button", text: "Start now", href: "#"
+    assert_select ".pub-c-button--start"
+  end
+
+  test "renders an anchor if href set" do
+    render_component(text: "Start now", href: "#")
+    assert_select "a.pub-c-button"
+    assert_select "button.pub-c-button", false
+  end
+
+  test "renders a button if href not set" do
+    render_component(text: "Start now")
+    assert_select "button.pub-c-button"
+    assert_select "a.pub-c-button", false
+  end
+
+  test "renders info text" do
+    render_component(text: "Start now", info_text: "Information text")
+    assert_select ".pub-c-button", text: "Start now"
+    assert_select ".pub-c-button__info-text", text: "Information text"
+  end
+end


### PR DESCRIPTION
Adds a button component to be used across applications

Note: We do not consume GOV.UK Elements directly due to the naming conventions being leaky, in time this component will be a wrapper for the [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) project's button component.
 
 Global button styles seen at `app/assets/stylesheets/helpers/_buttons.scss`
 should be considered deprecated with this component replacing any instances.
 
 govuk-* namespace replaced with pub-c-* otherwise we will conflict with https://github.com/alphagov/govuk-frontend/blob/master/docs/components.md

government-frontend PR using this component: https://github.com/alphagov/government-frontend/pull/418

| Before   |
|---|
| Big |
|   ![big](https://user-images.githubusercontent.com/2445413/28710090-b1a285fe-737a-11e7-8331-95444a36b802.png) |
| Not so big |
| ![lessbig](https://user-images.githubusercontent.com/2445413/28710134-d1237352-737a-11e7-90bf-c8650a4572bf.png) |
| Pretty small |
| ![kindasmall](https://user-images.githubusercontent.com/2445413/28710176-f532ec50-737a-11e7-94f1-3cd2d0faee70.png) |
| Small |
| ![small](https://user-images.githubusercontent.com/2445413/28710184-f967be7c-737a-11e7-83d7-bca4df5f18fa.png) |


| After |
|---|
| Big |
| ![big](https://user-images.githubusercontent.com/2445413/28723236-1262f9ae-73ae-11e7-83a7-43155a8b013c.png) |
| Medium |
| ![medium](https://user-images.githubusercontent.com/2445413/28723237-12643e54-73ae-11e7-8d95-23122d253fdc.png) |
| Small |
| ![small](https://user-images.githubusercontent.com/2445413/28723235-1260a78a-73ae-11e7-93ce-1581dde2c94e.png) |
| iPhone 6 iOS9 |
| ![iphone6 ios9](https://user-images.githubusercontent.com/2445413/28723238-12682802-73ae-11e7-9484-9487ed25d81f.png) |
| Samsung Galaxy S7 |
| ![samsunggalaxy7](https://user-images.githubusercontent.com/2445413/28723239-126d1420-73ae-11e7-8513-f1857828d86a.png) |
| Safari 6 |
| ![safari6](https://user-images.githubusercontent.com/2445413/28723240-12798926-73ae-11e7-8e4f-a9cfb825d647.png) |
| Chrome 57 |
| ![chrome57](https://user-images.githubusercontent.com/2445413/28723242-127c1484-73ae-11e7-974a-cfae1d8afe0e.png) |
| Firefox 56 |
| ![firefox56](https://user-images.githubusercontent.com/2445413/28723241-1279f654-73ae-11e7-81ff-a8d98fdca75b.png) |
| Edge 15 |
| ![edge15](https://user-images.githubusercontent.com/2445413/28723245-1283e6e6-73ae-11e7-97ac-9009f45b00e1.png) |
| IE11 |
| ![ie11](https://user-images.githubusercontent.com/2445413/28723244-1282c96e-73ae-11e7-86bd-ac42688965dc.png) |
| IE10 |
| ![ie10](https://user-images.githubusercontent.com/2445413/28723243-128274dc-73ae-11e7-8be9-011ba23e4f9a.png) |
| IE9 |
| ![ie9](https://user-images.githubusercontent.com/2445413/28723246-12924358-73ae-11e7-8470-80154092eac8.png) |
| IE8 |
| ![ie8](https://user-images.githubusercontent.com/2445413/28723248-1297308e-73ae-11e7-856c-40a34801e7b4.png) |
| IE7 |
| ![ie7](https://user-images.githubusercontent.com/2445413/28723247-1293b85a-73ae-11e7-9fee-91b5dc422a80.png) |
| IE6 |
| ![ie6](https://user-images.githubusercontent.com/2445413/28723249-129a45ee-73ae-11e7-94db-ce6e11e73ad9.png) |

Also extends component for use in the govspeak component

Component Guide

![screen shot 2017-08-01 at 13 15 21](https://user-images.githubusercontent.com/2445413/28827003-1547deb4-76c4-11e7-94a4-95576f429e85.png)

Hardcoded button example

www.gov.uk/access-to-work/apply

![screen shot 2017-08-01 at 13 14 47](https://user-images.githubusercontent.com/2445413/28827004-154bc074-76c4-11e7-9ee8-2e43e25d604f.png)












