### PR TITLE
Fix output of finding installed location

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -4,7 +4,7 @@ bundle install
 
 if [[ $1 == "--test-govuk-frontend-toolkit" ]] ; then
   # Find out where it the gem is installed
-  installed_location="$(bundle show govuk_frontend_toolkit)"
+  installed_location="$(bundle show govuk_frontend_toolkit | sed -1p)"
   temporary_location="./tmp/govuk_frontend_toolkit_gem_dev"
 
   # Remove any existing tmp file


### PR DESCRIPTION
This is a fix to the startup file which is currently failing.
The output of "bundle show govuk_frontend_toolkit" currently
contains warnings about us not running the latest version of
bundler which means the script fails. This fix simply
truncates the output at the first line.

(Note this is not a merge into master.)