### PR TITLE
Add global cross domain tracking

### DIFF
--- a/app/assets/javascripts/modules/cross-domain-tracking.js
+++ b/app/assets/javascripts/modules/cross-domain-tracking.js
@@ -1,0 +1,33 @@
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules, global) {
+  'use strict'
+
+  var $ = global.$
+
+  Modules.CrossDomainTracking = function () {
+    this.start = function ($context) {
+      var trackableLinkSelector = '[href][data-tracking-code][data-tracking-name]'
+
+      if ($context.is(trackableLinkSelector)) {
+        addLinkedTrackerDomain($context)
+      } else {
+        $context
+          .find(trackableLinkSelector)
+          .each(function () {
+            addLinkedTrackerDomain($(this))
+          })
+      }
+    }
+
+    function addLinkedTrackerDomain ($element) {
+      var code = $element.attr('data-tracking-code')
+      var name = $element.attr('data-tracking-name')
+      var hostname = $element.prop('hostname')
+
+      if (GOVUK.analytics !== 'undefined') {
+        GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
+      }
+    }
+  }
+})(window.GOVUK.Modules, window)

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -3,6 +3,7 @@
 // = require modules/toggle
 // = require modules/toggle-input-class-on-focus
 // = require modules/track-click
+// = require modules/cross-domain-tracking
 // = require govuk-component/tasklist
 
 $(document).ready(function () {

--- a/spec/javascripts/modules/cross-domain-tracking.spec.js
+++ b/spec/javascripts/modules/cross-domain-tracking.spec.js
@@ -1,0 +1,97 @@
+describe('Cross Domain Tracking', function () {
+  'use strict'
+  var module
+
+  beforeEach(function () {
+    GOVUK.analytics = GOVUK.analytics || {}
+    GOVUK.analytics.addLinkedTrackerDomain = function () {
+    }
+
+    spyOn(GOVUK.analytics, 'addLinkedTrackerDomain')
+    module = new GOVUK.Modules.CrossDomainTracking()
+  })
+
+  it('tracks realistic example', function () {
+    var anchorToTest = document.createElement('a')
+    anchorToTest.href = 'https://www.registertovote.service.gov.uk/register-to-vote/start'
+    anchorToTest.className = 'button button--start'
+    anchorToTest.setAttribute('role', 'button')
+    anchorToTest.setAttribute('data-module', 'cross-domain-tracking')
+    anchorToTest.setAttribute('data-tracking-code', 'UA-23066786-5')
+    anchorToTest.setAttribute('data-tracking-name', 'transactionTracker')
+    anchorToTest.textContent = 'Start Now'
+
+    module.start($(anchorToTest))
+
+    expect(
+      GOVUK.analytics.addLinkedTrackerDomain
+    ).toHaveBeenCalledWith('UA-23066786-5', 'transactionTracker', 'www.registertovote.service.gov.uk')
+  })
+
+  it('tracks links with cross-domain-analytics data attributes', function () {
+    var anchorToTest = document.createElement('a')
+    anchorToTest.href = 'https://www.gov.uk/browse/citizenship/voting'
+    anchorToTest.setAttribute('data-module', 'cross-domain-tracking')
+    anchorToTest.setAttribute('data-tracking-code', 'UA-XXXXXXXXX-Y')
+    anchorToTest.setAttribute('data-tracking-name', 'govspeakButtonTracker')
+
+    var wrapperDiv = document.createElement('div')
+    wrapperDiv.appendChild(anchorToTest)
+
+    module.start($(wrapperDiv))
+
+    expect(
+      GOVUK.analytics.addLinkedTrackerDomain
+    ).toHaveBeenCalledWith('UA-XXXXXXXXX-Y', 'govspeakButtonTracker', 'www.gov.uk')
+  })
+
+  it('tracks multiple links', function () {
+    var anchorToTest = document.createElement('a')
+    anchorToTest.href = 'https://www.gov.uk/browse/citizenship/voting'
+    anchorToTest.setAttribute(
+      'data-tracking-code',
+      'UA-XXXXXXXXX-Y'
+    )
+    anchorToTest.setAttribute(
+      'data-tracking-name',
+      'govspeakButtonTracker'
+    )
+
+    var secondAnchorToTest = document.createElement('a')
+    secondAnchorToTest.href = 'https://www.registertovote.service.gov.uk/register-to-vote/start'
+    secondAnchorToTest.setAttribute(
+      'data-tracking-code',
+      'UA-23066786-5'
+    )
+    secondAnchorToTest.setAttribute(
+      'data-tracking-name',
+      'transactionTracker'
+    )
+
+    var wrapperDiv = document.createElement('div')
+    wrapperDiv.appendChild(anchorToTest)
+    wrapperDiv.appendChild(secondAnchorToTest)
+
+    module.start($(wrapperDiv))
+
+    expect(
+      GOVUK.analytics.addLinkedTrackerDomain
+    ).toHaveBeenCalledWith('UA-XXXXXXXXX-Y', 'govspeakButtonTracker', 'www.gov.uk')
+
+    expect(
+      GOVUK.analytics.addLinkedTrackerDomain
+    ).toHaveBeenCalledWith('UA-23066786-5', 'transactionTracker', 'www.registertovote.service.gov.uk')
+  })
+
+  it('tracks doesnt track if data attributes are not there', function () {
+    var anchorToTest = document.createElement('a')
+    anchorToTest.href = 'https://www.registertovote.service.gov.uk/register-to-vote/start'
+
+    var wrapperDiv = document.createElement('div')
+    wrapperDiv.appendChild(anchorToTest)
+
+    module.start($(wrapperDiv))
+
+    expect(GOVUK.analytics.addLinkedTrackerDomain).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
This allows a generic method of cross domain tracking for links on GOV.UK.

This will be useful for when our govspeak extension is used in content,
where only content designers can author what goes into the body of the page.

Here we're using native DOM methods rather than jQuery fragments because, for
whatever reason jQuery produces a fragment that does not allow inspection of hostname.
(I think this is because we can't inject a fragment into a real dom)

So rather than add additional overhead to the users' javascript, the tests are a little more verbose.

Will also allow us to replace https://github.com/alphagov/frontend/blob/master/app/views/transaction/_cross_domain_analytics.html.erb

Trello: https://trello.com/c/ppqXaGPk/122-create-a-govspeak-component-for-buttons