### PR TITLE
Add ability to pass rel attributes to buttons

### DIFF
--- a/app/views/govuk_component/button.raw.html.erb
+++ b/app/views/govuk_component/button.raw.html.erb
@@ -2,6 +2,7 @@
   start ||= false
   href ||= false
   info_text ||= false
+  rel ||= false
   text ||= ""
   tag_name = href ? "a" : "button"
 %>
@@ -15,6 +16,10 @@
   <% if href %>
     href="<%= href.try(:html_safe) %>"
     role="button"
+  <% end %>
+
+  <% if rel %>
+    rel="<%= rel %>"
   <% end %>
 >
   <%= text %>

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -41,6 +41,7 @@ examples:
       text: "Start now"
       href: "#"
       start: true
+      rel: "external"
   start_now_button_with_info_text:
     data:
       text: "Start now"

--- a/test/govuk_component/button_test.rb
+++ b/test/govuk_component/button_test.rb
@@ -47,4 +47,12 @@ class ButtonTestCase < ComponentTestCase
     assert_select ".pub-c-button", text: "Start now"
     assert_select ".pub-c-button__info-text", text: "Information text"
   end
+
+  test "renders rel attribute correctly" do
+    render_component(text: "Start now", rel: "nofollow")
+    assert_select ".pub-c-button[rel='nofollow']", text: "Start now"
+
+    render_component(text: "Start now", rel: "nofollow preload")
+    assert_select ".pub-c-button[rel='nofollow preload']", text: "Start now"
+  end
 end


### PR DESCRIPTION
This is needed for transactions that applies rel="external"

See https://github.com/alphagov/frontend/blob/master/app/views/transaction/show.html.erb#L20

https://govuk-static-pr-1180.herokuapp.com/component-guide/button/start_now_button/preview