### PR TITLE
Add gaClientId to email surveys

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -44,6 +44,7 @@
     '    </label>' +
     '    <input name="email_survey_signup[survey_id]" type="hidden" value="{{surveyId}}">' +
     '    <input name="email_survey_signup[survey_source]" type="hidden" value="{{surveySource}}">' +
+    '    <input name="email_survey_signup[ga_client_id]" type="hidden" value="{{gaClientId}}">' +
     '    <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text" aria-describedby="survey-form-description">' +
     '    <button class="survey-form-button" type="submit">{{surveyFormCta}}</button>' +
          takeSurveyLink('{{surveyFormNoEmailInvite}}') +
@@ -243,6 +244,7 @@
             surveyId: survey.identifier,
             surveySource: userSurveys.currentPath(),
             surveyUrl: userSurveys.addParamsToURL(survey.url),
+            gaClientId: GOVUK.analytics.gaClientId,
           }
           var mergedArgs = $.extend(defaultEmailArgs, survey.templateArgs)
           return userSurveys.processTemplate(mergedArgs, EMAIL_SURVEY_TEMPLATE)
@@ -294,14 +296,14 @@
     },
 
     displayURLSurvey: function (survey, surveyContainer) {
-      var emailSurveyTemplate = userSurveys.getUrlSurveyTemplate()
-      surveyContainer.append(emailSurveyTemplate.render(survey))
+      var urlSurveyTemplate = userSurveys.getUrlSurveyTemplate()
+      surveyContainer.append(urlSurveyTemplate.render(survey))
       userSurveys.setURLSurveyEventHandlers(survey)
     },
 
     displayEmailSurvey: function (survey, surveyContainer) {
-      var urlSurveyTemplate = userSurveys.getEmailSurveyTemplate()
-      surveyContainer.append(urlSurveyTemplate.render(survey))
+      var emailSurveyTemplate = userSurveys.getEmailSurveyTemplate()
+      surveyContainer.append(emailSurveyTemplate.render(survey))
       userSurveys.setEmailSurveyEventHandlers(survey)
     },
 

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -106,6 +106,7 @@ The template for a url survey is as follows:
         </label>
         <input name="email_survey_signup[survey_id]" type="hidden" value="{{surveyId}}">
         <input name="email_survey_signup[survey_source]" type="hidden" value="{{surveySource}}">
+        <input name="email_survey_signup[ga_client_id]" type="hidden" value="{{gaClientId}}">
         <input class="survey-form-input" name="email_survey_signup[email_address]" id="survey-email-address" type="text" aria-describedby="survey-form-description">
         <button class="survey-form-button" type="submit">{{surveyFormCta}}</button>
         <a href="javascript:void()" id="take-survey" target="_blank" rel="noopener noreferrer">{{surveyFormNoEmailInvite}}</a>

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -40,6 +40,11 @@ describe('Surveys', function () {
     $('#take-survey').on('click', function (e) {
       e.preventDefault()
     })
+
+    GOVUK.analytics = {
+      trackEvent: function() {},
+      gaClientId: '12345.67890'
+    }
   })
 
   afterEach(function () {
@@ -189,6 +194,12 @@ describe('Surveys', function () {
         surveys.displaySurvey(emailSurvey)
 
         expect($('#email-survey-form input[name="email_survey_signup[survey_source]"]').val()).toEqual(window.location.pathname)
+      })
+
+      it('adds the GA client ID to the form', function () {
+        surveys.displaySurvey(emailSurvey)
+
+        expect($('#email-survey-form input[name="email_survey_signup[ga_client_id]"]').val()).toEqual(GOVUK.analytics.gaClientId)
       })
 
       it('sets event handlers on the survey', function () {


### PR DESCRIPTION
For: https://trello.com/c/xDdnial5/220-clientid-pushed-into-email-surveys-as-custom-data

In order to track the user journey when a user completes an EMAIL survey, we can use the client ID to identify a session for a user and record all the pages he has visited before arriving to our survey. This will provide a more detailed picture about our user's browsing habits and will help to separate the data out, since the info collected on surveys is anonymous.

Depends on this PR: https://github.com/alphagov/feedback/pull/211