### PR TITLE
Update design of taxonomy sidebar

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,29 +1,37 @@
 .govuk-taxonomy-sidebar {
-  border-top: 10px solid $mainstream-brand;
-  padding-top: 5px;
+  border-top: 2px solid $govuk-blue;
+  padding-top: $gutter-half;
   @include core-16;
 
-  h2 {
-    @include bold-24;
-    margin-top: 0.3em;
-    margin-bottom: 0.5em;
+  .govuk-taxonomy-sidebar__heading {
+    margin-top: 0;
+    margin-bottom: $gutter-one-third;
+    @include bold-19;
   }
 
   .taxon-description {
-    margin-bottom: 0.75em;
+    margin-top: 0;
+    margin-bottom: $gutter-one-third;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  nav {
+    margin-bottom: $gutter;
+  }
+
+  li {
+    padding: 0;
+    list-style-type: none;
+    margin-bottom: $gutter-one-third;
   }
 
   ul {
     // reset the default browser styles
     padding: 0;
     margin: 0;
-    list-style: none;
     margin-bottom: 1.25em;
-
-    li {
-      // reset the default browser styles
-      padding: 0;
-      margin-bottom: 0.75em;
-    }
-  }
+ }
 }

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -48,7 +48,7 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
-            - title: "Slide pack from Phil Beach at the Skills & Employability Summit"
+            - title: "Slide pack from Phil Beach at the Skills &amp; Employability Summit"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
             - title: "Transport to education and training for people aged 16 to 18"
               link: /government/publications/primary-assessments-information-and-resources-for-2017

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,9 +1,10 @@
 <% if local_assigns[:items] && !items.blank? %>
 
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
+    <h2 class='govuk-taxonomy-sidebar__heading'><%= t("govuk_component.taxonomy_sidebar.related_content") %></h2>
     <% items.each_with_index do |item, item_index| %>
       <div class='sidebar-taxon' data-track-count="sidebarTaxonSection">
-        <h2>
+        <h3 class='govuk-taxonomy-sidebar__heading'>
           <%=
             link_to_if(
               item[:url],
@@ -21,7 +22,7 @@
               },
             )
           %>
-        </h2>
+        </h3>
 
         <p class='taxon-description'>
           <%= item[:description] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,5 @@ en:
     related_items:
       more: "More"
       in: "in"
+    taxonomy_sidebar:
+      related_content: "Related content"

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -27,7 +27,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    taxon_titles = css_select(".sidebar-taxon h2").map { |taxon_title| taxon_title.text.strip }
+    taxon_titles = css_select(".sidebar-taxon h3").map { |taxon_title| taxon_title.text.strip }
     assert_equal ["Item 1 title", "Item 2 title"], taxon_titles
   end
 
@@ -70,7 +70,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
     total_sections = 2
     total_links_in_section_1 = 3
 
-    assert_select 'h2 a', "Item title"
+    assert_select 'h3 a', "Item title"
     assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
     assert_tracking_link("category", "relatedLinkClicked", 6)
 
@@ -94,7 +94,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
   end
 
 
-  test "renders without url on the h2 heading" do
+  test "renders without url on the h3 heading" do
     render_component(
       items: [
         {
@@ -114,7 +114,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    assert_select 'h2', "Without an url"
-    assert_select 'h2 a', false
+    assert_select 'h3', "Without an url"
+    assert_select 'h3 a', false
   end
 end


### PR DESCRIPTION
We are developing a [new navigation sidebar component](https://github.com/alphagov/government-frontend/pull/542) in government-frontend. We need to bring the taxonomy sidebar component design in line with the new related links. Ideally we'd be updating this component to follow our [component conventions](https://github.com/alphagov/govuk_publishing_components/blob/master/docs/component_conventions.md), e.g: using BEM, but this is probably a bigger piece of work, especially with the caching issues we've had previously when updating static components.

Component Guide: https://govuk-static-pr-1200.herokuapp.com/component-guide/taxonomy_sidebar

**Note: this change will affect the taxonomy sidebar across all applications (not just government-frontend). Example pages to tests are:**

- [Detailed Guides](http://government-frontend.dev.gov.uk/guidance/status-of-eu-nationals-in-the-uk-what-you-need-to-know )
- [Document Collection](http://government-frontend.dev.gov.uk/government/collections/national-curriculum)
- [Publication](http://government-frontend.dev.gov.uk/government/publications/apprenticeship-funding-from-may-2017)
- [Simple Smart Answer](https://www.gov.uk/independent-school-registration)
 
## Design
**Navigation Sidebar Component:**
<img width="922" alt="screen shot 2017-11-22 at 16 20 11" src="https://user-images.githubusercontent.com/29889908/33137949-2e5dd328-cfa1-11e7-9877-a8e315ad85f6.png">

**Taxonomy Sidebar Component**
<img width="986" alt="screen shot 2017-11-24 at 13 38 31" src="https://user-images.githubusercontent.com/29889908/33212861-c9d577e4-d11c-11e7-9f21-e8fc7e0792af.png">
