### PR TITLE
Include integration tests for static component guide

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,7 @@ GEM
     commander (4.4.3)
       highline (~> 1.7.2)
     concurrent-ruby (1.0.5)
-    crack (0.4.2)
+    crack (0.4.3)
       safe_yaml (~> 1.0.0)
     debug_inspector (0.0.2)
     domain_name (0.5.20170404)
@@ -118,6 +118,7 @@ GEM
       slimmer
     govuk_template (0.22.2)
       rails (>= 3.1)
+    hashdiff (0.3.6)
     highline (1.7.8)
     htmlentities (4.3.4)
     http-cookie (1.0.3)
@@ -282,9 +283,10 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    webmock (1.21.0)
+    webmock (3.0.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+      hashdiff
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)

--- a/test/integration/component_guide_test.rb
+++ b/test/integration/component_guide_test.rb
@@ -1,0 +1,38 @@
+require 'integration_test_helper'
+require 'webmock/minitest'
+require 'slimmer/test_helpers/govuk_components'
+
+module GovukPublishingComponentsSkipSlimmer
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :skip_slimmer
+  end
+
+  def skip_slimmer
+    response.headers[Slimmer::Headers::SKIP_HEADER] = "true" unless ENV['USE_SLIMMER'] == "true"
+  end
+end
+
+GovukPublishingComponents::ApplicationController.include(GovukPublishingComponentsSkipSlimmer)
+
+class ComponentGuideTest < ActionDispatch::IntegrationTest
+  include Slimmer::TestHelpers::GovukComponents
+
+  def setup
+    stub_shared_component_locales
+  end
+
+  context "component guide" do
+    should "render an index" do
+      visit "/component-guide"
+      assert page.has_selector? "title", text: 'Static Component Guide', visible: false
+      assert page.has_selector? shared_component_selector('title')
+    end
+
+    should "render all component previews without erroring" do
+      visit '/component-guide'
+      all(:css, '.component-list a').map { |el| "#{el[:href]}/preview" }.each { |component| visit component }
+    end
+  end
+end


### PR DESCRIPTION
Test that all components render without error

* Require webmock minitest for `stub_request` in stub_shared_component_locales
* Add an ActiveSupport concern to avoid hitting Slimmer for component guide requests (this matches the way we avoid hitting Slimmer when using Jasmine)
* This doesn’t explicitly run Javascript, accessibility tests will not yet be running

Follow on from #1125 
Part of https://trello.com/c/Yq9FFia1/