### PR TITLE
Remove stray slash in hrmc manuals survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -248,7 +248,7 @@
         },
         activeWhen: {
           path: [
-            '^/hmrc-internal-manuals/(?:/|$)'
+            '^/hmrc-internal-manuals(?:/|$)'
           ]
         }
       }


### PR DESCRIPTION
For: https://trello.com/c/NDPcQSmk/283-govuk-survey-hmrc-manuals

This survey should work on all paths under hmrc-internal-manuals, but we
left a slash in our regexp matcher that means it would only match entries
with a double slash (e.g. /hrmc-internal-manuals//foo instead of
/hrmrc-internal-manuals/foo).

We probably need to think about an abstraction for defining these matches
to make it hard to make this kind of mistake in the future.