### PR TITLE
Improve task list Google Analytics

### DIFF
--- a/app/assets/javascripts/govuk-component/tasklist.js
+++ b/app/assets/javascripts/govuk-component/tasklist.js
@@ -18,6 +18,7 @@
     };
 
     var rememberOpenSection = false;
+    var taskListSize;
 
     this.start = function ($element) {
 
@@ -30,15 +31,16 @@
       $element.removeClass('js-hidden');
 
       rememberOpenSection = !!$element.filter('[data-remember]').length;
-      var $steps = $element.find('.pub-c-tasklist__step');
+      taskListSize = $element.hasClass('pub-c-task-list--large') ? 'Big' : 'Small';
+      var $steps = $element.find('.pub-c-task-list__step');
       var $sections = $element.find('.js-section');
       var $sectionHeaders = $element.find('.js-toggle-panel');
       var totalSections = $element.find('.js-panel').length;
-      var totalLinks = $element.find('.pub-c-tasklist__panel-link-item').length;
+      var totalLinks = $element.find('.pub-c-task-list__panel-link-item').length;
 
       var $openOrCloseAllButton;
 
-      var tasklistTracker = new TasklistTracker(totalSections,totalLinks);
+      var tasklistTracker = new TasklistTracker(totalSections, totalLinks);
 
       addButtonstoSections();
       addOpenCloseAllButton();
@@ -263,7 +265,7 @@
       }
 
       function numberOfContentItems() {
-        return $sectionContent.find('.pub-c-tasklist__panel-link').length;
+        return $sectionContent.find('.pub-c-task-list__panel-link').length;
       }
     }
 
@@ -286,8 +288,8 @@
     function SectionToggleClick(event, sectionView, $sections, tasklistTracker, $steps) {
       this.track = trackClick;
       var $target = $(event.target);
-      var $thisStep = sectionView.element.closest('.pub-c-tasklist__step');
-      var $thisStepSections = $thisStep.find('.pub-c-tasklist__section');
+      var $thisStep = sectionView.element.closest('.pub-c-task-list__step');
+      var $thisStepSections = $thisStep.find('.pub-c-task-list__section');
 
       function trackClick() {
         var tracking_options = {label: trackingLabel(), dimension28: sectionView.numberOfContentItems().toString()}
@@ -307,7 +309,7 @@
       }
 
       function trackingLabel() {
-        return stepIndex() + '.' + accordionIndex() + ' - ' + sectionView.title + ' - ' + locateClickElement() + ": " + getSize();
+        return stepIndex() + '.' + accordionIndex() + ' - ' + sectionView.title + ' - ' + locateClickElement() + ": " + taskListSize;
       }
 
       // needs to return which step we're in
@@ -339,7 +341,7 @@
       }
 
       function clickedOnIcon() {
-        return $target.hasClass('pub-c-tasklist__icon');
+        return $target.hasClass('pub-c-task-list__icon');
       }
 
       function clickedOnHeading() {
@@ -348,10 +350,6 @@
 
       function iconType() {
         return (sectionView.isClosed() ? 'Minus' : 'Plus');
-      }
-
-      function getSize() {
-        return sectionView.element.closest('.pub-c-tasklist').hasClass('pub-c-tasklist--large') ? 'Big' : 'Small';
       }
     }
 

--- a/app/assets/javascripts/govuk-component/tasklist.js
+++ b/app/assets/javascripts/govuk-component/tasklist.js
@@ -34,10 +34,11 @@
       var $sections = $element.find('.js-section');
       var $sectionHeaders = $element.find('.js-toggle-panel');
       var totalSections = $element.find('.js-panel').length;
+      var totalLinks = $element.find('.pub-c-tasklist__panel-link-item').length;
 
       var $openOrCloseAllButton;
 
-      var tasklistTracker = new TasklistTracker(totalSections);
+      var tasklistTracker = new TasklistTracker(totalSections,totalLinks);
 
       addButtonstoSections();
       addOpenCloseAllButton();
@@ -281,46 +282,7 @@
       var newLocation = hash || GOVUK.getCurrentLocation().pathname;
       history.replaceState({}, '', newLocation);
     }
-/*
-    // FIXME FROM SERVICE MANUAL FOR REFERENCE DELETE
-    // A contructor for an object that represents a click event on a subsection which
-    // handles the complexity of sending different tracking labels to Google Analytics
-    // depending on which part of the subsection the user clicked.
-    function SubsectionToggleClick (subsectionView, event) {
-      var that = this;
-      this.$target = $(event.target);
 
-      this.track = function () {
-        track('pageElementInteraction', that._trackingAction(), { label: that._trackingLabel() });
-      }
-
-      this._trackingAction = function () {
-        return (subsectionView.isClosed() ? 'accordionClosed' : 'accordionOpened');
-      }
-
-      this._trackingLabel = function () {
-        if (that._clickedOnIcon()) {
-          return subsectionView.title + ' - ' + that._iconType() + ' Click';
-        } else if (that._clickedOnHeading()) {
-          return subsectionView.title + ' - Heading Click';
-        } else {
-          return subsectionView.title + ' - Click Elsewhere';
-        }
-      }
-
-      this._clickedOnIcon = function () {
-        return that.$target.hasClass('subsection__icon');
-      }
-
-      this._clickedOnHeading = function () {
-        return that.$target.hasClass('js-subsection-button');
-      }
-
-      this._iconType = function () {
-        return (subsectionView.isClosed() ? 'Minus' : 'Plus');
-      }
-    }
-*/
     function SectionToggleClick(event, sectionView, $sections, tasklistTracker, $steps) {
       this.track = trackClick;
       var $target = $(event.target);
@@ -395,11 +357,15 @@
 
     // A helper that sends a custom event request to Google Analytics if
     // the GOVUK module is setup
-    function TasklistTracker(totalSections) {
+    function TasklistTracker(totalSections, totalLinks) {
       this.track = function(category, action, options) {
+        // dimension26 records the total number of expand/collapse sections in this tasklist
+        // dimension27 records the total number of component links in this tasklist
+        // dimension28 records the number of component links in the section that was opened/closed (handled in click event)
         if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
           options = options || {};
-          options["dimension28"] = options["dimension28"] || totalSections.toString();
+          options["dimension26"] = options["dimension26"] || totalSections.toString();
+          options["dimension27"] = options["dimension27"] || totalLinks.toString();
           GOVUK.analytics.trackEvent(category, action, options);
         }
       }

--- a/app/assets/stylesheets/govuk-component/_task-list.scss
+++ b/app/assets/stylesheets/govuk-component/_task-list.scss
@@ -216,7 +216,7 @@ $icon-size-large: 12px;
       height: $icon-size-large;
       width: $icon-size-large;
       margin-top: -($icon-size-large / 2) - 2;
-      // use a different PNG for IE8, which doesn't support background size
+      // repeating these two lines for the benefit of IE8, which doesn't support background size
       background-image: image-url('icon-plus-minus.png'); // PNG fallback for SVG
       background: image-url("icon-plus-minus.svg"), linear-gradient(transparent, transparent); // http://pauginer.com/post/36614680636/invisible-gradient-technique
     }

--- a/app/views/govuk_component/docs/task_list.yml
+++ b/app/views/govuk_component/docs/task_list.yml
@@ -25,6 +25,8 @@ accessibility_criteria: |
   - inform the user which step a link belongs to
   - inform the user which step the current page is in, particularly where there are multiple sections in one step
 
+  The open/close all button only needs to list the first panel id in the aria-controls attribute, rather than all of them.
+
   Section headings must use a button element:
 
   - so that sections can be toggled with the space and enter keys
@@ -203,17 +205,17 @@ examples:
             title: 'Panel links',
             panel_links: [
               {
-                href: '/notalink',
-                text: 'First item'
+                href: '/link1',
+                text: 'Link 1'
               },
               {
-                href: '/notalink',
-                text: 'Second item',
+                href: '/link2',
+                text: 'Link 2',
                 active: true
               },
               {
-                href: '/notalink',
-                text: 'Third item'
+                href: '/link3',
+                text: 'Link 3'
               }
             ]
           }
@@ -223,16 +225,16 @@ examples:
             title: 'More panel links',
             panel_links: [
               {
-                href: '/notalink',
-                text: 'First item'
+                href: '/link4',
+                text: 'Link 4'
               },
               {
-                href: '/notalink',
-                text: 'Second item',
+                href: '/link5',
+                text: 'Link 5',
               },
               {
-                href: '/notalink',
-                text: 'Third item'
+                href: '/link6',
+                text: 'Link 6'
               }
             ]
           }
@@ -259,21 +261,21 @@ examples:
             ],
             panel_links: [
               {
-                href: '/notalink',
-                text: 'First item'
+                href: '/link1',
+                text: 'Link 1'
               },
               {
-                href: '/notalink',
-                text: 'Second item'
+                href: '/link2',
+                text: 'Link 2'
               },
               {
-                href: '/notalink',
-                text: 'Third item',
+                href: '/link3',
+                text: 'Link 3',
                 active: true
               },
               {
-                href: '/notalink',
-                text: 'Fourth item'
+                href: '/link4',
+                text: 'Link 4'
               }
             ]
           },
@@ -334,13 +336,13 @@ examples:
             ],
             panel_links: [
               {
-                href: '/notalink',
-                text: 'First item',
+                href: '/link1',
+                text: 'Link 1',
                 active: true
               },
               {
-                href: '/notalink',
-                text: 'Second item'
+                href: '/link2',
+                text: 'Link 2'
               }
             ]
           }
@@ -348,7 +350,21 @@ examples:
         [
           {
             title: 'Small panel links 3',
-            panel: 'content'
+            panel: 'content',
+            panel_links: [
+              {
+                href: '/link3',
+                text: 'Link 3'
+              },
+              {
+                href: '/link4',
+                text: 'Link 4'
+              },
+              {
+                href: '/link5',
+                text: 'Link 5'
+              }
+            ]
           }
         ]
       ]

--- a/spec/javascripts/govuk-component/task-list-spec.js
+++ b/spec/javascripts/govuk-component/task-list-spec.js
@@ -216,26 +216,6 @@ describe('A tasklist module', function () {
       });
     });
 
-    it("triggers a google analytics custom event when clicking on the title on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
-      $sectionLink.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1.1 - Topic Section One - Heading click: Big',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
     it("triggers a google analytics custom event when clicking on the icon", function () {
       GOVUK.analytics = {
         trackEvent: function () {
@@ -254,26 +234,6 @@ describe('A tasklist module', function () {
       });
     });
 
-    it("triggers a google analytics custom event when clicking on the icon on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      var $sectionIcon = $element.find('.pub-c-task-list__icon');
-      $sectionIcon.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1.1 - Topic Section One - Plus click: Big',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
     it("triggers a google analytics custom event when clicking in space in the header", function () {
       GOVUK.analytics = {
         trackEvent: function () {
@@ -286,26 +246,6 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Elsewhere click: Small',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
-    it("triggers a google analytics custom event when clicking in space in the header on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      var $sectionHeader = $element.find('.pub-c-task-list__header');
-      $sectionHeader.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1.1 - Topic Section One - Elsewhere click: Big',
         dimension26: expectedTasklistSectionCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -353,27 +293,6 @@ describe('A tasklist module', function () {
       });
     });
 
-    it("triggers a google analytics custom event when clicking on the title on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
-      $sectionLink.click();
-      $sectionLink.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1.1 - Topic Section One - Heading click: Big',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
     it("triggers a google analytics custom event when clicking on the icon", function () {
       GOVUK.analytics = {
         trackEvent: function () {
@@ -387,27 +306,6 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Minus click: Small',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
-    it("triggers a google analytics custom event when clicking on the icon on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      var $sectionIcon = $element.find('.pub-c-task-list__icon');
-      $sectionIcon.click();
-      $sectionIcon.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1.1 - Topic Section One - Minus click: Big',
         dimension26: expectedTasklistSectionCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -428,28 +326,6 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Elsewhere click: Small',
-        dimension26: expectedTasklistSectionCount.toString(),
-        dimension27: expectedTasklistLinkCount.toString(),
-        dimension28: expectedTasklistContentCount.toString()
-      });
-    });
-
-    it("triggers a google analytics custom event when clicking in space in the header on a big tasklist", function () {
-      $element.addClass('pub-c-task-list--large');
-
-      GOVUK.analytics = {
-        trackEvent: function () {
-        }
-      };
-      spyOn(GOVUK.analytics, 'trackEvent');
-
-      tasklist.start($element);
-      var $sectionHeader = $element.find('.pub-c-task-list__header');
-      $sectionHeader.click();
-      $sectionHeader.click();
-
-      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1.1 - Topic Section One - Elsewhere click: Big',
         dimension26: expectedTasklistSectionCount.toString(),
         dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
@@ -476,6 +352,128 @@ describe('A tasklist module', function () {
     it("leaves other sections closed", function () {
       var $section = $element.find('#topic-section-two');
       expect($section).not.toHaveClass('section-is-open');
+    });
+  });
+
+  describe('When tracking a big task list', function () {
+    beforeEach(function () {
+      tasklist = new GOVUK.Modules.Tasklist();
+      $element = $(html);
+      $element.addClass('pub-c-task-list--large');
+      tasklist.start($element);
+    });
+
+    it("triggers a google analytics custom event when clicking on the title on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
+      $sectionLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Heading click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on the icon on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionIcon = $element.find('.pub-c-task-list__icon');
+      $sectionIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Plus click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking in space in the header on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionHeader = $element.find('.pub-c-task-list__header');
+      $sectionHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Elsewhere click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when closing by clicking on the title on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
+      $sectionLink.click();
+      $sectionLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Heading click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+
+    it("triggers a google analytics custom event when closing by clicking on the icon on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionIcon = $element.find('.pub-c-task-list__icon');
+      $sectionIcon.click();
+      $sectionIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Minus click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when closing by clicking in space in the header on a big tasklist", function () {
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      tasklist.start($element);
+      var $sectionHeader = $element.find('.pub-c-task-list__header');
+      $sectionHeader.click();
+      $sectionHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Elsewhere click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
+        dimension28: expectedTasklistContentCount.toString()
+      });
     });
   });
 

--- a/spec/javascripts/govuk-component/task-list-spec.js
+++ b/spec/javascripts/govuk-component/task-list-spec.js
@@ -18,7 +18,7 @@ describe('A tasklist module', function () {
             <div class="pub-c-task-list__panel js-panel" id="section-panel-10-0">\
               <ol class="pub-c-task-list__panel-links">\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 1</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 1</a>\
                 </li>\
               </ol>\
             </div>\
@@ -31,10 +31,10 @@ describe('A tasklist module', function () {
             <div class="pub-c-task-list__panel js-panel" id="section-panel-11-1">\
               <ol class="pub-c-task-list__panel-links">\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 2</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 2</a>\
                 </li>\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 3</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 3</a>\
                 </li>\
               </ol>\
             </div>\
@@ -52,13 +52,13 @@ describe('A tasklist module', function () {
             <div class="pub-c-task-list__panel js-panel" id="section-panel-12-0">\
               <ol class="pub-c-task-list__panel-links">\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 4</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 4</a>\
                 </li>\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 5</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 5</a>\
                 </li>\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">Link 6</a>\
+                  <a href="#" class="pub-c-task-list__panel-link-item">Link 6</a>\
                 </li>\
               </ol>\
             </div>\
@@ -69,6 +69,7 @@ describe('A tasklist module', function () {
 
   var expectedTasklistSectionCount = 0;
   var expectedTasklistContentCount = 0;
+  var expectedTasklistLinkCount = 0;
 
   beforeEach(function () {
     tasklist = new GOVUK.Modules.Tasklist();
@@ -76,6 +77,7 @@ describe('A tasklist module', function () {
     tasklist.start($element);
     expectedTasklistSectionCount = $element.find('.pub-c-task-list__section').length;
     expectedTasklistContentCount = $element.find('.pub-c-task-list__section').first().find('.pub-c-task-list__panel-link').length;
+    expectedTasklistLinkCount = $element.find('.pub-c-task-list__panel-link-item').length;
   });
 
   afterEach(function () {
@@ -154,7 +156,8 @@ describe('A tasklist module', function () {
     it("triggers a google analytics custom event", function () {
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistAllOpened', {
         label: 'Open All',
-        dimension28: expectedTasklistSectionCount.toString()
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString()
       });
     });
   });
@@ -172,7 +175,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistAllClosed', {
         label: 'Close All',
-        dimension28: expectedTasklistSectionCount.toString()
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString()
       });
     });
   });
@@ -206,6 +210,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Heading click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -224,6 +230,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Heading click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -240,6 +248,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Plus click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -258,6 +268,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Plus click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -274,6 +286,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Elsewhere click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -292,6 +306,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
         label: '1.1 - Topic Section One - Elsewhere click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -331,6 +347,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Heading click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -350,6 +368,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Heading click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -367,6 +387,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Minus click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -386,6 +408,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Minus click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -404,6 +428,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Elsewhere click: Small',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -424,6 +450,8 @@ describe('A tasklist module', function () {
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
         label: '1.1 - Topic Section One - Elsewhere click: Big',
+        dimension26: expectedTasklistSectionCount.toString(),
+        dimension27: expectedTasklistLinkCount.toString(),
         dimension28: expectedTasklistContentCount.toString()
       });
     });

--- a/spec/javascripts/govuk-component/task-list-spec.js
+++ b/spec/javascripts/govuk-component/task-list-spec.js
@@ -6,7 +6,7 @@ describe('A tasklist module', function () {
   var html = '\
     <div data-module="tasklist" class="pub-c-task-list js-hidden">\
       <ol>\
-        <li class="pub-c-task-list__section-wrapper">\
+        <li class="pub-c-task-list__step">\
           <span class="pub-c-task-list__number">\
             <span class="visuallyhidden">Step </span>1\
           </span>\
@@ -18,26 +18,47 @@ describe('A tasklist module', function () {
             <div class="pub-c-task-list__panel js-panel" id="section-panel-10-0">\
               <ol class="pub-c-task-list__panel-links">\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">list item in here</a>\
-                </li>\
-                <li class="pub-c-task-list__panel-link">\
-                  <a href="">list item in here</a>\
+                  <a href="">Link 1</a>\
                 </li>\
               </ol>\
             </div>\
           </div>\
           <div class="pub-c-task-list__section js-section" id="topic-section-two" data-track-count="tasklistSection">\
             <div class="pub-c-task-list__header js-toggle-panel">\
-              <h2 class="pub-c-task-list__title js-section-title">Topic Section One</h2>\
+              <h2 class="pub-c-task-list__title js-section-title">Topic Section Two</h2>\
               <p class="pub-c-task-list__description">Section 2 description in here</p>\
             </div>\
             <div class="pub-c-task-list__panel js-panel" id="section-panel-11-1">\
               <ol class="pub-c-task-list__panel-links">\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">list item in here</a>\
+                  <a href="">Link 2</a>\
                 </li>\
                 <li class="pub-c-task-list__panel-link">\
-                  <a href="">list item in here</a>\
+                  <a href="">Link 3</a>\
+                </li>\
+              </ol>\
+            </div>\
+          </div>\
+        </li>\
+        <li class="pub-c-task-list__step">\
+          <span class="pub-c-task-list__number">\
+            <span class="visuallyhidden">Step </span>2\
+          </span>\
+          <div class="pub-c-task-list__section js-section" id="topic-section-one" data-track-count="tasklistSection">\
+            <div class="pub-c-task-list__header js-toggle-panel">\
+              <h2 class="pub-c-task-list__title js-section-title">Topic Section Three</h2>\
+              <p class="pub-c-task-list__description">Section 3 description in here</p>\
+            </div>\
+            <div class="pub-c-task-list__panel js-panel" id="section-panel-12-0">\
+              <ol class="pub-c-task-list__panel-links">\
+                <li class="pub-c-task-list__panel-link">\
+                  <a href="">Link 4</a>\
+                </li>\
+                <li class="pub-c-task-list__panel-link">\
+                  <a href="">Link 5</a>\
+                </li>\
+                <li class="pub-c-task-list__panel-link">\
+                  <a href="">Link 6</a>\
                 </li>\
               </ol>\
             </div>\
@@ -45,13 +66,16 @@ describe('A tasklist module', function () {
         </li>\
       </ol>\
     </div>';
-  var expectedTasklistSectionCount = 2;
-  var expectedTasklistContentCount = 2;
+
+  var expectedTasklistSectionCount = 0;
+  var expectedTasklistContentCount = 0;
 
   beforeEach(function () {
     tasklist = new GOVUK.Modules.Tasklist();
     $element = $(html);
     tasklist.start($element);
+    expectedTasklistSectionCount = $element.find('.pub-c-task-list__section').length;
+    expectedTasklistContentCount = $element.find('.pub-c-task-list__section').first().find('.pub-c-task-list__panel-link').length;
   });
 
   afterEach(function () {
@@ -75,7 +99,7 @@ describe('A tasklist module', function () {
     // It has an aria-expanded false attribute as all sections are closed
     expect($openCloseAllButton).toHaveAttr("aria-expanded", "false");
     // It has an aria-controls attribute that includes all the section_content IDs
-    expect($openCloseAllButton).toHaveAttr('aria-controls', 'section-panel-10-0 section-panel-11-1 ');
+    expect($openCloseAllButton).toHaveAttr('aria-controls', 'section-panel-10-0');
   });
 
   it("has no sections which have an open state", function () {
@@ -103,7 +127,7 @@ describe('A tasklist module', function () {
     expect($sectionHeader).toContainElement('.pub-c-task-list__icon');
   });
 
-  describe('Clicking the "Expand all" button', function () {
+  describe('Clicking the "Open all" button', function () {
     beforeEach(function () {
       GOVUK.analytics = {
         trackEvent: function () {
@@ -114,11 +138,13 @@ describe('A tasklist module', function () {
     });
 
     it('adds a .section-is-open class to each section to hide the icon', function () {
-      expect($element.find('.section-is-open').length).toEqual(2);
+      var sectionCount = $element.find('.pub-c-task-list__section').length;
+      expect($element.find('.section-is-open').length).toEqual(sectionCount);
     });
 
     it('adds an aria-expanded attribute to each section link', function () {
-      expect($element.find('.js-section-title-button[aria-expanded="true"]').length).toEqual(2);
+      var sectionCount = $element.find('.pub-c-task-list__section').length;
+      expect($element.find('.js-section-title-button[aria-expanded="true"]').length).toEqual(sectionCount);
     });
 
     it('changes the Open/Close all button text to "Close all"', function () {
@@ -179,7 +205,25 @@ describe('A tasklist module', function () {
       $sectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Heading click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on the title on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
+      $sectionLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Heading click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -195,7 +239,25 @@ describe('A tasklist module', function () {
       $sectionIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Plus click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on the icon on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionIcon = $element.find('.pub-c-task-list__icon');
+      $sectionIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Plus click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -211,7 +273,25 @@ describe('A tasklist module', function () {
       $sectionHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Elsewhere click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking in space in the header on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionHeader = $element.find('.pub-c-task-list__header');
+      $sectionHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistOpened', {
+        label: '1.1 - Topic Section One - Elsewhere click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -250,7 +330,26 @@ describe('A tasklist module', function () {
       $sectionLink.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Heading click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on the title on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionLink = $element.find('.pub-c-task-list__header .pub-c-task-list__button--title');
+      $sectionLink.click();
+      $sectionLink.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Heading click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -267,7 +366,26 @@ describe('A tasklist module', function () {
       $sectionIcon.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Minus click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking on the icon on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      var $sectionIcon = $element.find('.pub-c-task-list__icon');
+      $sectionIcon.click();
+      $sectionIcon.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Minus click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });
@@ -285,7 +403,27 @@ describe('A tasklist module', function () {
       $sectionHeader.click();
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
-        label: '1. Topic Section One',
+        label: '1.1 - Topic Section One - Elsewhere click: Small',
+        dimension28: expectedTasklistContentCount.toString()
+      });
+    });
+
+    it("triggers a google analytics custom event when clicking in space in the header on a big tasklist", function () {
+      $element.addClass('pub-c-task-list--large');
+
+      GOVUK.analytics = {
+        trackEvent: function () {
+        }
+      };
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      tasklist.start($element);
+      var $sectionHeader = $element.find('.pub-c-task-list__header');
+      $sectionHeader.click();
+      $sectionHeader.click();
+
+      expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('pageElementInteraction', 'tasklistClosed', {
+        label: '1.1 - Topic Section One - Elsewhere click: Big',
         dimension28: expectedTasklistContentCount.toString()
       });
     });


### PR DESCRIPTION
- update JS to include code to determine which element in the task list accordion header was clicked (button, plus/minus, or white space) from service manual
- dimension26 records total number of expand/collapse sections in task list
- dimension27 records total number of component links in task list (links that are part of the component)
- dimension28 records number of component links in the section that was opened/closed (handled in click event)

Trello card: https://trello.com/c/EiXT7IAh/227-implement-tracking-on-the-beta-task-list

PR: https://govuk-static-pr-1179.herokuapp.com/component-guide/task_list (no visual changes but tracking can be viewed using the GA Chrome plugin)