### PR TITLE
Extends DfE and HMRC surveys until Sept 30, 2017

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -131,7 +131,7 @@
         surveyType: 'url',
         frequency: 20,
         startTime: new Date('July 21, 2017').getTime(),
-        endTime: new Date('August 20, 2017 23:59:50').getTime(),
+        endTime: new Date('September 30, 2017 23:59:50').getTime(),
         // use a map to translate the path into the utm_campaign value
         url: 'https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=' + hmrcSurveyUtmCampaignValueMap() + '&utm_source=Money_and_tax&utm_medium=gov.uk&t=HMRC',
         templateArgs: {
@@ -162,7 +162,7 @@
         surveyType: 'url',
         frequency: 6,
         startTime: new Date('July 18, 2017').getTime(),
-        endTime: new Date('August 18, 2017 23:59:50').getTime(),
+        endTime: new Date('September 30, 2017 23:59:50').getTime(),
         // use a map to translate the path into the utm_campaign value
         url: 'https://signup.take-part-in-research.service.gov.uk/home?utm_campaign=' + dfeSurveyUtmCampaignValueMap() + '&utm_source=Education&utm_medium=gov.uk&t=DfE',
         templateArgs: {


### PR DESCRIPTION
For: https://trello.com/c/p5i0D2IU/214-extend-dfe-and-hmrc-surveys-for-another-month

The surveys are due to end in the following days and will be extended until the end of September 2017 at midnight.

Originally added here: 

HMRC survey: https://github.com/alphagov/static/commit/581cfa19d0b15bb7410414568d3460e11df0b2ef
Dfe survey: https://github.com/alphagov/static/commit/8fa83662e4f8ee3793c77c39e3cdf22142006bfc