### PR TITLE
Style start buttons on simple smart answers correctly

### DIFF
--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -41,7 +41,8 @@
 .transaction .get-started .button,
 .local_transaction .get-started .button,
 .licence .get-started .button,
-.next-steps-promo .get-started .button {
+.next-steps-promo .get-started .button,
+.simple_smart_answer .get-started .button {
   padding: 0.60em 1.7em 0.45em 0.67em;
   background-image: image-url("icon-pointer.png");
   background-position: 100% 50%;
@@ -69,7 +70,8 @@
 @include ie(6) {
   .transaction .get-started input.button,
   .local_transaction .get-started input.button,
-  .licence .get-started input.button {
+  .licence .get-started input.button,
+  .simple_smart_answer .get-started input.button {
     padding: 0.45em 0.5em 0.62em 0em;
   }
 }


### PR DESCRIPTION
Simple smart answers are missing the correct styles on their start buttons. This change ensures they have the right styling.

### Before

![www gov uk-register-employer iphone 6](https://user-images.githubusercontent.com/523014/32273607-06c39d0e-befb-11e7-91f6-77214d6a7c8d.png)

### After

![www gov uk-register-employer iphone 6 1](https://user-images.githubusercontent.com/523014/32273610-0ca82f6e-befb-11e7-9841-99e65e31eced.png)
