### PR TITLE
Change PageContent.getNumberOfSections to handle leaf pages

### DIFF
--- a/app/assets/javascripts/analytics/page-content.js
+++ b/app/assets/javascripts/analytics/page-content.js
@@ -19,6 +19,7 @@
         return $('.topic section h1.label').length;
       case isFinderPage():
       case isWhitehallFinderPage():
+      case isNavigationLeafPage():
         // The default in finders should be one, so it's comparable with A-Z
         // lists in other navigation pages. Request made by performance
         // analysts.

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -528,7 +528,7 @@ describe("GOVUK.StaticAnalytics", function() {
         it('does not track any sections', function() {
           analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
           pageViewObject = getPageViewObject();
-          expect(pageViewObject.dimension26).toEqual('0');
+          expect(pageViewObject.dimension26).toEqual('1');
         });
 
         it('tracks the total number of leaf links', function() {


### PR DESCRIPTION
It should return 1 for the number of sections on a leaf page to be
consistent with the tracking on the legacy navigation.

https://trello.com/c/4RaDaoiX/151-amend-dimension-26-navigation-sections-analytics-tracking-on-leaf-pages