### PR TITLE
Send client ID with survey currentPath param

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -238,7 +238,7 @@
             title: 'Tell us what you think of GOV.UK',
             surveyCta: 'Take the 3 minute survey',
             surveyCtaPostscript: 'This will open a short survey on another website',
-            surveyUrl: userSurveys.addCurrentPathToURL(survey.url),
+            surveyUrl: userSurveys.addParamsToURL(survey.url),
           }
           var mergedArgs = $.extend(defaultUrlArgs, survey.templateArgs)
           return userSurveys.processTemplate(mergedArgs, URL_SURVEY_TEMPLATE)
@@ -260,7 +260,7 @@
             surveyFailure: 'Sorry, we’re unable to send you an email right now. Please try again later.',
             surveyId: survey.identifier,
             surveySource: userSurveys.currentPath(),
-            surveyUrl: userSurveys.addCurrentPathToURL(survey.url),
+            surveyUrl: userSurveys.addParamsToURL(survey.url),
           }
           var mergedArgs = $.extend(defaultEmailArgs, survey.templateArgs)
           return userSurveys.processTemplate(mergedArgs, EMAIL_SURVEY_TEMPLATE)
@@ -323,8 +323,14 @@
       userSurveys.setEmailSurveyEventHandlers(survey)
     },
 
-    addCurrentPathToURL: function (surveyUrl) {
-      return surveyUrl.replace(/\{\{currentPath\}\}/g, userSurveys.currentPath());
+    addParamsToURL: function (surveyUrl) {
+      var newSurveyUrl = surveyUrl.replace(/\{\{currentPath\}\}/g, userSurveys.currentPath());
+      if (surveyUrl.indexOf("?c=") !== -1) {
+        return newSurveyUrl + "&gcl=" + GOVUK.analytics.gaClientId;
+      }
+      else {
+        return newSurveyUrl + "?gcl=" + GOVUK.analytics.gaClientId;
+      }
     },
 
     setEmailSurveyEventHandlers: function (survey) {

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -51,6 +51,9 @@ Used in a link in the survey that the user is directed to click on. This should 
 * `https://www.smartsurvey.com/s/2AAAAAA` - it will be left alone and inserted in the template as-is.
 * `https://www.smartsurvey.com/s/2AAAAAA?c={{currentPath}}` - will be transformed into `https://www.smartsurvey.com/s/2AAAAAA?c=/government/publications/the-kingdom-of-the-crystal-skull` (assuming the page the survey was shown on was https://www.gov.uk/government/publications/the-kindgom-of-the-crystal-skull).
 
+Please be aware that the GA client ID will also be appended to the end of the url, so the final result will be: `https://www.smartsurvey.com/s/2AAAAAA?c=/government/publications/the-kingdom-of-the-crystal-skull&gcl=12345.67890`.
+If the `?c={{currentPath}}` template param is missing from the link, then the resulting url will be: `https://www.smartsurvey.com/s/2AAAAAA?gcl=12345.67890`.
+
 #### `templateArgs` for `url` survey
 The template for a url survey is as follows:
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -57,7 +57,7 @@ describe('Surveys', function () {
       spyOn(surveys, 'randomNumberMatches').and.returnValue(true)
       surveys.init()
 
-      expect($('#take-survey').attr('href')).toContain(surveys.addCurrentPathToURL(surveys.defaultSurvey.url))
+      expect($('#take-survey').attr('href')).toContain(surveys.addParamsToURL(surveys.defaultSurvey.url))
       expect($('#user-satisfaction-survey').length).toBe(1)
       expect($('#user-satisfaction-survey').hasClass('visible')).toBe(true)
       expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false')
@@ -114,7 +114,9 @@ describe('Surveys', function () {
       it("does not inject the current path if the survey url does not contain the {{currentPath}} template parameter", function () {
         surveys.displaySurvey(urlSurvey)
 
-        expect($('#take-survey').attr('href')).toEqual(urlSurvey.url)
+        var expectedUrl = urlSurvey.url + "?gcl=" + GOVUK.analytics.gaClientId
+
+        expect($('#take-survey').attr('href')).toEqual(expectedUrl)
       })
 
       describe('without overrides for the template defaults', function () {
@@ -212,10 +214,27 @@ describe('Surveys', function () {
         expect($('#take-survey').attr('href')).toContain("?c=" + window.location.pathname)
       })
 
-      it("does not inject the current path if the survey url does not contain the {{currentPath}} template parameter", function () {
+      it("does not inject the current path if the {{currentPath}} template parameter is missing", function () {
         surveys.displaySurvey(emailSurvey)
 
-        expect($('#take-survey').attr('href')).toEqual(emailSurvey.url)
+        expect($('#take-survey').attr('href')).not.toContain("?c=" + window.location.pathname)
+      })
+
+      it("adds the GA client ID to the survey url if the {{currentPath}} template parameter is present", function () {
+        var emailSurveyWithCurrentPath = {
+          surveyType: 'email',
+          url: 'smartsurvey.com/default?c={{currentPath}}',
+          identifier: 'email-survey',
+        }
+        surveys.displaySurvey(emailSurveyWithCurrentPath)
+
+        expect($('#take-survey').attr('href')).toContain("?c=" + window.location.pathname + "&gcl=" + GOVUK.analytics.gaClientId)
+      })
+
+      it("adds the GA client ID to the survey url if the {{currentPath}} template parameter is missing", function () {
+        surveys.displaySurvey(emailSurvey)
+
+        expect($('#take-survey').attr('href')).toEqual(emailSurvey.url + "?gcl=" + GOVUK.analytics.gaClientId)
       })
 
       describe("without overrides for the template defaults", function() {


### PR DESCRIPTION
For: https://trello.com/c/F5wcNrsV/219-clientid-pushed-into-survey-urls-as-custom-data

## Why
In order to track the user journey when a user completes a survey, we can use the GA client ID to identify a session for a user and check all the pages he has visited before arriving to our survey. This will provide more detailed data about a user's browsing habits and will help to separate the data out, since the info collected on surveys is anonymous.

## What
Sends client ID alongside the currentPath param when completing survey. This will help in identifying the session in GA. 