### PR TITLE
Adding inverse flag to title component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -3,6 +3,14 @@
   @include responsive-vertical-margins;
 }
 
+.pub-c-title--inverse {
+  color: $white;
+
+  .pub-c-title__context {
+    color: inherit;
+  }
+}
+
 .pub-c-title__context {
   @include core-24;
   color: $secondary-text-colour;

--- a/app/views/govuk_component/docs/search.yml
+++ b/app/views/govuk_component/docs/search.yml
@@ -21,6 +21,8 @@ examples:
   for_use_on_govuk_blue_background:
     data:
       on_govuk_blue: true
+    context:
+      dark_background: true
   change_label_text:
     data:
       label_text: "Search"

--- a/app/views/govuk_component/docs/title.yml
+++ b/app/views/govuk_component/docs/title.yml
@@ -27,3 +27,11 @@ examples:
       context: Publication
       title: My page title which is often really long and verbose and has lots of extra words it doesn't need
       average_title_length: long
+  title_on_dark_background:
+    description: Page titles with dark backgrounds are used in HTML Publications ([see example](https://www.gov.uk/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court))
+    data:
+      context: Publication
+      title: My inverse page title
+      inverse: true
+    context:
+      dark_background: true

--- a/app/views/govuk_component/title.raw.html.erb
+++ b/app/views/govuk_component/title.raw.html.erb
@@ -1,8 +1,9 @@
 <%
   average_title_length ||= false
   context ||= false
+  inverse ||= false
 %>
-<div class="pub-c-title">
+<div class="pub-c-title <% if inverse %>pub-c-title--inverse<% end %>">
   <% if context %>
     <p class="pub-c-title__context"><%= context %></p>
   <% end %>


### PR DESCRIPTION
Passing inverse: true to title component means the title can work on a dark background.

<img width="979" alt="screen shot 2017-09-06 at 13 18 26" src="https://user-images.githubusercontent.com/29889908/30112489-7dcc196c-9309-11e7-9cba-8a4c0e20404c.png">


**Note: needs to be merged before updating HTML publications in government-frontend, but only after update to govuk_publishing_components.**