### PR TITLE
Add accessibility acceptance criteria

### DIFF
--- a/app/views/govuk_component/docs/alpha_label.yml
+++ b/app/views/govuk_component/docs/alpha_label.yml
@@ -1,6 +1,12 @@
 name: Alpha Banner
-description: A banner that indicates content is in an alpha phase with an optional
+description: A banner that indicates content is in an alpha phase, with an optional
   explanation
+accessibility_criteria: |
+  The alpha label must:
+
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data: {}

--- a/app/views/govuk_component/docs/analytics_meta_tags.yml
+++ b/app/views/govuk_component/docs/analytics_meta_tags.yml
@@ -5,6 +5,8 @@ body: |
   can then turn into the correct analytics identifier metadata tags.
 
   The code which reads the meta tags can be found <a href="https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/static-analytics.js#L76-L96">in static-analytics.js</a>.
+accessibility_criteria: |
+  The analytics meta tags component should not be visible to any users.
 examples:
   with_organisations:
     data:

--- a/app/views/govuk_component/docs/beta_label.yml
+++ b/app/views/govuk_component/docs/beta_label.yml
@@ -1,5 +1,11 @@
 name: Beta Banner
-description: A banner that indicates content is in a beta phase with an optional explanation
+description: A banner that indicates content is in a beta phase, with an optional explanation
+accessibility_criteria: |
+  The beta label must:
+
+  - have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data: {}

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -2,6 +2,8 @@ name: "Breadcrumbs"
 description: "Navigational breadcrumbs, showing page hierarchy"
 body: |
   Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:
@@ -54,7 +56,7 @@ examples:
         url: '/browse/abroad'
       - title: 'Travel abroad'
   highlight_current_page:
-    description: This is currently used within the Education navigation A/B tests, such as [on this page](https://www.gov.uk/education/education-of-disadvantaged-children).
+    description: This is currently used on pages tagged to the taxonomy, such as [on this page](https://www.gov.uk/guidance/pupil-premium-information-for-schools-and-alternative-provision-settings).
     data:
       breadcrumbs:
       - title: 'Home'
@@ -64,7 +66,7 @@ examples:
       - title: 'Education of disadvantaged children'
         is_current_page: true
   collapse_on_mobile:
-    description: This is currently used within the Education navigation A/B tests, such as [on this page](https://www.gov.uk/education/education-of-disadvantaged-children).
+    description: This is currently used within on pages tagged to the taxonomy, such as [on this page](https://www.gov.uk/guidance/pupil-premium-information-for-schools-and-alternative-provision-settings).
     data:
       collapse_on_mobile: true
       breadcrumbs:

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -1,5 +1,5 @@
-name: "Button"
-description: "Use buttons to move though a transaction, aim to use only one button per page."
+name: Button
+description: Use buttons to move though a transaction, aim to use only one button per page.
 body: |
   Button text should be short and describe the action the button performs.
 

--- a/app/views/govuk_component/docs/document_footer.yml
+++ b/app/views/govuk_component/docs/document_footer.yml
@@ -1,5 +1,14 @@
 name: Document footer metadata
 description: A metadata block to be displayed below the document
+accessibility_criteria: |
+  The document footer metadata component must:
+
+  - indicate that any expandable content can be expanded or collapsed
+  - indicate the initial state of expandable content
+  - indicate where the state of expandable content has changed
+
+shared_accessibility_criteria:
+  - link
 examples:
   from_only:
     data:

--- a/app/views/govuk_component/docs/government_navigation.yml
+++ b/app/views/govuk_component/docs/government_navigation.yml
@@ -2,6 +2,12 @@ name: Government navigation
 description: Navigation placed in the header by Slimmer and used by pages which sit
   under the /government path. This is a markup only component and is not available
   for preview here. It can be passed a string to mark a link as being active.
+accessibility_criteria: |
+  The government navigation component must:
+
+  - Be identified as a [navigation landmark](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_navigation)
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data: {}

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -11,6 +11,11 @@ body: |
 
   - Progressively enhanced, accessible charts (using [Magna Charta](https://github.com/alphagov/magna-charta), derived from tabular data (see example below)
   - Progressively enhanced, accessible embedded YouTube player (using [AccessibleMediaPlayer](https://github.com/alphagov/Accessible-Media-Player))
+accessibility_criteria: |
+  - headings must be part of a correct heading structure for the page
+  - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
 examples:
   basic_content:
     data:

--- a/app/views/govuk_component/docs/govspeak_html_publication.yml
+++ b/app/views/govuk_component/docs/govspeak_html_publication.yml
@@ -4,6 +4,11 @@ body: |
   This component calls the standard [Govspeak component](/components/govspeak), and layers a set of overriding styles on top. Styles for numbered parts are added, and heading sizes are increased.
 
   Requires Slimmer >= 9.1.0 for nested component support.
+accessibility_criteria: |
+  - headings must be part of a correct heading structure for the page
+  - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+shared_accessibility_criteria:
+  - link
 examples:
   basic_content:
     data:

--- a/app/views/govuk_component/docs/metadata.yml
+++ b/app/views/govuk_component/docs/metadata.yml
@@ -1,5 +1,14 @@
 name: Metadata block
 description: To display relevant metadata about organisations and tags for a document
+accessibility_criteria: |
+  The metadata component must:
+
+  - indicate that any expandable content can be expanded or collapsed
+  - indicate the initial state of expandable content
+  - indicate where the state of expandable content has changed
+
+shared_accessibility_criteria:
+  - link
 examples:
   from_only:
     data:

--- a/app/views/govuk_component/docs/option_select.yml
+++ b/app/views/govuk_component/docs/option_select.yml
@@ -2,11 +2,17 @@ name: Option select
 description: A scrollable list of checkboxes to be displayed on a form where one might
   otherwise use a multi-select
 accessibility_criteria: |
+  The option select must:
+
+  - indicate that the option select is expandable/collapsible
+  - indicate the initial state of expandable content
+  - indicate where the state of expandable content has changed
+
   The option select inputs must:
 
-  * have a space to the right when the box is scrollable so that users can interact with a scrollbar without accidentally clicking an option
-  * only include an `aria-controls` attribute if an element with the ID specified exists on the page
-  * be [grouped with a label](https://www.w3.org/WAI/GL/wiki/Using_grouping_roles_to_identify_related_form_controls)
+  - have a margin to the right when the box is scrollable so that users can interact with a scrollbar without accidentally clicking an option
+  - only include an `aria-controls` attribute if an element with the ID specified exists on the page
+  - be [grouped with a label](https://www.w3.org/WAI/GL/wiki/Using_grouping_roles_to_identify_related_form_controls)
 examples:
   default:
     data:

--- a/app/views/govuk_component/docs/organisation_logo.yml
+++ b/app/views/govuk_component/docs/organisation_logo.yml
@@ -5,6 +5,11 @@ body: |
   These cannot be inferred from the name alone.
 
   Alternatively a custom organisation logo can be provided as an image.
+accessibility_criteria: |
+  The crest image itself must be presentational and ignored by screen readers.
+
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/govuk_component/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_component/docs/previous_and_next_navigation.yml
@@ -1,5 +1,5 @@
 name: Previous and next navigation
-description: Navigational links that allow users navigate within a series of pages
+description: Navigational links that allow users to navigate within a series of pages
   or elements.
 body: |
   This component accepts 2 optional parameters, previous and next.
@@ -11,26 +11,16 @@ body: |
   - a label that can add extra info (ie page number) that will be displayed under the title
 
   If one of the 2 parameters is nil, no link will appear.
-accessibility-criteria: |
+accessibility_criteria: |
+  Icons in the component must not be announced by screen readers.
+
   The component must:
 
   - identify itself as pagination navigation
   - provide a distinction between the navigation text and label text of the links both visually and for screenreaders
 
-  Links in the component must:
-
-  - identify whether they will take the user to the next or previous page
-  - accept focus
-  - be focusable with a keyboard
-  - be usable with a keyboard
-  - indicate when it has focus
-  - change in appearance when touched (in the touch-down state)
-  - change in appearance when hovered
-  - be usable with touch
-  - be usable with [voice commands](https://www.w3.org/WAI/perspectives/voice.html)
-  - have visible text
-
-  Icons in the component must not be announced by screen readers.
+shared_accessibility_criteria:
+  - link
 examples:
   only_previous:
     data:

--- a/app/views/govuk_component/docs/related_items.yml
+++ b/app/views/govuk_component/docs/related_items.yml
@@ -4,6 +4,11 @@ body: |
   Accepts an array of sections. Each section can have a title, url, id and a list of related items.
 
   Each item is a hash with a title and url. If the url is external, a rel value can also be provided.
+accessibility_criteria: |
+  - Should have a role of 'complementary' as it complements the main page content
+  - Should have a role of 'navigation' on any navigation elements inside the component
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:

--- a/app/views/govuk_component/docs/search.yml
+++ b/app/views/govuk_component/docs/search.yml
@@ -7,6 +7,12 @@ body: |
   It can be used on white or on govuk-blue using the on_govuk_blue option.
 
   Markup such as heading tags can be included in the label using the label_text option. Styling is not included in the component for heading tags in labels, however this is what the search results page does.
+accessibility_criteria: |
+  The search box should:
+
+  - be used inside a form with the role of 'search', to indicate it as a [search landmark](https://www.w3.org/TR/wai-aria-practices-1.1/#aria_lh_search)
+  - have a clear label to identify the search functionality, which is visible to all users
+
 examples:
   default:
     data: {}

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -6,6 +6,11 @@ body: |
 
   Each item is a hash with a title, url, description, and list of related content
   associated with that item.
+accessibility_criteria: |
+  - Should have a role of 'complementary' as it complements the main page content
+  - Should have a role of 'navigation' on any navigation elements inside the component
+shared_accessibility_criteria:
+  - link
 examples:
   default:
     data:


### PR DESCRIPTION
Updating some of the static components with accessibility criteria.

I haven't touched the following so they're still displaying the 'no accessibility criteria' warning. If anyone has any ideas, let me know...

- [Government Navigation](https://govuk-static.herokuapp.com/component-guide/government_navigation)
- [Govspeak Content](https://govuk-static.herokuapp.com/component-guide/govspeak)
- [Govspeak Content HTML Publications](https://govuk-static.herokuapp.com/component-guide/govspeak_html_publication)

Component Guide PR Link: https://govuk-static-pr-1198.herokuapp.com/component-guide