### PR TITLE
Wait for GA Client ID to be loaded before surveys

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -15,6 +15,8 @@
     ga(function (tracker) {
       this.gaClientId = tracker.get('clientId');
 
+      $(window).trigger('gaClientSet');
+
       // Track initial pageview
       this.trackPageview(null, null, trackingOptions);
 

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -614,8 +614,15 @@
   window.GOVUK.userSurveys = userSurveys
 
   $(document).ready(function () {
-    if (window.GOVUK.userSurveys) {
-      window.GOVUK.userSurveys.init()
+    if (GOVUK.userSurveys) {
+      if (GOVUK.analytics && GOVUK.analytics.gaClientId) {
+        window.GOVUK.userSurveys.init()
+      }
+      else {
+        $(window).on('gaClientSet', function() {
+          window.GOVUK.userSurveys.init()
+        })
+      }
     }
   })
 })(window.jQuery)


### PR DESCRIPTION
For: https://trello.com/c/AokZntDm/221-investigate-why-client-id-isnt-being-loaded-for-all-surveys

## Why 

The assignment of the GA client ID happens by invoking a bound function in `static-analytics.js` (seen below), which is passed to `ga`:

```
// static-analytics.js

ga(function (tracker) {
   this.gaClientId = tracker.get('clientId')

   // Track initial pageview
   this.trackPageview(null, null, trackingOptions);

//   ...
}.bind(this));
```

Normally this happens immediately, and would initialise the GA Client ID which could then be used in `surveys.js` to send the ID along in the survey URL. 

Empirically, we've discovered that this only happens 50% of the time, because `surveys.js` might load before `static-analytics.js`. This means that for 50% of our survey responses we can't track the user in GA using the Client ID, causing our data to be inconsistent.

## What 
Initially `surveys.js` was always loaded after `static-analytics.js` as they were part of the same JS bundle, so the script loading order was always the same. However, due to frequent changes to `surveys.js`, users would have to re-download the entire JS bundle every time we deployed a new change to surveys. To avoid this we've had to extract the `surveys.js` into a separate JS bundle: https://github.com/alphagov/static/pull/1038

To get around the case when `surveys.js` loads **before** `static-analytics.js`, we've modified the surveys code to wait until the `ga` callback has occurred in `static-analytics.js`. Once that happens we trigger a `gaClientSet` event which will be listened for in `surveys.js`. 

We can then initialize surveys and construct the survey URLS using the GA client ID. 

In the alternative case where `surveys.js` loads **after** `static-analytics.js`, then the gaClientID is already set, so we don't setup a listener and just load surveys. 