### PR TITLE
Update Gemfile to reference ruby-version file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ ENV APP_HOME /app
 RUN mkdir $APP_HOME
 
 WORKDIR $APP_HOME
+ADD .ruby-version $APP_HOME/
 ADD Gemfile* $APP_HOME/
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby File.read('.ruby-version').chomp
+
 gem 'rails', '~> 5.1'
 gem 'unicorn', '4.9.0'
 gem 'logstasher', '0.4.8'


### PR DESCRIPTION
We have had issues with static not running correctly based on the ruby version being different
on Heroku and production, this change ensures the version is the same

Thanks to @tijmenb for this 👍 