### PR TITLE
Fix search button radius in Chrome 62 (Mac)

### DIFF
--- a/app/assets/stylesheets/govuk-component/_search.scss
+++ b/app/assets/stylesheets/govuk-component/_search.scss
@@ -25,6 +25,7 @@
     padding: 6px;
     border: 0;
     cursor: pointer;
+    border-radius: 0;
   }
 
   // IE6 + IE7 always get the simplest version, regardless of whether javascript is enabled


### PR DESCRIPTION
Chrome 62 [updates the default styles for buttons to add a default `border-radius` of 4px][1], which is affecting the buttons in the search box (noticed on the homepage).

This sets an explicit border radius of `0`, which corrects the search button to look like it does in Chrome 61.

## Before
![govuk-static herokuapp com_component-guide_search](https://user-images.githubusercontent.com/121939/32364693-251c5114-c06e-11e7-8936-acc6b1c5c44b.png)


## After
![govuk-static herokuapp com_component-guide_search 1](https://user-images.githubusercontent.com/121939/32364696-285b8700-c06e-11e7-927b-f0d04074a53e.png)

[1]: https://www.chromestatus.com/features/5743649186906112