### PR TITLE
Implement customisable spacing for title component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_title.scss
+++ b/app/assets/stylesheets/govuk-component/_title.scss
@@ -1,6 +1,13 @@
 // scss-lint:disable SelectorFormat
 .pub-c-title {
-  @include responsive-vertical-margins;
+  @include responsive-top-margin;
+}
+
+// this will be moved and extended into a model for general component spacing
+// once this has been decided upon and other work completed, see:
+// https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components
+.pub-c-title--bottom-margin {
+  @include responsive-bottom-margin;
 }
 
 .pub-c-title--inverse {

--- a/app/views/govuk_component/docs/title.yml
+++ b/app/views/govuk_component/docs/title.yml
@@ -27,11 +27,12 @@ examples:
       context: Publication
       title: My page title which is often really long and verbose and has lots of extra words it doesn't need
       average_title_length: long
-  title_on_dark_background:
-    description: Page titles with dark backgrounds are used in HTML Publications ([see example](https://www.gov.uk/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court))
+  in_html_publication:
+    description: Page titles are used in HTML Publications ([see example](https://www.gov.uk/government/publications/fees-for-civil-and-family-courts/court-fees-for-the-high-court-county-court-and-family-court))
     data:
       context: Publication
-      title: My inverse page title
+      title: HTML publication page title
       inverse: true
+      margin_bottom: 0
     context:
       dark_background: true

--- a/app/views/govuk_component/title.raw.html.erb
+++ b/app/views/govuk_component/title.raw.html.erb
@@ -2,8 +2,12 @@
   average_title_length ||= false
   context ||= false
   inverse ||= false
+  margin_bottom ||= 1
+  margin_bottom_class = "pub-c-title--bottom-margin" if margin_bottom == 1
 %>
-<div class="pub-c-title <% if inverse %>pub-c-title--inverse<% end %>">
+<div class="pub-c-title
+  <% if inverse %>pub-c-title--inverse<% end %>
+  <%= margin_bottom_class %>">
   <% if context %>
     <p class="pub-c-title__context"><%= context %></p>
   <% end %>


### PR DESCRIPTION
- remove bottom margin from component
- add margin helper class for original component bottom margin
- default component state will use that class unless an alternative is passed i.e. 0, which means there is no need to update any instance of the component as it will still be as it was before this change

![screen shot 2017-09-13 at 16 59 56](https://user-images.githubusercontent.com/861310/30387630-ffe0925c-98a4-11e7-8059-2f6e004e1927.png)

https://trello.com/c/KEkNsxG3/142-3-implement-customisable-spacing-for-components

This issue is complicated by our need for responsive margins. The ideal would be a mechanism where we pass a number to the component to interpret as margin-bottom e.g. 0 = no margin, 1 = gutter-half, 2 = gutter, etc. but an [https://docs.google.com/spreadsheets/d/1mL-zAgi_Vfb7BO3KPF8b9xAPq_pIXIZHHSjvlB1Tulg/edit#gid=0](audit of the components) reveals there is no simple scale for doing this when responsive is included (even though this change is for one component it would be good to consider the others).

We could try separating the responsive classes e.g. pass margin-bottom-mobile = 1, margin-bottom-tablet = 1, margin-bottom-desktop = 2 but that seemed overly horrible.
