### PR TITLE
Remove 'require' logic from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.6"
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'nokogiri', "~> 1.7"
 gem 'redis', "~> 3.3.3"
-gem 'govuk_publishing_components', '~> 1.4.0', require: ENV['RAILS_ENV'] != "production" || ENV['HEROKU_APP_NAME'].to_s.length.positive?
+gem 'govuk_publishing_components', '~> 1.4.0', require: false
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,10 @@ require "sprockets/railtie"
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+if !Rails.env.production? || ENV['HEROKU_APP_NAME'].present?
+  require 'govuk_publishing_components'
+end
+
 module Static
   class Application < Rails::Application
     # Settings in config/environments/* take precedence over those specified here.


### PR DESCRIPTION
Move the decision point for the `require` out of the Gemfile and into application.rb
