### PR TITLE
Style taxonomy sidebar like related links

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,38 +1,29 @@
 .govuk-taxonomy-sidebar {
   border-top: 10px solid $mainstream-brand;
-  padding-bottom: $gutter * 2;
+  padding-top: 5px;
   @include core-16;
 
-  .sidebar-taxon {
-    padding-top: 1.25em;
+  h2 {
+    @include bold-24;
+    margin-top: 0.3em;
+    margin-bottom: 0.5em;
+  }
 
-    h2 {
-      @include bold-24;
-      margin: 0 0 5px;
-    }
+  .taxon-description {
+    margin-bottom: 0.75em;
+  }
 
-    .taxon-description {
-      @include core-16;
-      margin: 0;
-    }
+  ul {
+    // reset the default browser styles
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    margin-bottom: 1.25em;
 
-    .related-content {
-      @include core-16;
-      margin: 0 0 0 15px;
+    li {
+      // reset the default browser styles
       padding: 0;
-
-      li {
-        // Scale the bullets down in size using this variable, and
-        // then scale the text back up by the reciprocal
-        $bullet-fraction: 0.75;
-        font-size: #{$bullet-fraction}em;
-
-        a {
-          display: block;
-          font-size: #{1 / $bullet-fraction}em;
-          line-height: 1.5;
-        }
-      }
+      margin-bottom: 0.75em;
     }
   }
 }

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -28,3 +28,18 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
+  no_children:
+    description: |
+      The child links are usually pulled from rummager. If rummager doesn’t respond we fallback to a sidebar with a taxon link but without any child content links.
+    data:
+      items:
+        - title: "School curriculum"
+          url: /education/school-curriculum
+          description: |
+            Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+            exams and assessments, PSHE and SMSC.
+        - title: "Tests (key stage 1)"
+          url: /key-stage-1-tests
+          description: |
+            Key dates, sample and test materials, administration, moderation,
+            assessing and reporting, statistics, frameworks.

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -43,3 +43,15 @@ examples:
           description: |
             Key dates, sample and test materials, administration, moderation,
             assessing and reporting, statistics, frameworks.
+  taxon_with_no_link:
+    data:
+      items:
+        - title: "Taxon without a link"
+          description: |
+            Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+            exams and assessments, PSHE and SMSC.
+          related_content:
+            - title: "Key stage 1 teacher assessment"
+              link: /government/collections/key-stage-1-teacher-assessment
+            - title: "Primary assessments: information and resources for 2017"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -28,6 +28,37 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
+  long_example:
+    data:
+      items:
+        - title: "School curriculum for children ages 16 to 19, and 10 to 14"
+          url: /education/school-curriculum
+          description: |
+            Early years, key stages 1 to 5, GCSE and AS and A level reforms, tests,
+            exams and assessments, PSHE and SMSC. Widening participation, funding
+            for children in deprived areas. Improving attainment in schools for
+            looked-after children.
+          related_content:
+            - title: "Further education financial management and data collection"
+              link: /government/collections/key-stage-1-teacher-assessment
+            - title: "Primary assessments: information and resources for 2017"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017
+            - title: "Slide pack from Phil Beach at the Skills & Employability Summit"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017
+            - title: "Transport to education and training for people aged 16 to 18"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017
+        - title: "Tests (key stage 1, 2 and 3), plus further tests outside of school"
+          url: /key-stage-1-tests
+          description: |
+            Key dates, sample and test materials, administration, moderation,
+            assessing and reporting, statistics, frameworks. University and college
+            qualifications. Apprenticeships, traineeships and internships. Funding
+            for further education providers.
+          related_content:
+            - title: "Key stage 1 teacher assessment"
+              link: /government/collections/key-stage-1-teacher-assessment
+            - title: "Primary assessments: information and resources for 2017"
+              link: /government/publications/primary-assessments-information-and-resources-for-2017
   no_children:
     description: |
       The child links are usually pulled from rummager. If rummager doesn’t respond we fallback to a sidebar with a taxon link but without any child content links.


### PR DESCRIPTION
We will be iterating both components as part of a multivariate test. This commit avoids a more thorough refactor to make them identical, in favour of making them alike. It’s an alternative to #1177.

* Port related links styles directly from related links component
* Makes two components similar
* Increases spacing around links for easier clicking on mobile
* Adds more examples

This PR does not address:
* Need to use `pub-c` as the prefix
* Inconsistent API between related links and taxonomy sidebar
* Style re-use between components

https://govuk-static-pr-1185.herokuapp.com/component-guide/taxonomy_sidebar

Part of:
https://trello.com/c/FN3ppmn2/60-update-taxonomy-related-links-in-right-column-to-match-the-design-used-by-mainstream-browse-related-links

## Screenshots
Old on left, new on right

![screen shot 2017-11-06 at 11 58 46](https://user-images.githubusercontent.com/319055/32440205-1b04d380-c2ea-11e7-99a7-9097aff232d4.png)

![screen shot 2017-11-06 at 11 59 21](https://user-images.githubusercontent.com/319055/32440207-1b23b66a-c2ea-11e7-839a-7b8a7f6c0cea.png)

## Thin viewport

![screen shot 2017-11-06 at 12 00 20](https://user-images.githubusercontent.com/319055/32440208-1b40acde-c2ea-11e7-9ff3-1ae8f35874dd.png)
