### PR TITLE
Add click tracking to task list header links

### DIFF
--- a/app/views/govuk_component/task_list_header.raw.html.erb
+++ b/app/views/govuk_component/task_list_header.raw.html.erb
@@ -5,10 +5,16 @@
   skip_link_text ||= "Skip content"
 %>
 <% if title %>
-  <div class="pub-c-task-list-header">
+  <div class="pub-c-task-list-header" data-module="track-click">
     <span class="pub-c-task-list-header__part-of">Part of</span>
     <% if path %>
-      <a href="<%= path %>" class="pub-c-task-list-header__title">
+      <a href="<%= path %>"
+        class="pub-c-task-list-header__title"
+        data-track-category="tasklistHeaderClicked"
+        data-track-action="top"
+        data-track-label="<%= path %>"
+        data-track-dimension="<%= title %>"
+        data-track-dimension-index="29">
         <%= title %>
       </a>
     <% else %>
@@ -18,7 +24,13 @@
     <% end %>
 
     <% if skip_link %>
-      <a href="<%= skip_link %>" class="pub-c-task-list-header__skip-link">
+      <a href="<%= skip_link %>"
+        class="pub-c-task-list-header__skip-link"
+        data-track-category="tasklistHeaderClicked"
+        data-track-action="top"
+        data-track-label="<%= skip_link %>"
+        data-track-dimension="<%= skip_link_text %>"
+        data-track-dimension-index="29">
         <%= skip_link_text %>
       </a>
     <% end %>

--- a/test/govuk_component/task_list_header_test.rb
+++ b/test/govuk_component/task_list_header_test.rb
@@ -18,13 +18,27 @@ class TaskListHeaderTestCase < ComponentTestCase
   test "renders with a link" do
     render_component(title: "This is my title", path: "/notalink")
 
-    assert_select ".pub-c-task-list-header a.pub-c-task-list-header__title[href='/notalink']", text: "This is my title"
+    link = ".pub-c-task-list-header a.pub-c-task-list-header__title"
+
+    assert_select link + "[href='/notalink']", text: "This is my title"
+    assert_select link + "[data-track-category='tasklistHeaderClicked']"
+    assert_select link + "[data-track-action='top']"
+    assert_select link + "[data-track-label='/notalink']"
+    assert_select link + "[data-track-dimension='This is my title']"
+    assert_select link + "[data-track-dimension-index='29']"
   end
 
   test "renders with a skip link" do
     render_component(title: "This is my title", skip_link: "#skiplink")
 
-    assert_select ".pub-c-task-list-header .pub-c-task-list-header__skip-link[href='#skiplink']", text: "Skip content"
+    link = ".pub-c-task-list-header .pub-c-task-list-header__skip-link"
+
+    assert_select link + "[href='#skiplink']", text: "Skip content"
+    assert_select link + "[data-track-category='tasklistHeaderClicked']"
+    assert_select link + "[data-track-action='top']"
+    assert_select link + "[data-track-label='#skiplink']"
+    assert_select link + "[data-track-dimension='Skip content']"
+    assert_select link + "[data-track-dimension-index='29']"
   end
 
   test "renders with a skip link with custom text" do


### PR DESCRIPTION
- add GA tracking to both main link and skip link
- records: EventCategory = ‘tasklistHeaderClicked’, Action = 'top', eventlabel = [link url], dimension29 = [link text]
- as detailed in 'Sticky navigation' section of https://docs.google.com/document/d/1bvUR4i8aARl-gPGHt3dzDoPFU3RZNgM7he3zB3ua2Gk/

Both links shown below:

![screen shot 2017-11-15 at 09 12 43](https://user-images.githubusercontent.com/861310/32827767-2c74f0da-c9e5-11e7-95bc-e22b9b399433.png)

Trello: https://trello.com/c/d6B6hRhh/292-restore-tracking-on-task-list-header-%F0%9F%9A%97