### PR TITLE
Bump govuk_publishing_components gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.6"
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'nokogiri', "~> 1.7"
 gem 'redis', "~> 3.3.3"
-gem 'govuk_publishing_components', '~> 1.4.0', require: false
+gem 'govuk_publishing_components', '~> 1.5.0', require: false
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     govuk_frontend_toolkit (7.0.1)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (1.4.0)
+    govuk_publishing_components (1.5.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
@@ -304,7 +304,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.6.0)
   govuk_frontend_toolkit (~> 7.0.1)
-  govuk_publishing_components (~> 1.4.0)
+  govuk_publishing_components (~> 1.5.0)
   govuk_template (= 0.22.2)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.14.1)


### PR DESCRIPTION
Update to 1.5.0, adds links to documentation