### PR TITLE
Deprecate taxonomy sidebar component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,3 +1,5 @@
+// DEPRECATED: Will be removed in follow up PR
+// Cannot immediately remove because of https://github.com/alphagov/static/issues/1121
 .govuk-taxonomy-sidebar {
   border-top: 10px solid $mainstream-brand;
   padding-bottom: $gutter * 2;

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -1,11 +1,16 @@
-name: "Taxonomy sidebar"
+name: "Taxonomy sidebar (deprecated)"
 description: "Sidebar navigation for displaying on pages tagged to the GOV.UK taxonomy."
 body: |
-  Accepts an array of items. These items are typically the list of taxons the current
-  content page is tagged to.
+  Component originally showed taxons with descriptions and links to children.
 
-  Each item is a hash with a title, url, description, and list of related content
-  associated with that item.
+  Links are now coerced into a related items component, creating a single consistent
+  navigation pattern across pages.
+
+  Taxons with descriptions but no children are shown in a single "Elsewhere on GOV.UK"
+  section.
+
+  Taxons with children are shown in their own section, with a "More" link pointing to
+  the taxon page if a URL is provided.
 examples:
   default:
     data:

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -41,3 +41,15 @@ examples:
           description: |
             Key dates, sample and test materials, administration, moderation,
             assessing and reporting, statistics, frameworks.
+  taxon_with_no_link:
+    data:
+      items:
+        - title: "Taxon without a link"
+          description: |
+            Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+            exams and assessments, PSHE and SMSC.
+          related_content:
+            - title: "Key stage 1 teacher assessment"
+              link: /government/collections/key-stage-1-teacher-assessment
+            - title: "Primary assessments: information and resources for 2017"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -28,3 +28,16 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
+  no_children:
+    data:
+      items:
+        - title: "School curriculum"
+          url: /education/school-curriculum
+          description: |
+            Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+            exams and assessments, PSHE and SMSC.
+        - title: "Tests (key stage 1)"
+          url: /key-stage-1-tests
+          description: |
+            Key dates, sample and test materials, administration, moderation,
+            assessing and reporting, statistics, frameworks.

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,61 +1,35 @@
+<%# Deprecated - taxonomy links are now coerced into the related links component %>
 <% if local_assigns[:items] && !items.blank? %>
+  <%
+    elsewhere_on_govuk = {
+      title: 'Elsewhere on GOV.UK',
+      items: []
+    }
 
-  <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
-    <% items.each_with_index do |item, item_index| %>
-      <div class='sidebar-taxon' data-track-count="sidebarTaxonSection">
-        <h2>
-          <%=
-            link_to_if(
-              item[:url],
-              item[:title],
-              item[:url],
-              class: 'taxon-link',
-              data: {
-                track_category: 'relatedLinkClicked',
-                track_action: "#{item_index + 1}",
-                track_label: item[:url],
-                track_options: {
-                  dimension28: items.length.to_s,
-                  dimension29: item[:title],
-                },
-              },
-            )
-          %>
-        </h2>
+    sections = []
+    items.each do |i|
+      if i[:related_content] && i[:related_content].any?
+        related_content_items = i[:related_content].map do |related_content_link|
+                                  related_content_link[:url] = related_content_link.delete :link
+                                  related_content_link
+                                end
 
-        <p class='taxon-description'>
-          <%= item[:description] %>
-        </p>
+        sections << {
+          title: i[:title],
+          url: i[:url],
+          items: i[:related_content]
+        }
+      else
+        elsewhere_on_govuk[:items] << {
+          title: i[:title],
+          url: i[:url]
+        }
+      end
+    end
 
-        <% item[:related_content] ||= [] %>
-        <% if item[:related_content].any? %>
-          <nav role='navigation'>
-            <ul class='related-content'>
-              <% item[:related_content].each_with_index do |related_item, related_content_index| %>
-                <li>
-                  <%=
-                    link_to(
-                      related_item[:title],
-                      related_item[:link],
-                      data: {
-                          track_category: 'relatedLinkClicked',
-                          track_action: "#{item_index + 1}.#{related_content_index + 1}",
-                          track_label: related_item[:link],
-                          track_options: {
-                            dimension28: item[:related_content].length.to_s,
-                            dimension29: related_item[:title],
-                          }
-                      },
-                      class: 'related-link',
-                    )
-                  %>
-                </li>
-              <% end %>
-            </ul>
-          </nav>
-        <% end %>
-      </div>
-    <% end %>
-  </aside>
-
+    if elsewhere_on_govuk[:items].any?
+      sections << elsewhere_on_govuk
+    end
+  %>
+  <%= render file: 'govuk_component/related_items.raw', locals: { sections: sections } %>
 <% end %>

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -11,94 +11,30 @@ class TaxonomySidebarTestCase < ComponentTestCase
     end
   end
 
-  test "renders a taxonomy sidebar" do
+  test "renders a taxonomy sidebar with no children as an 'Elsewhere on' related links block" do
     render_component(
       items: [
         {
           title: "Item 1 title",
           url: "/item-1",
-          description: "item 1",
         },
         {
           title: "Item 2 title",
           url: "/item-2",
-          description: "item 2",
         },
       ]
     )
 
-    taxon_titles = css_select(".sidebar-taxon h2").map { |taxon_title| taxon_title.text.strip }
-    assert_equal ["Item 1 title", "Item 2 title"], taxon_titles
+    assert_select "h2", "Elsewhere on GOV.UK"
+    taxon_links = css_select("a").map { |taxon_title| taxon_title.text.strip }
+    assert_equal ["Item 1 title", "Item 2 title"], taxon_links
   end
 
-  test "renders all data attributes for tracking" do
+  test "renders without More link for taxons without URLs" do
     render_component(
       items: [
         {
-          title: "Item title",
-          url: "/item",
-          description: "An item",
-          related_content: [
-            {
-              title: "Related link 1a",
-              link: "/related-link-1a",
-            },
-            {
-              title: "Related link 1b",
-              link: "/related-link-1b",
-            },
-            {
-              title: "Related link 1c",
-              link: "/related-link-1c",
-            },
-          ],
-        },
-        {
-          title: "Second item title",
-          url: "/item-2",
-          description: "Another item",
-          related_content: [
-            {
-              title: "Related link 2a",
-              link: "/related-link-2a",
-            },
-          ],
-        },
-      ]
-    )
-
-    total_sections = 2
-    total_links_in_section_1 = 3
-
-    assert_select 'h2 a', "Item title"
-    assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
-    assert_tracking_link("category", "relatedLinkClicked", 6)
-
-    assert_tracking_link(
-      "options",
-      { dimension28: total_sections.to_s, dimension29: "Item title" }.to_json)
-    assert_tracking_link("action", "1")
-    assert_tracking_link("label", "/item")
-
-    assert_tracking_link(
-      "options",
-      { dimension28: total_links_in_section_1.to_s, dimension29: "Related link 1a" }.to_json)
-    assert_tracking_link("action", "1.1")
-    assert_tracking_link("label", "/related-link-1a")
-
-    assert_tracking_link(
-      "options",
-      { dimension28: total_links_in_section_1.to_s, dimension29: "Related link 1a" }.to_json)
-    assert_tracking_link("action", "1.2")
-    assert_tracking_link("label", "/related-link-1b")
-  end
-
-
-  test "renders without url on the h2 heading" do
-    render_component(
-      items: [
-        {
-          title: "Without an url",
+          title: "Without a url",
           description: "An item",
           related_content: [
             {
@@ -114,7 +50,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    assert_select 'h2', "Without an url"
-    assert_select 'h2 a', false
+    assert_select 'h2', "Without a url"
+    assert_select '.related-items-more', false
   end
 end


### PR DESCRIPTION
Depends on https://github.com/alphagov/government-frontend/pull/507

Bring taxonomy links in line with related links, leaving a single
pattern that can be iterated in multivariate tests.

In time, uses of this component will be switched to the related links
component or a new alternative.

* Coerce taxonomy sidebar into related links component
* Use the “More” link to point to taxon pages
* Use the “Elsewhere on GOV.UK” section to group taxon links without children
* Don’t show taxon descriptions

![screen_shot_2017-10-30_at_11 58 57](https://user-images.githubusercontent.com/319055/32215693-9b4a431a-be1a-11e7-83fe-f0a868558760.png)

https://trello.com/c/FN3ppmn2/60-update-taxonomy-related-links-in-right-column-to-match-the-design-used-by-mainstream-browse-related-links