### PR TITLE
Remove full stop from titles of surveys

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -135,7 +135,7 @@
         // use a map to translate the path into the utm_campaign value
         url: 'https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=' + hmrcSurveyUtmCampaignValueMap() + '&utm_source=Money_and_tax&utm_medium=gov.uk&t=HMRC',
         templateArgs: {
-          title: 'Help improve GOV.UK.',
+          title: 'Help improve GOV.UK',
           surveyCta: 'Answer some questions about yourself to join the research community.',
           surveyCtaPostscript: 'This link opens in a new tab.'
         },
@@ -166,7 +166,7 @@
         // use a map to translate the path into the utm_campaign value
         url: 'https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=' + dfeSurveyUtmCampaignValueMap() + '&utm_source=Education&utm_medium=gov.uk&t=DfE',
         templateArgs: {
-          title: 'Help improve GOV.UK.',
+          title: 'Help improve GOV.UK',
           surveyCta: 'Answer some questions about yourself to join the research community.',
           surveyCtaPostscript: 'This link opens in a new tab.'
         },
@@ -193,7 +193,7 @@
         endTime: new Date('August 26, 2017 23:59:50').getTime(),
         url: 'https://www.smartsurvey.co.uk/s/govuktransportsurvey?c={{currentPath}}',
         templateArgs: {
-          title: 'Help improve GOV.UK.',
+          title: 'Help improve GOV.UK',
           surveyCta: 'Answer 3 quick questions to help us make GOV.UK better',
           surveyCtaPostscript: 'This will open in a new tab.'
         },


### PR DESCRIPTION
Following the styleguide (see:
https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#titles)
titles should not end with a fullstop.

Thanks to @fofr for pointing it out