### PR TITLE
Force button outlines to be shown on focus

### DIFF
--- a/app/assets/stylesheets/govuk-component/_button.scss
+++ b/app/assets/stylesheets/govuk-component/_button.scss
@@ -7,6 +7,10 @@
     width: 100%;
     text-align: center;
   }
+
+  &:focus {
+    outline: 3px solid $focus-colour;
+  }
 }
 
 %pub-c-button--start,


### PR DESCRIPTION
The button includes CSS to set the outline, this means when
it's mixed in to the govspeak component it's too specific and overrides the
global outline selectors.

Tested locally (http://government-frontend.dev.gov.uk/log-in-file-self-assessment-tax-return) and in the static component guide.

http://govuk-static-pr-1164.herokuapp.com/component-guide/govspeak/button/preview
http://govuk-static-pr-1164.herokuapp.com/component-guide/button/preview