### PR TITLE
Bump publishing component gem to 1.9.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'sass-rails', "5.0.6"
 gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem 'nokogiri', "~> 1.7"
 gem 'redis', "~> 3.3.3"
-gem 'govuk_publishing_components', '~> 1.5.0', require: false
+gem 'govuk_publishing_components', '~> 1.9.0', require: false
 
 group :development do
   gem 'image_optim', '0.17.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,12 +110,13 @@ GEM
     govuk_frontend_toolkit (7.0.1)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (1.5.0)
+    govuk_publishing_components (1.9.0)
       govspeak (>= 5.0.3)
       govuk_frontend_toolkit
       rails (>= 5.0.0.1)
+      rouge
       sass-rails (>= 5.0.4)
-      slimmer
+      slimmer (>= 11.1.0)
     govuk_template (0.22.2)
       rails (>= 3.1)
     hashdiff (0.3.6)
@@ -222,6 +223,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
+    rouge (2.2.1)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -249,7 +251,7 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    slimmer (11.0.2)
+    slimmer (11.1.1)
       activesupport
       json
       nokogiri (~> 1.7)
@@ -306,7 +308,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.4)
   govuk-lint (~> 0.6.0)
   govuk_frontend_toolkit (~> 7.0.1)
-  govuk_publishing_components (~> 1.5.0)
+  govuk_publishing_components (~> 1.9.0)
   govuk_template (= 0.22.2)
   image_optim (= 0.17.1)
   jasmine-rails (~> 0.14.1)
@@ -326,6 +328,9 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   unicorn (= 4.9.0)
   webmock
+
+RUBY VERSION
+   ruby 2.2.3p173
 
 BUNDLED WITH
    1.15.1

--- a/test/integration/component_guide_test.rb
+++ b/test/integration/component_guide_test.rb
@@ -27,7 +27,7 @@ class ComponentGuideTest < ActionDispatch::IntegrationTest
     should "render an index" do
       visit "/component-guide"
       assert page.has_selector? "title", text: 'Static Component Guide', visible: false
-      assert page.has_selector? shared_component_selector('title')
+      assert page.has_selector? '.pub-c-title', text: 'Static Component Guide'
     end
 
     should "render all component previews without erroring" do


### PR DESCRIPTION
- modify component guide test to account for changes in 1.9.0