### PR TITLE
Create task list related links component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -27,3 +27,4 @@
 @import "lead-paragraph";
 @import "task-list";
 @import "task-list-header";
+@import "task-list-related";

--- a/app/assets/stylesheets/govuk-component/_task-list-related.scss
+++ b/app/assets/stylesheets/govuk-component/_task-list-related.scss
@@ -1,0 +1,3 @@
+.pub-c-task-list-related {
+
+}

--- a/app/assets/stylesheets/govuk-component/_task-list-related.scss
+++ b/app/assets/stylesheets/govuk-component/_task-list-related.scss
@@ -1,3 +1,39 @@
 .pub-c-task-list-related {
+  margin-bottom: $gutter-half;
+}
 
+.pub-c-task-list-related__heading,
+.pub-c-task-list-related__links {
+  @include bold-19;
+  margin: 0;
+  padding: 0;
+}
+
+.pub-c-task-list-related__pretitle {
+  display: block;
+  margin-bottom: $gutter-half;
+
+  @include media(tablet) {
+    margin-bottom: 5px;
+  }
+}
+
+.pub-c-task-list-related__links {
+  list-style: none;
+}
+
+.pub-c-task-list-related__link-item {
+  margin-top: $gutter-half;
+
+  @include media(tablet) {
+    margin-top: 5px;
+  }
+}
+
+.pub-c-task-list-related__link {
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
 }

--- a/app/views/govuk_component/docs/task_list_related.yml
+++ b/app/views/govuk_component/docs/task_list_related.yml
@@ -1,0 +1,13 @@
+name: Task list related
+description: Links to task lists that a page is part of
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data:
+      links: [
+        {
+          href: '/learn-to-drive-a-car',
+          text: 'Learn to drive a car: step by step'
+        }
+      ]

--- a/app/views/govuk_component/docs/task_list_related.yml
+++ b/app/views/govuk_component/docs/task_list_related.yml
@@ -1,5 +1,19 @@
-name: Task list related
+name: Task list related links
 description: Links to task lists that a page is part of
+body: |
+  The component is designed to go on a content page to accompany a small task list in a sidebar. It provides links to the main task list page.
+
+  The component has two uses:
+
+  - above the task list, it provides a link to the main task list page
+  - below the task list, it shows and links to any other task lists that this page belongs to
+
+  In the first use case, only one link should be present and the entire text of the component should be contained in a heading. In the second use case, if more than one link is provided, the links should be shown in a list, separate from the heading.
+accessibility_criteria: |
+  The component must:
+
+  - display a single link as part of a heading
+  - display multiple links outside of a heading in a separate list
 shared_accessibility_criteria:
   - link
 examples:
@@ -9,5 +23,32 @@ examples:
         {
           href: '/learn-to-drive-a-car',
           text: 'Learn to drive a car: step by step'
+        }
+      ]
+  with_more_than_one_link:
+    description: If more than one link is passed to the component it should output them as a list outside of the heading.
+    data:
+      links: [
+        {
+          href: '/learn-to-drive-a-car',
+          text: 'Learn to drive a car: step by step'
+        },
+        {
+          href: '/learn-to-drive-a-motorbike',
+          text: 'Learn to drive a motorbike: step by step'
+        }
+      ]
+  with_a_different_title:
+    description: The default title 'Part of' can be replaced if required.
+    data:
+      pretitle: 'Also part of'
+      links: [
+        {
+          href: '/learn-to-drive-a-car',
+          text: 'Learn to drive a car: step by step'
+        },
+        {
+          href: '/learn-to-drive-a-motorbike',
+          text: 'Learn to drive a motorbike: step by step'
         }
       ]

--- a/app/views/govuk_component/task_list_related.raw.html.erb
+++ b/app/views/govuk_component/task_list_related.raw.html.erb
@@ -3,12 +3,17 @@
   pretitle ||= t("govuk_component.task_list_related.part_of", default: "Part of")
 %>
 <% if links %>
-  <div class="pub-c-task-list-related">
+  <div class="pub-c-task-list-related" data-module="track-click">
     <h2 class="pub-c-task-list-related__heading">
       <span class="pub-c-task-list-related__pretitle"><%= pretitle %></span>
-
       <% if links.length == 1 %>
-          <a href="<%= links[0][:href] %>" class="pub-c-task-list-related__link">
+          <a href="<%= links[0][:href] %>"
+            class="pub-c-task-list-related__link"
+            data-track-category="tasklistPartOfClicked"
+            data-track-action="<%= pretitle %>"
+            data-track-label="<%= links[0][:href] %>"
+            data-track-dimension="<%= links[0][:text] %>"
+            data-track-dimension-index="29">
             <%= links[0][:text] %>
           </a>
         </h2>
@@ -17,7 +22,13 @@
         <ul class="pub-c-task-list-related__links">
           <% links.each do |link| %>
             <li class="pub-c-task-list-related__link-item">
-              <a href="<%= link[:href] %>" class="pub-c-task-list-related__link">
+              <a href="<%= link[:href] %>"
+                class="pub-c-task-list-related__link"
+                data-track-category="tasklistPartOfClicked"
+                data-track-action="<%= pretitle %>"
+                data-track-label="<%= link[:href] %>"
+                data-track-dimension="<%= link[:text] %>"
+                data-track-dimension-index="29">
                 <%= link[:text] %>
               </a>
             </li>

--- a/app/views/govuk_component/task_list_related.raw.html.erb
+++ b/app/views/govuk_component/task_list_related.raw.html.erb
@@ -1,0 +1,13 @@
+<%
+  links ||= false
+%>
+<% if links %>
+  <div class="pub-c-task-list-related">
+    <h2>Part of</h2>
+    <% links.each do |link| %>
+      <a href="<%= link[:href] %>">
+        <%= link[:text] %>
+      </a>
+    <% end %>
+  </div>
+<% end %>

--- a/app/views/govuk_component/task_list_related.raw.html.erb
+++ b/app/views/govuk_component/task_list_related.raw.html.erb
@@ -1,13 +1,28 @@
 <%
   links ||= false
+  pretitle ||= t("govuk_component.task_list_related.part_of", default: "Part of")
 %>
 <% if links %>
   <div class="pub-c-task-list-related">
-    <h2>Part of</h2>
-    <% links.each do |link| %>
-      <a href="<%= link[:href] %>">
-        <%= link[:text] %>
-      </a>
-    <% end %>
+    <h2 class="pub-c-task-list-related__heading">
+      <span class="pub-c-task-list-related__pretitle"><%= pretitle %></span>
+
+      <% if links.length == 1 %>
+          <a href="<%= links[0][:href] %>" class="pub-c-task-list-related__link">
+            <%= links[0][:text] %>
+          </a>
+        </h2>
+      <% else %>
+        </h2>
+        <ul class="pub-c-task-list-related__links">
+          <% links.each do |link| %>
+            <li class="pub-c-task-list-related__link-item">
+              <a href="<%= link[:href] %>" class="pub-c-task-list-related__link">
+                <%= link[:text] %>
+              </a>
+            </li>
+          <% end %>
+        </ul>
+      <% end %>
   </div>
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,3 +32,5 @@ en:
     related_items:
       more: "More"
       in: "in"
+    task_list_related:
+      part_of: "Part of"

--- a/test/govuk_component/task_list_related_test.rb
+++ b/test/govuk_component/task_list_related_test.rb
@@ -1,0 +1,54 @@
+require 'govuk_component_test_helper'
+
+class TaskListRelatedTestCase < ComponentTestCase
+  def component_name
+    "task_list_related"
+  end
+
+  def one_link
+    [
+      {
+        href: '/link1',
+        text: 'Link 1'
+      }
+    ]
+  end
+
+  def two_links
+    [
+      {
+        href: '/link1',
+        text: 'Link 1'
+      },
+      {
+        href: '/link2',
+        text: 'Link 2'
+      }
+    ]
+  end
+
+  test "renders nothing without passed content" do
+    assert_empty render_component({})
+  end
+
+  test "displays one link inside a heading" do
+    render_component(links: one_link)
+
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__link[href='/link1']", text: 'Link 1'
+  end
+
+  test "displays more than one link in a list" do
+    render_component(links: two_links)
+
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link1']", text: 'Link 1'
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link2']", text: 'Link 2'
+  end
+
+  test "alternative heading text" do
+    render_component(links: one_link, pretitle: 'Moo')
+
+    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Moo'
+  end
+end

--- a/test/govuk_component/task_list_related_test.rb
+++ b/test/govuk_component/task_list_related_test.rb
@@ -34,21 +34,36 @@ class TaskListRelatedTestCase < ComponentTestCase
   test "displays one link inside a heading" do
     render_component(links: one_link)
 
+    this_link = ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__link"
+
     assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__link[href='/link1']", text: 'Link 1'
+    assert_select this_link + "[href='/link1']", text: 'Link 1'
+    assert_select this_link + "[data-track-category='tasklistPartOfClicked']"
+    assert_select this_link + "[data-track-action='Part of']"
+    assert_select this_link + "[data-track-label='/link1']"
+    assert_select this_link + "[data-track-dimension='Link 1']"
+    assert_select this_link + "[data-track-dimension-index='29']"
   end
 
   test "displays more than one link in a list" do
     render_component(links: two_links)
 
+    this_link = ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link2']"
+
     assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Part of'
     assert_select ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link1']", text: 'Link 1'
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__links .pub-c-task-list-related__link[href='/link2']", text: 'Link 2'
+    assert_select this_link, text: 'Link 2'
+    assert_select this_link + "[data-track-category='tasklistPartOfClicked']"
+    assert_select this_link + "[data-track-action='Part of']"
+    assert_select this_link + "[data-track-label='/link2']"
+    assert_select this_link + "[data-track-dimension='Link 2']"
+    assert_select this_link + "[data-track-dimension-index='29']"
   end
 
   test "alternative heading text" do
     render_component(links: one_link, pretitle: 'Moo')
 
-    assert_select ".pub-c-task-list-related .pub-c-task-list-related__heading .pub-c-task-list-related__pretitle", text: 'Moo'
+    assert_select ".pub-c-task-list-related__pretitle", text: 'Moo'
+    assert_select ".pub-c-task-list-related__link[data-track-action='Moo']"
   end
 end


### PR DESCRIPTION
Designed to go above (and below) a small task list in the sidebar, to provide a link back to the main task list. Secondary purpose is underneath the same task list, to show links to other task lists this page might be a part of.

![screen shot 2017-12-06 at 10 18 20](https://user-images.githubusercontent.com/861310/33656709-d19636b6-da6e-11e7-8a6f-6b5a0bd4897a.png)

In context:

![screen shot 2017-12-08 at 09 33 02](https://user-images.githubusercontent.com/861310/33759597-d3529318-dbfa-11e7-974e-721ed82738b7.png)

- [Component guide page](https://govuk-static-pr-1209.herokuapp.com/component-guide/task_list_related)
- [Trello card](https://trello.com/c/T6XscwyL/386-create-task-list-sidebar-part-of-links-component)