### PR TITLE
Change footer link to point directly at destination page

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -69,7 +69,7 @@
         <ul>
           <li><a href="/government/how-government-works">How government works</a></li>
           <li><a href="/government/organisations">Departments</a></li>
-          <li><a href="/government/world">Worldwide</a></li>
+          <li><a href="/world">Worldwide</a></li>
           <li><a href="/government/policies">Policies</a></li>
           <li><a href="/government/publications">Publications</a></li>
           <li><a href="/government/announcements">Announcements</a></li>


### PR DESCRIPTION
Existing footer link to Worldwide goes through a redirect to the destination, this pr links directly to it instead.