### PR TITLE
Fix issue preventing deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.6"
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'nokogiri', "~> 1.7"
 gem 'redis', "~> 3.3.3"
-gem 'govuk_publishing_components', '~> 1.4.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
+gem 'govuk_publishing_components', '~> 1.4.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length > 0
 
 group :development do
   gem 'image_optim', '0.17.1'


### PR DESCRIPTION
Due to a ruby version mixup, `Numeric#positive?` isn't a method available in our production stack. 

Temporary fix to get deployments moving again. I hope to be able to move the logic out of this Gemfile in a later PR.