### PR TITLE
Add user defined link text to emergency banner

### DIFF
--- a/app/views/notifications/_emergency_banner.html.erb
+++ b/app/views/notifications/_emergency_banner.html.erb
@@ -5,7 +5,7 @@
       <p><%= banner.short_description %></p>
     <% end %>
     <% if banner.link %>
-      <a href="<%= banner.link %>">More information</a>
+      <a href="<%= banner.link %>"><%= banner.link_text %></a>
     <% end %>
   </div>
 </div>

--- a/doc/emergency-banner.md
+++ b/doc/emergency-banner.md
@@ -7,7 +7,7 @@ See the [opsmanual](https://docs.publishing.service.gov.uk/manual/emergency-publ
 ### Deploying the Emergency banner
 
 ```
-bundle exec rake emergency_banner:deploy['{campaign_class}','{heading}','{short_description}','{link}']
+bundle exec rake emergency_banner:deploy['{campaign_class}','{heading}','{short_description}','{link}','{link_text}']
 ```
 
 Where
@@ -16,6 +16,8 @@ Where
 * `heading` is the \<H1\> title
 * `short_description` is the text that appears under the title
 * `link` is the more information link
+* 'link_text' is the anchor text for the more information link above.
+  Defaults to "More information"
 
 N.B. Don't add spaces between the parameters.
 

--- a/lib/emergency_banner/deploy.rb
+++ b/lib/emergency_banner/deploy.rb
@@ -1,12 +1,13 @@
 module EmergencyBanner
   class Deploy
-    def run(campaign_class, heading, short_description = "", link = "")
+    def run(campaign_class, heading, short_description = "", link = "", link_text = "")
       redis = Redis.new
       redis.hmset(:emergency_banner,
                   :campaign_class, campaign_class,
                   :heading, heading,
                   :short_description, short_description,
                   :link, link,
+                  :link_text, link_text,
                  )
     end
   end

--- a/lib/emergency_banner/display.rb
+++ b/lib/emergency_banner/display.rb
@@ -30,7 +30,15 @@ module EmergencyBanner
       content[:link] if content[:link].present?
     end
 
+    def link_text
+      return nil if link.blank?
+      return content[:link_text] if content[:link_text].present?
+      MORE_INFORMATION
+    end
+
   private
+
+    MORE_INFORMATION = "More information"
 
     def content
       return @content if defined? @content

--- a/lib/tasks/emergency_banner.rake
+++ b/lib/tasks/emergency_banner.rake
@@ -3,11 +3,11 @@ require_relative '../emergency_banner/remove'
 
 namespace :emergency_banner do
   desc 'Deploy the emergency banner'
-  task :deploy, [:campaign_class, :heading, :short_description, :link] => :environment do |_, args|
+  task :deploy, [:campaign_class, :heading, :short_description, :link, :link_text] => :environment do |_, args|
     raise ArgumentError unless args.campaign_class
     raise ArgumentError unless args.heading
 
-    EmergencyBanner::Deploy.new.run(args.campaign_class, args.heading, args.short_description, args.link)
+    EmergencyBanner::Deploy.new.run(args.campaign_class, args.heading, args.short_description, args.link, args.link_text)
   end
 
   desc 'Remove the emergency banner'

--- a/test/integration/notifications_test.rb
+++ b/test/integration/notifications_test.rb
@@ -41,6 +41,17 @@ class NotificationsTest < ActionDispatch::IntegrationTest
       assert_match(/yoricks\.gov/, page.body)
     end
 
+    should "render the more information link with specified text" do
+      EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
+      EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("notable-death")
+      EmergencyBanner::Display.any_instance.stubs(:link).returns("https://yoricks.gov")
+      EmergencyBanner::Display.any_instance.stubs(:link_text).returns("Some specified text for more information")
+
+      visit "/templates/wrapper.html.erb"
+
+      assert_match "Some specified text for more information", page.body
+    end
+
     should "not render the more information link if it does not exist" do
       EmergencyBanner::Display.any_instance.stubs(:heading).returns("Alas poor Yorick")
       EmergencyBanner::Display.any_instance.stubs(:campaign_class).returns("notable-death")

--- a/test/tasks/emergency_banner_test.rb
+++ b/test/tasks/emergency_banner_test.rb
@@ -32,9 +32,9 @@ describe 'emergency_banner:deploy' do
   end
 
   should 'pass all supplied parameters to the deploy job' do
-    EmergencyBanner::Deploy.any_instance.expects(:run).with('campaign class', 'heading', 'short description', 'link')
+    EmergencyBanner::Deploy.any_instance.expects(:run).with('campaign class', 'heading', 'short description', 'link', 'link_text')
 
-    Rake::Task['emergency_banner:deploy'].invoke('campaign class', 'heading', 'short description', 'link')
+    Rake::Task['emergency_banner:deploy'].invoke('campaign class', 'heading', 'short description', 'link', 'link_text')
   end
 end
 

--- a/test/unit/emergency_banner/deploy_test.rb
+++ b/test/unit/emergency_banner/deploy_test.rb
@@ -9,6 +9,7 @@ describe "Emergency Banner::Deploy" do
                                               :heading, "A title",
                                               :short_description, "",
                                               :link, "",
+                                              :link_text, "",
                                              )
 
       EmergencyBanner::Deploy.new.run("notable-death", "A title")
@@ -20,31 +21,46 @@ describe "Emergency Banner::Deploy" do
                                               :heading, "A title",
                                               :short_description, "A short description of the event",
                                               :link, "",
+                                              :link_text, "",
                                              )
 
       EmergencyBanner::Deploy.new.run("notable-death", "A title", "A short description of the event")
     end
 
-    should "create an emergency_banner with a campaign_class, heading and a link" do
+    should "create an emergency_banner with a campaign_class, heading and link" do
       Redis.any_instance.expects(:hmset).with(:emergency_banner,
                                               :campaign_class, "notable-death",
                                               :heading, "A title",
                                               :short_description, "",
-                                              :link, "https://www.gov.uk"
+                                              :link, "https://www.gov.uk",
+                                              :link_text, ""
                                              )
 
       EmergencyBanner::Deploy.new.run("notable-death", "A title", "", "https://www.gov.uk")
     end
 
-    should "create an emergency_banner with a campaign_class, heading, short_description and a link" do
+    should "create an emergency_banner with a campaign_class, heading, short_description and link" do
       Redis.any_instance.expects(:hmset).with(:emergency_banner,
                                               :campaign_class, "notable-death",
                                               :heading, "A title",
                                               :short_description, "A short description of the event",
-                                              :link, "https://www.gov.uk"
+                                              :link, "https://www.gov.uk",
+                                              :link_text, ""
                                              )
 
       EmergencyBanner::Deploy.new.run("notable-death", "A title", "A short description of the event", "https://www.gov.uk")
+    end
+
+    should "create an emergency_banner with a campaign_class, heading, short_description, link and link_text" do
+      Redis.any_instance.expects(:hmset).with(:emergency_banner,
+                                              :campaign_class, "notable-death",
+                                              :heading, "A title",
+                                              :short_description, "A short description of the event",
+                                              :link, "https://www.gov.uk",
+                                              :link_text, "Text for hyperlink",
+                                             )
+
+      EmergencyBanner::Deploy.new.run("notable-death", "A title", "A short description of the event", "https://www.gov.uk", "Text for hyperlink")
     end
   end
 end

--- a/test/unit/emergency_banner/display_test.rb
+++ b/test/unit/emergency_banner/display_test.rb
@@ -129,11 +129,47 @@ describe "Emergency Banner::Display" do
       assert_nil @banner.link
     end
 
-    should "return nil for the short description and the link if they are not present" do
+    should "return the link_text if there is a link and the link_text it is present" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(
+        link: "https://www.gov.uk",
+        link_text: "More information link text"
+      )
+
+      assert_equal "More information link text", @banner.link_text
+    end
+
+    should "return default link_text if link is present but link_text is not" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(
+        link: "https://www.gov.uk/some-or-other-url",
+      )
+
+      assert_equal "More information", @banner.link_text
+    end
+
+    should "return default link_text if link is present but link_text is empty string" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(
+        link: "https://www.gov.uk",
+        link_text: ""
+      )
+
+      assert_equal "More information", @banner.link_text
+    end
+
+    should "return nil for the link_text if there is no link, even if link_text is present" do
+      Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns(
+        link: "",
+        link_text: "More information link text"
+      )
+
+      assert_nil @banner.link_text
+    end
+
+    should "return nil for the short description, link and link_text if they are not present in redis" do
       Redis.any_instance.stubs(:hgetall).with("emergency_banner").returns({})
 
       assert_nil @banner.short_description
       assert_nil @banner.link
+      assert_nil @banner.link_text
     end
   end
 end


### PR DESCRIPTION
Emergency banners have the option of displaying a hyperlink for more information. The hyperlink text is currently hard coded to "More information" in the view. This PR makes the anchor text user definable.

* Add a parameter to the EmergencyBanner::Deploy class which writes the emergency banner data to Redis.
* Expose the new parameter that we store in Redis above via EmergencyBanner::Display. Also include a little logic to set a default value of "More information" since it isn't a mandatory field.
* Using the new "property" in EmergencyBanner::Display, show the anchor text in the view
* Update the rake task that we call from Jenkins to deploy the banner to include the new variable.

This should be released in conjunction with:

- [ ] [PR 6170 in GOV.UK Puppet](https://github.com/alphagov/govuk-puppet/pull/6170)
- [ ] [PR 352 in GOV.UK Developer Docs](https://github.com/alphagov/govuk-developer-docs/pull/352)


[Trello](https://trello.com/c/ZPkk7hnk/58-add-new-field-for-link-text)
