### PR TITLE
[Do not merge] Improve next previous accessibility

### DIFF
--- a/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
+++ b/app/assets/stylesheets/govuk-component/_previous-and-next-navigation.scss
@@ -79,5 +79,16 @@
   display: inline-block;
   margin-top: 0.1em;
   text-decoration: underline;
+
+  // this pseudo element makes screen readers pause, preventing navigation and label text confusion
+  &:before {
+    content: ".";
+    position: absolute;
+    left: -9999em;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+  }
 }
 // scss-lint:enable SelectorFormat

--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -15,7 +15,6 @@
             <%= previous_page[:title] %>
           </span>
           <% if previous_page[:label].present? %>
-            <span class="visually-hidden">:</span>
             <span class="pub-c-pagination__link-label"><%= previous_page[:label] %></span>
           <% end %>
         </a>
@@ -31,7 +30,6 @@
             </svg>
           </span>
           <% if next_page[:label].present? %>
-            <span class="visually-hidden">:</span>
             <span class="pub-c-pagination__link-label"><%= next_page[:label] %></span>
           <% end %>
         </a>

--- a/test/govuk_component/previous_and_next_navigation_test.rb
+++ b/test/govuk_component/previous_and_next_navigation_test.rb
@@ -33,38 +33,4 @@ class PreviousAndNextNavigationTestCase < ComponentTestCase
     assert_select ".pub-c-pagination__link-label", text: "2 of 3"
     assert_link("next-page")
   end
-
-  test "there is a distinction between the navigation text and label text of the links when a label is present" do
-    render_component(
-      previous_page: {
-        url: "previous-page",
-        title: "Previous page",
-        label: "1 of 3"
-      },
-      next_page: {
-        url: "next-page",
-        title: "Next page",
-        label: "2 of 3"
-      }
-    )
-
-    assert_select ".pub-c-pagination__item--previous .pub-c-pagination__link .visually-hidden", text: ":"
-    assert_select ".pub-c-pagination__item--next .pub-c-pagination__link .visually-hidden", text: ":"
-  end
-
-  test "there is no distinction between the navigation text and label text of the links when labels are not present" do
-    render_component(
-      previous_page: {
-        url: "previous-page",
-        title: "Previous page"
-      },
-      next_page: {
-        url: "next-page",
-        title: "Next page"
-      }
-    )
-
-    assert_select ".pub-c-pagination__item--previous .pub-c-pagination__link .visually-hidden", false
-    assert_select ".pub-c-pagination__item--next .pub-c-pagination__link .visually-hidden", false
-  end
 end


### PR DESCRIPTION
- hidden pseudo before on label element containing "." causes screen readers to take a breath between navigation and label parts of link
- tested on Voiceover (Mac), Narrator, Jaws 18, NVDA (Windows)
- unable to test for pseudo element content so specific tests for accessibility removed, but comment added to SCSS to prevent accidental removal

![screen shot 2017-08-30 at 09 29 17](https://user-images.githubusercontent.com/861310/29862860-b3ee8830-8d65-11e7-98b5-9e9e8e5ec392.png)

See https://trello.com/c/0kYwSKe4/222-investigate-accessibility-of-next-previous-component
