### PR TITLE
Fix section tracking for grid pages

### DIFF
--- a/app/assets/javascripts/analytics/page-content.js
+++ b/app/assets/javascripts/analytics/page-content.js
@@ -6,7 +6,7 @@
   PageContent.getNumberOfSections = function () {
     switch(true) {
       case isNavigationGridPage():
-        return $('a[data-track-category="navGridLinkClicked"]').length;
+        return 1 + $('.parent-topic-contents').length;
       case isNavigationAccordionPage():
         return $('[data-track-count="accordionSection"]').length;
       case isDocumentCollectionPage():

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -473,10 +473,10 @@ describe("GOVUK.StaticAnalytics", function() {
             $('.test-fixture').remove();
           });
 
-          it('does tracks sections equal to the number of grid links', function() {
+          it('tracks the number of sections', function() {
             analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
             pageViewObject = getPageViewObject();
-            expect(pageViewObject.dimension26).toEqual('3');
+            expect(pageViewObject.dimension26).toEqual('2');
           });
 
           it('tracks the total number of grid links and leaf links', function() {


### PR DESCRIPTION
This needs to return either 1 or 2 as a value. 1 by default and 2 if
there is a leaf section at the bottom of the grid.

https://trello.com/c/DEhfAo80/149-amend-dimension26-navigation-sections-analytics-tracking-on-grid-pages