### PR TITLE
Rename "current" to "not withdrawn"

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -46,7 +46,7 @@
       'political-status': {dimension: 7},
       'analytics:organisations': {dimension: 9},
       'analytics:world-locations': {dimension: 10},
-      'withdrawn': {dimension: 12, defaultValue: 'current'},
+      'withdrawn': {dimension: 12, defaultValue: 'not withdrawn'},
       'schema-name': {dimension: 17},
       'rendering-application': {dimension: 20},
       'navigation-page-type': {dimension: 32, defaultValue: 'none'},

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -150,7 +150,7 @@ describe('Ecommerce reporter for results pages', function() {
       dimension11: '1',
       dimension3: 'other',
       dimension4: '00000000-0000-0000-0000-000000000000',
-      dimension12: 'current',
+      dimension12: 'not withdrawn',
       dimension23: 'unknown',
       dimension26: '0',
       dimension27: '0',


### PR DESCRIPTION
For: [Trello card](https://trello.com/c/KXyHx427/212-rename-current-to-not-withdrawn-when-sending-data-to-ga-on-publication-status)

## Why
This is aimed at clearing up some confusion in GA data where documents that are marked as current/withdrawn may actually be in a third state where they are not relevant anymore but have not yet been withdrawn.

## What
For this purpose, we're renaming the word "current" to "not withdrawn" to keep the current binary classification and reduce confusion.