### PR TITLE
Change frequency of publisher guidance survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -107,7 +107,7 @@
       {
         identifier: 'publisher_guidance_survey',
         surveyType: 'url',
-        frequency: 6,
+        frequency: 1,
         startTime: new Date('July 17, 2017').getTime(),
         endTime: new Date('August 16, 2017 23:59:50').getTime(),
         url: 'https://www.smartsurvey.co.uk/s/govukpublisherguidance?c={{currentPath}}',


### PR DESCRIPTION
Change frequency of `publisher_guidance_survey` from `1 in 6 times` to `1 in 1 times`. This is a result of noticing that there aren't a lot of visitors to the pages where this survey is running.

For: https://trello.com/c/Ye7GkB92/204-change-frequency-of-publisher-guidance-survey-from-1-in-6-to-1-in-1