### PR TITLE
Update title component to meet chosen conventions

### DIFF
--- a/app/assets/stylesheets/govuk-component/_title-print.scss
+++ b/app/assets/stylesheets/govuk-component/_title-print.scss
@@ -1,9 +1,9 @@
-.govuk-title {
-  .context {
-    margin: 0;
-  }
-
-  h1 {
-    margin-top: 0;
-  }
+// scss-lint:disable SelectorFormat
+.pub-c-title__context {
+  margin: 0;
 }
+
+.pub-c-title__text {
+  margin-top: 0;
+}
+// scss-lint:enable SelectorFormat

--- a/app/assets/stylesheets/govuk-component/_title-print.scss
+++ b/app/assets/stylesheets/govuk-component/_title-print.scss
@@ -7,3 +7,14 @@
   margin-top: 0;
 }
 // scss-lint:enable SelectorFormat
+
+// To Be Deleted: Old Styling
+.govuk-title {
+  .context {
+    margin: 0;
+  }
+
+  h1 {
+    margin-top: 0;
+  }
+}

--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -16,3 +16,21 @@
   @include bold-36;
 }
 // scss-lint:enable SelectorFormat
+
+// To Be Deleted: Old Styling
+.govuk-title {
+  @include responsive-vertical-margins;
+
+  .context {
+    @include core-24;
+    color: $secondary-text-colour;
+  }
+
+  h1 {
+    @include bold-48;
+  }
+
+  &.length-long h1 {
+    @include bold-36;
+  }
+}

--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -1,16 +1,18 @@
-.govuk-title {
+// scss-lint:disable SelectorFormat
+.pub-c-title {
   @include responsive-vertical-margins;
-
-  .context {
-    @include core-24;
-    color: $secondary-text-colour;
-  }
-
-  h1 {
-    @include bold-48;
-  }
-
-  &.length-long h1 {
-    @include bold-36;
-  }
 }
+
+.pub-c-title__context {
+  @include core-24;
+  color: $secondary-text-colour;
+}
+
+.pub-c-title__text {
+  @include bold-48;
+}
+
+.pub-c-title__text--long {
+  @include bold-36;
+}
+// scss-lint:enable SelectorFormat

--- a/app/views/govuk_component/docs/title.yml
+++ b/app/views/govuk_component/docs/title.yml
@@ -8,6 +8,12 @@ body: |
 
   On average the titles on government bits of content are 50 characters. The
   average for bits of general guidance are nearer 27 characters long.
+accessibility_criteria:
+  The page title must:
+
+    - be part of a correct heading structure for a page
+    - be semantically represented as a heading
+    - convey the heading level
 fixtures:
   default:
     title: My page title

--- a/app/views/govuk_component/title.raw.html.erb
+++ b/app/views/govuk_component/title.raw.html.erb
@@ -1,10 +1,12 @@
 <%
-  average_title_length ||= :average
+  average_title_length ||= false
   context ||= false
 %>
-<div class="govuk-title length-<%= average_title_length %>">
+<div class="pub-c-title">
   <% if context %>
-    <p class="context"><%= context %></p>
+    <p class="pub-c-title__context"><%= context %></p>
   <% end %>
-  <h1><%= title %></h1>
+  <h1 class="pub-c-title__text <% if average_title_length %>pub-c-title__text--<%= average_title_length %><% end %>">
+    <%= title %>
+  </h1>
 </div>

--- a/test/govuk_component/title_test.rb
+++ b/test/govuk_component/title_test.rb
@@ -13,11 +13,16 @@ class TitleComponentTestCase < ComponentTestCase
 
   test "title text appears" do
     render_component(title: "Hello World")
-    assert_select ".govuk-title", text: "Hello World"
+    assert_select ".pub-c-title__text", text: "Hello World"
   end
 
   test "title context appears" do
     render_component(title: "Hello World", context: "Format")
-    assert_select ".govuk-title .context", text: "Format"
+    assert_select ".pub-c-title__context", text: "Format"
+  end
+
+  test "applies title length if supplied" do
+    render_component(title: "Hello World", context: "format", average_title_length: 'long')
+    assert_select ".pub-c-title .pub-c-title__text--long", text: "Hello World"
   end
 end


### PR DESCRIPTION
Updating static title component to meet government-frontend component conventions.
This includes:
* Using pub-c namespace for CSS classes
* Use of BEM
* Adding accessibility criteria to docs

<img width="990" alt="screen shot 2017-08-21 at 09 49 50" src="https://user-images.githubusercontent.com/29889908/29511135-21b5a914-8656-11e7-86f0-983586854dbe.png">

<img width="990" alt="screen shot 2017-08-21 at 09 50 03" src="https://user-images.githubusercontent.com/29889908/29511138-2506a67c-8656-11e7-9063-cb3c309d8f57.png">

