### PR TITLE
Add new breadcrumb examples to component guide

### DIFF
--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -53,3 +53,24 @@ examples:
       - title: 'Passports, travel and living abroad'
         url: '/browse/abroad'
       - title: 'Travel abroad'
+  highlight_current_page:
+    description: This is currently used within the Education navigation A/B tests, such as [on this page](https://www.gov.uk/education/education-of-disadvantaged-children).
+    data:
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Education, training and skills'
+        url: '/education'
+      - title: 'Education of disadvantaged children'
+        is_current_page: true
+  collapse_on_mobile:
+    description: This is currently used within the Education navigation A/B tests, such as [on this page](https://www.gov.uk/education/education-of-disadvantaged-children).
+    data:
+      collapse_on_mobile: true
+      breadcrumbs:
+      - title: 'Home'
+        url: '/'
+      - title: 'Education, training and skills'
+        url: '/education'
+        is_page_parent: true
+      - title: 'Education of disadvantaged children'


### PR DESCRIPTION
The new navigation on the Education A/B tests uses a slightly enhanced breadcrumb with highlighting for the current page and collapsing on mobile. This adds those examples to the component guide.

https://govuk-static-pr-1169.herokuapp.com/component-guide/breadcrumbs

<img width="979" alt="screen shot 2017-10-17 at 13 17 53" src="https://user-images.githubusercontent.com/29889908/31664845-e69df8b6-b33e-11e7-9d40-280cb87c50db.png">

<img width="980" alt="screen shot 2017-10-17 at 13 18 01" src="https://user-images.githubusercontent.com/29889908/31664847-e9c3703e-b33e-11e7-95c1-d49c34aabd89.png">



