### PR TITLE
Allow any links in footer or metadata components to be tracked

### DIFF
--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -15,7 +15,7 @@
   direction_class = ""
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
-<div class="govuk-document-footer<%= direction_class %>">
+<div class="govuk-document-footer<%= direction_class %>" data-module="track-click">
   <h2 class="visuallyhidden">
     <%= t("govuk_component.document_footer.document_information", default: "Document information") %>
   </h2>
@@ -42,7 +42,6 @@
         <p>
           <a href="#full-history" data-controls="full-history"
                                   data-expanded="false"
-                                  data-module="track-click"
                                   data-track-category="content-history"
                                   data-track-action="full-page-history-toggled"
                                   data-track-label="full-history">

--- a/app/views/govuk_component/metadata.raw.html.erb
+++ b/app/views/govuk_component/metadata.raw.html.erb
@@ -11,7 +11,7 @@
   direction_class = " direction-#{direction}" if local_assigns.include?(:direction)
 %>
 <div class="govuk-metadata<%= direction_class %>" data-module="toggle">
-  <dl>
+  <dl data-module="track-click">
     <% if from.any? %>
       <dt><%= t("govuk_component.metadata.from", default: "From") %>:</dt>
       <dd>
@@ -36,8 +36,7 @@
       <dt><%= t("govuk_component.metadata.last_updated", default: "Last updated") %>:</dt>
       <dd>
         <%= last_updated %><% if local_assigns.include?(:see_updates_link) %>,
-          <a href="#history" data-module="track-click"
-                             data-track-category="content-history"
+          <a href="#history" data-track-category="content-history"
                              data-track-action="see-all-updates-link-clicked"
                              data-track-label="history">
             <%= t("govuk_component.metadata.see_all_updates", default: "see all updates") %>


### PR DESCRIPTION
Make document_footer and metadata components more flexible for tracking link clicks.

By passing tracking attributes to any link the component will track their clicks.

Avoids instantiating the track-click module and adding an event listener for every link.