### PR TITLE
Update pagination component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
@@ -1,81 +1,83 @@
-.govuk-previous-and-next-navigation {
+.pub-c-pagination {
   display: block;
   margin-top: $gutter;
   margin-bottom: $gutter;
   margin-left: -$gutter-half;
   margin-right: -$gutter-half;
+}
 
-  ul {
-    margin: 0;
-    padding: 0;
-  }
+// scss-lint:disable SelectorFormat
+.pub-c-pagination__list {
+  margin: 0;
+  padding: 0;
 
-  li {
-    @include core-16($line-height: (20 / 16));
-    float: left;
-    list-style: none;
-    text-align: right;
-    margin: 0;
-    padding: 0;
-    width: 50%;
-
-    a {
-      display: block;
-      padding: $gutter-half;
-      text-decoration: none;
-
-      &:visited {
-        color: $link-colour;
-      }
-
-      &:hover,
-      &:active {
-        background-color: $canvas-colour;
-      }
-
-      .pagination-part-title {
-        @include core-27($line-height: (33.75 / 27));
-        display: block;
-      }
-    }
-  }
-
-  .previous-page {
-    float: left;
-    text-align: left;
-  }
-
-  .next-page {
-    float: right;
-    text-align: right;
-  }
-
-  @include media-down(mobile) {
-    .previous-page,
-    .next-page {
-      float: none;
-      width: 100%;
-    }
-
-    .next-page a {
-      text-align: right;
-    }
-  }
-
-  .pagination-icon {
-    display: inline-block;
-    margin-bottom: 1px;
-    height: .482em;
-    width: .63em;
-  }
-
-  .pagination-label {
-    display: inline-block;
-    margin-top: 0.1em;
-    text-decoration: underline;
-
-    &:empty {
-      display: none;
-    }
+  &:after {
+    content: "";
+    display: block;
+    clear: both;
   }
 }
+
+.pub-c-pagination__item {
+  @include core-16($line-height: (20 / 16));
+  float: left;
+  list-style: none;
+  text-align: right;
+  margin: 0;
+  padding: 0;
+  width: 50%;
+}
+
+.pub-c-pagination__link {
+  display: block;
+  padding: $gutter-half;
+  text-decoration: none;
+
+  &:visited {
+    color: $link-colour;
+  }
+
+  &:hover,
+  &:active {
+    background-color: $canvas-colour;
+  }
+}
+
+.pub-c-pagination__link-title {
+  @include core-27($line-height: (33.75 / 27));
+  display: block;
+}
+
+.pub-c-pagination__item--previous {
+  @include media-down(mobile) {
+    float: none;
+    width: 100%;
+  }
+
+  float: left;
+  text-align: left;
+}
+
+.pub-c-pagination__item--next {
+  @include media-down(mobile) {
+    float: none;
+    width: 100%;
+  }
+
+  float: right;
+  text-align: right;
+}
+
+.pub-c-pagination__link-icon {
+  display: inline-block;
+  margin-bottom: 1px;
+  height: .482em;
+  width: .63em;
+}
+
+.pub-c-pagination__link-label {
+  display: inline-block;
+  margin-top: 0.1em;
+  text-decoration: underline;
+}
+// scss-lint:enable SelectorFormat

--- a/app/views/govuk_component/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_component/docs/previous_and_next_navigation.yml
@@ -11,6 +11,25 @@ body: |
   - a label that can add extra info (ie page number) that will be displayed under the title
 
   If one of the 2 parameters is nil, no link will appear.
+accessibility-criteria: |
+  The component must:
+
+  - identify itself as pagination navigation
+
+  Links in the component must:
+
+  - identify whether they will take the user to the next or previous page
+  - accept focus
+  - be focusable with a keyboard
+  - be usable with a keyboard
+  - indicate when it has focus
+  - Change in appearance when touched (in the touch-down state)
+  - Change in appearance when hovered
+  - Usable with touch
+  - Usable with speech
+  - Have visible text
+
+  Icons in the component must not be announced by screen readers.
 fixtures:
   only_previous:
     previous_page:

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -1,36 +1,36 @@
 <% if local_assigns.include?(:next_page) || local_assigns.include?(:previous_page) %>
 <nav
-  class="govuk-previous-and-next-navigation"
+  class="pub-c-pagination"
   role="navigation"
   aria-label="<%= t("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
 >
-  <ul class="group">
+  <ul class="pub-c-pagination__list">
     <% if local_assigns.include?(:previous_page) %>
-      <li class="previous-page">
-        <a href="<%= previous_page[:url] %>" rel="prev">
-          <span class="pagination-part-title">
-            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+      <li class="pub-c-pagination__item pub-c-pagination__item--previous">
+        <a href="<%= previous_page[:url] %>" class="pub-c-pagination__link" rel="prev">
+          <span class="pub-c-pagination__link-title">
+            <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
             </svg>
             <%= previous_page[:title] %>
           </span>
           <% if previous_page[:label].present? %>
-            <span class="pagination-label"><%= previous_page[:label] %></span>
+            <span class="pub-c-pagination__link-label"><%= previous_page[:label] %></span>
           <% end %>
         </a>
       </li>
     <% end %>
     <% if local_assigns.include?(:next_page) %>
-      <li class="next-page">
-        <a href="<%= next_page[:url] %>" rel="next">
-          <span class="pagination-part-title">
+      <li class="pub-c-pagination__item pub-c-pagination__item--next">
+        <a href="<%= next_page[:url] %>" class="pub-c-pagination__link" rel="next">
+          <span class="pub-c-pagination__link-title">
             <%= next_page[:title] %>
-            <svg class="pagination-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
+            <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m10.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"/>
             </svg>
           </span>
           <% if next_page[:label].present? %>
-            <span class="pagination-label"><%= next_page[:label] %></span>
+            <span class="pub-c-pagination__link-label"><%= next_page[:label] %></span>
           <% end %>
         </a>
       </li>

--- a/test/govuk_component/previous_and_next_navigation_test.rb
+++ b/test/govuk_component/previous_and_next_navigation_test.rb
@@ -16,8 +16,9 @@ class PreviousAndNextNavigationTestCase < ComponentTestCase
       label: "1 of 3"
     })
 
-    assert_select ".pagination-part-title", text: "Previous page"
-    assert_select ".pagination-label", text: "1 of 3"
+    assert_select ".pub-c-pagination[role='navigation']"
+    assert_select ".pub-c-pagination__link-title", text: "Previous page"
+    assert_select ".pub-c-pagination__link-label", text: "1 of 3"
     assert_link("previous-page")
   end
 
@@ -28,8 +29,8 @@ class PreviousAndNextNavigationTestCase < ComponentTestCase
       label: "2 of 3"
     })
 
-    assert_select ".pagination-part-title", text: "Next page"
-    assert_select ".pagination-label", text: "2 of 3"
+    assert_select ".pub-c-pagination__link-title", text: "Next page"
+    assert_select ".pub-c-pagination__link-label", text: "2 of 3"
     assert_link("next-page")
   end
 end


### PR DESCRIPTION
- to use CSS class naming convention for components
- adds accessibility criteria to documentation
- tests for navigation role

https://trello.com/c/3rWOvqBG/95-2-update-pagination-component-to-be-inline-with-component-principles

Should look exactly the same as the current one, but here's some screenshots for examples.

![screen shot 2017-08-21 at 08 59 42](https://user-images.githubusercontent.com/861310/29509153-2c84b3c8-864f-11e7-8f7c-4447c06c6e2d.png)

![screen shot 2017-08-21 at 09 00 11](https://user-images.githubusercontent.com/861310/29509165-3b2df54c-864f-11e7-9156-139c3ff89ca4.png)

See also related but non-dependent PR: https://github.com/alphagov/finder-frontend/pull/301