### PR TITLE
Send identifying value for legacy Education & Childcare navigation pages

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -57,7 +57,8 @@
       'taxon-id': {dimension: 57, defaultValue: 'other'},
       'taxon-slugs': {dimension: 58, defaultValue: 'other'},
       'taxon-ids': {dimension: 59, defaultValue: 'other'},
-      'content-has-history': {dimension: 39, defaultValue: 'false'}
+      'content-has-history': {dimension: 39, defaultValue: 'false'},
+      'navigation-legacy': {dimension: 30, defaultValue: 'none'}
     };
 
     var $metas = $('meta[name^="govuk:"]');

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -162,6 +162,7 @@ describe('Ecommerce reporter for results pages', function() {
       dimension57: 'other',
       dimension58: 'other',
       dimension59: 'other',
+      dimension30: 'none'
     })
   });
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -14,7 +14,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
   describe('when created', function() {
     // The number of setup arguments which are set before the dimensions
-    const numberOfDimensionsWithDefaultValues = 17;
+    const numberOfDimensionsWithDefaultValues = 18;
 
     var pageViewObject;
 
@@ -98,6 +98,7 @@ describe("GOVUK.StaticAnalytics", function() {
           <meta name="govuk:analytics:world-locations" content="<W1>">\
           <meta name="govuk:withdrawn" content="withdrawn">\
           <meta name="govuk:schema-name" content="schema-name">\
+          <meta name="govuk:navigation-legacy" content="education">\
         ');
         analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
         pageViewObject = getPageViewObject();
@@ -112,6 +113,7 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(pageViewObject.dimension12).toEqual('withdrawn');
         expect(pageViewObject.dimension17).toEqual('schema-name');
         expect(pageViewObject.dimension23).toEqual('fr');
+        expect(pageViewObject.dimension30).toEqual('education')
       });
 
       it('ignores meta tags not set', function() {
@@ -195,6 +197,11 @@ describe("GOVUK.StaticAnalytics", function() {
           name: 'taxon-ids',
           number: 59,
           defaultValue: 'other'
+        },
+        {
+          name: 'navigation-legacy',
+          number: 30,
+          defaultValue: 'none'
         }
       ].forEach(function (dimension) {
         it('sets the ' + dimension.name + ' dimension from a meta tag if present', function () {


### PR DESCRIPTION
In order to make accurate comparisons of legacy and beta navigation we
need to know which pages to compare.  

This change will pick up any values set in a `govuk:navigation-legacy` meta tag, and add them to dimension 30 with a default of 'none'.

The [backend implementation change in Collections](https://github.com/alphagov/collections/pull/379)

[Trello](https://trello.com/c/IPAyElBg/248-send-identifying-value-for-legacy-education-childcare-navigation-pages)