### PR TITLE
Allow document_footer "from" field to be translatable

### DIFF
--- a/app/views/govuk_component/document_footer.raw.html.erb
+++ b/app/views/govuk_component/document_footer.raw.html.erb
@@ -64,7 +64,7 @@
   </div>
   <div class="related-information">
     <% if from.any? %>
-      <p>From: <span class="from">
+      <p><%= t("govuk_component.document_footer.from", default: "From") %>: <span class="from">
         <% from.each do |definition| %>
           <span class="definition">
             <%= definition.html_safe %>


### PR DESCRIPTION
This commit changes the hardcoded "From" string in the `document_footer` component to be translatable.