### PR TITLE
Send the client ID inside a custom dimension

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -25,7 +25,8 @@
   function customDimensionsFromBrowser() {
     var customDimensions = {
       dimension15: window.httpStatusCode || 200,
-      dimension16: GOVUK.cookie('TLSversion') || 'unknown'
+      dimension16: GOVUK.cookie('TLSversion') || 'unknown',
+      dimension95: GOVUK.analytics.gaClientId
     };
 
     if (window.devicePixelRatio) {

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -10,17 +10,23 @@
 
     var trackingOptions = getOptionsFromCookie();
 
-    // Track initial pageview
-    this.trackPageview(null, null, trackingOptions);
+    // We're setting the client ID inside a callback function because
+    // we don't have access to the client ID until GA returns a tracker object.
+    ga(function (tracker) {
+      this.gaClientId = tracker.get('clientId');
 
-    // Begin error and print tracking
-    GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
-    GOVUK.analyticsPlugins.printIntent();
-    GOVUK.analyticsPlugins.mailtoLinkTracker();
-    GOVUK.analyticsPlugins.externalLinkTracker();
-    GOVUK.analyticsPlugins.downloadLinkTracker({
-      selector: 'a[href*="/government/uploads"], a[href*="assets.publishing.service.gov.uk"]'
-    });
+      // Track initial pageview
+      this.trackPageview(null, null, trackingOptions);
+
+      // Begin error and print tracking
+      GOVUK.analyticsPlugins.error({filenameMustMatch: /gov\.uk/});
+      GOVUK.analyticsPlugins.printIntent();
+      GOVUK.analyticsPlugins.mailtoLinkTracker();
+      GOVUK.analyticsPlugins.externalLinkTracker();
+      GOVUK.analyticsPlugins.downloadLinkTracker({
+        selector: 'a[href*="/government/uploads"], a[href*="assets.publishing.service.gov.uk"]'
+      });
+    }.bind(this));
   };
 
   StaticAnalytics.load = function () {


### PR DESCRIPTION
For: https://trello.com/c/n22tcj9Q/206-custom-dimension-google-analytics-client-id-and-session-id

In order to track user journeys in GA, it's been requested that we send the client ID as a custom dimension. The docs for extracting the client id can be found here: https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id?hl=en#getting_the_client_id_from_the_cookie

Using the recommended way means we're expecting a tracker to be loaded, which may or may not have happened at that point. Because our method is asynchronous, it might be called before `trackPageView` and not have a tracker object to query for the client ID.

In order to avoid this, we've put the call for `trackPageView` inside the asynchronous method for setting the client ID. This will guarantee that these two methods are called in the right order.

We've also had to move the rest of the plugin loading after the `trackPageView` event in order to ensure the same order will be kept.