### PR TITLE
Fix end date of emotional survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -186,7 +186,7 @@
         surveyType: 'url',
         frequency: 6,
         startTime: new Date('September 1, 2017').getTime(),
-        endTime: new Date('September 12, 2017 23:59:50').getTime(),
+        endTime: new Date('September 5, 2017 23:59:50').getTime(),
         url: 'https://www.smartsurvey.co.uk/s/gov_uk_2q/?c={{currentPath}}',
         templateArgs: {
           title: 'Tell us about your visit to GOV.UK',

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -164,24 +164,6 @@
         }
       },
       {
-        identifier: 'govuk_transport',
-        surveyType: 'url',
-        frequency: 20,
-        startTime: new Date('July 27, 2017').getTime(),
-        endTime: new Date('August 26, 2017 23:59:50').getTime(),
-        url: 'https://www.smartsurvey.co.uk/s/govuktransportsurvey?c={{currentPath}}',
-        templateArgs: {
-          title: 'Help improve GOV.UK',
-          surveyCta: 'Answer 3 quick questions to help us make GOV.UK better',
-          surveyCtaPostscript: 'This will open in a new tab.'
-        },
-        activeWhen: {
-          path: ['^/browse/driving(?:/|$)'],
-          organisation: ['<D9>','<D1117>','<EA74>','<EA78>','<EA80>','<EA1114>','<EA570>','<PB459>','<PB460>','<PB461>','<PB462>','<PB463>','<PB1118>','<PB247>','<PB465>','<PC469>','<PC472>','<PC493>','<OT248>','<OT249>'],
-          breadcrumb: ['Driving and transport']
-        }
-      },
-      {
         identifier: 'govuk_2Q',
         surveyType: 'url',
         frequency: 6,


### PR DESCRIPTION
For: https://trello.com/c/b4J4OpaM/218-emotional-survey-test-banner

Due to a misunderstanding when interpreting the card we
set this survey to end a week later than it should do.  It should run
from Friday 1st to Tuesday 5th, not Tuesday 12th.