### PR TITLE
[DO NOT MERGE] Count finder sections as one

### DIFF
--- a/app/assets/javascripts/analytics/page-content.js
+++ b/app/assets/javascripts/analytics/page-content.js
@@ -17,6 +17,12 @@
         return $('.topics-page nav.index-list').length;
       case isPolicyAreaPage():
         return $('.topic section h1.label').length;
+      case isFinderPage():
+      case isWhitehallFinderPage():
+        // The default in finders should be one, so it's comparable with A-Z
+        // lists in other navigation pages. Request made by performance
+        // analysts.
+        return 1;
       default:
         // It's a content page, not a "finding" page
         var sidebarSections = $('[data-track-count="sidebarRelatedItemSection"]').length;

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -839,7 +839,7 @@ describe("GOVUK.StaticAnalytics", function() {
         it('tracks the number of sections', function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
           pageViewObject = getPageViewObject();
-          expect(pageViewObject.dimension26).toEqual('0');
+          expect(pageViewObject.dimension26).toEqual('1');
         });
 
         it('tracks the total number of links', function() {
@@ -897,7 +897,7 @@ describe("GOVUK.StaticAnalytics", function() {
         it('tracks the number of sections', function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
           pageViewObject = getPageViewObject();
-          expect(pageViewObject.dimension26).toEqual('0');
+          expect(pageViewObject.dimension26).toEqual('1');
         });
 
         it('tracks the total number of links', function() {


### PR DESCRIPTION
We should default to 1 section in all finders, so that it's comparable with navigations with only an A-Z section.

This is a request from Vin, performance analyst.

Trello: https://trello.com/c/vRtpDbnk/56-investigate-getting-nav-beta-analytics-tracking-onto-finder-template

**Note to the reviewer:** this was built on top of https://github.com/alphagov/static/pull/1103, please review that one first and I will rebase this branch to remove the cherry-picked commit.