### PR TITLE
Update taxonomy sidebar design

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,29 +1,37 @@
 .govuk-taxonomy-sidebar {
-  border-top: 10px solid $mainstream-brand;
-  padding-top: 5px;
+  border-top: 2px solid $govuk-blue;
+  padding-top: $gutter-half;
   @include core-16;
 
-  h2 {
-    @include bold-24;
-    margin-top: 0.3em;
-    margin-bottom: 0.5em;
+  .govuk-taxonomy-sidebar__heading {
+    margin-top: 0;
+    margin-bottom: $gutter-one-third;
+    @include bold-19;
   }
 
   .taxon-description {
-    margin-bottom: 0.75em;
+    margin-top: 0;
+    margin-bottom: $gutter-one-third;
+  }
+
+  a {
+    text-decoration: none;
+  }
+
+  nav {
+    margin-bottom: $gutter;
+  }
+
+  li {
+    padding: 0;
+    list-style-type: none;
+    margin-bottom: $gutter-one-third;
   }
 
   ul {
     // reset the default browser styles
     padding: 0;
     margin: 0;
-    list-style: none;
     margin-bottom: 1.25em;
-
-    li {
-      // reset the default browser styles
-      padding: 0;
-      margin-bottom: 0.75em;
-    }
-  }
+ }
 }

--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -33,5 +33,16 @@
     padding: 0;
     margin: 0;
     margin-bottom: 1.25em;
- }
+  }
+
+  .govuk-taxonomy-sidebar__collections-heading {
+    border-top: 1px solid $border-colour;
+    margin-bottom: $gutter-half;
+    margin-top: $gutter;
+    padding-top: $gutter-half;
+  }
+
+  .govuk-taxonomy-sidebar__collections-link {
+    @include bold-19;
+  }
 }

--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -1,48 +1,50 @@
 .govuk-taxonomy-sidebar {
+  @include core-16;
   border-top: 2px solid $govuk-blue;
   padding-top: $gutter-half;
-  @include core-16;
+}
 
-  .govuk-taxonomy-sidebar__heading {
-    margin-top: 0;
-    margin-bottom: $gutter-one-third;
-    @include bold-19;
-  }
+.govuk-taxonomy-sidebar__heading {
+  @include bold-19;
+  margin-bottom: $gutter-one-third;
+  margin-top: 0;
+}
 
-  .taxon-description {
-    margin-top: 0;
-    margin-bottom: $gutter-one-third;
-  }
+.govuk-taxonomy-sidebar__taxon-description {
+  margin-bottom: $gutter-one-third;
+  margin-top: 0;
+}
 
-  a {
-    text-decoration: none;
-  }
+.govuk-taxonomy-sidebar__navigation {
+  margin-bottom: $gutter;
+}
 
-  nav {
-    margin-bottom: $gutter;
-  }
+.govuk-taxonomy-sidebar__list {
+  list-style: none;
+  margin: 0;
+  margin-bottom: 1.25em;
+  padding: 0;
+}
 
-  li {
-    padding: 0;
-    list-style-type: none;
-    margin-bottom: $gutter-one-third;
-  }
+.govuk-taxonomy-sidebar__item {
+  list-style-type: none;
+  margin-bottom: $gutter-one-third;
+  padding: 0;
+}
 
-  ul {
-    // reset the default browser styles
-    padding: 0;
-    margin: 0;
-    margin-bottom: 1.25em;
-  }
+.govuk-taxonomy-sidebar__link {
+  text-decoration: none;
+}
 
-  .govuk-taxonomy-sidebar__collections-heading {
-    border-top: 1px solid $border-colour;
-    margin-bottom: $gutter-half;
-    margin-top: $gutter;
-    padding-top: $gutter-half;
-  }
 
-  .govuk-taxonomy-sidebar__collections-link {
-    @include bold-19;
-  }
+.govuk-taxonomy-sidebar__collections-heading {
+  border-top: 1px solid $border-colour;
+  margin-bottom: $gutter-half;
+  margin-top: $gutter;
+  padding-top: $gutter-half;
+}
+
+.govuk-taxonomy-sidebar__collections-link {
+  @include bold-19;
+  text-decoration: none;
 }

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -48,7 +48,7 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
-            - title: "Slide pack from Phil Beach at the Skills & Employability Summit"
+            - title: "Slide pack from Phil Beach at the Skills &amp; Employability Summit"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
             - title: "Transport to education and training for people aged 16 to 18"
               link: /government/publications/primary-assessments-information-and-resources-for-2017

--- a/app/views/govuk_component/docs/taxonomy_sidebar.yml
+++ b/app/views/govuk_component/docs/taxonomy_sidebar.yml
@@ -64,6 +64,9 @@ examples:
               link: /government/collections/key-stage-1-teacher-assessment
             - title: "Primary assessments: information and resources for 2017"
               link: /government/publications/primary-assessments-information-and-resources-for-2017
+      collections:
+        - text: "Statistics: outcome based success measures"
+        - path: "/government/collections/statistics-outcome-based-success-measures"
   no_children:
     description: |
       The child links are usually pulled from rummager. If rummager doesn’t respond we fallback to a sidebar with a taxon link but without any child content links.

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -1,9 +1,10 @@
 <% if local_assigns[:items] && !items.blank? %>
 
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
+    <h2 class='govuk-taxonomy-sidebar__heading'><%= t("govuk_component.taxonomy_sidebar.related_content") %></h2>
     <% items.each_with_index do |item, item_index| %>
       <div class='sidebar-taxon' data-track-count="sidebarTaxonSection">
-        <h2>
+        <h3 class='govuk-taxonomy-sidebar__heading'>
           <%=
             link_to_if(
               item[:url],
@@ -21,7 +22,7 @@
               },
             )
           %>
-        </h2>
+        </h3>
 
         <p class='taxon-description'>
           <%= item[:description] %>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -3,14 +3,14 @@
   <aside class='govuk-taxonomy-sidebar' data-module='track-click' role='complementary'>
     <h2 class='govuk-taxonomy-sidebar__heading'><%= t("govuk_component.taxonomy_sidebar.related_content") %></h2>
     <% items.each_with_index do |item, item_index| %>
-      <div class='sidebar-taxon' data-track-count="sidebarTaxonSection">
+      <div data-track-count="sidebarTaxonSection">
         <h3 class='govuk-taxonomy-sidebar__heading'>
           <%=
             link_to_if(
               item[:url],
               item[:title],
               item[:url],
-              class: 'taxon-link',
+              class: 'govuk-taxonomy-sidebar__link',
               data: {
                 track_category: 'relatedLinkClicked',
                 track_action: "#{item_index + 1}",
@@ -24,16 +24,16 @@
           %>
         </h3>
 
-        <p class='taxon-description'>
+        <p class='govuk-taxonomy-sidebar__taxon-description'>
           <%= item[:description] %>
         </p>
 
         <% item[:related_content] ||= [] %>
         <% if item[:related_content].any? %>
-          <nav role='navigation'>
-            <ul class='related-content'>
+          <nav class='govuk-taxonomy-sidebar__navigation' role='navigation'>
+            <ul class='govuk-taxonomy-sidebar__list'>
               <% item[:related_content].each_with_index do |related_item, related_content_index| %>
-                <li>
+                <li class='govuk-taxonomy-sidebar__item'>
                   <%=
                     link_to(
                       related_item[:title],
@@ -47,7 +47,7 @@
                             dimension29: related_item[:title],
                           }
                       },
-                      class: 'related-link',
+                      class: 'related-link govuk-taxonomy-sidebar__link',
                     )
                   %>
                 </li>
@@ -60,14 +60,16 @@
 
     <% if local_assigns[:collections] && !collections.blank? %>
       <div>
-        <h3 class="govuk-taxonomy-sidebar__collections-heading">Collections</h3>
-        <nav role='navigation'>
-          <ul>
+        <h3 class='govuk-taxonomy-sidebar__collections-heading'>Collections</h3>
+        <nav class='govuk-taxonomy-sidebar__navigation' role='navigation'>
+          <ul class='govuk-taxonomy-sidebar__list'>
             <% collections.each do |item| %>
               <% if item[:text] && item[:path] %>
-                <li><%= link_to(item[:text],
-                                item[:path],
-                                class: "govuk-taxonomy-sidebar__collections-link") %></li>
+                <li>
+                  <%= link_to(item[:text],
+                              item[:path],
+                              class: 'govuk-taxonomy-sidebar__collections-link') %>
+                </li>
               <% end %>
             <% end %>
           </ul>

--- a/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
+++ b/app/views/govuk_component/taxonomy_sidebar.raw.html.erb
@@ -57,6 +57,23 @@
         <% end %>
       </div>
     <% end %>
+
+    <% if local_assigns[:collections] && !collections.blank? %>
+      <div>
+        <h3 class="govuk-taxonomy-sidebar__collections-heading">Collections</h3>
+        <nav role='navigation'>
+          <ul>
+            <% collections.each do |item| %>
+              <% if item[:text] && item[:path] %>
+                <li><%= link_to(item[:text],
+                                item[:path],
+                                class: "govuk-taxonomy-sidebar__collections-link") %></li>
+              <% end %>
+            <% end %>
+          </ul>
+        </nav>
+      </div>
+    <% end %>
   </aside>
 
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,3 +34,5 @@ en:
       in: "in"
     task_list_related:
       part_of: "Part of"
+    taxonomy_sidebar:
+      related_content: "Related content"

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -117,4 +117,30 @@ class TaxonomySidebarTestCase < ComponentTestCase
     assert_select 'h3', "Without an url"
     assert_select 'h3 a', false
   end
+
+  test "renders collections links" do
+    render_component(
+      items: [
+        {
+          title: "Without an url",
+          description: "An item",
+          related_content: [
+            {
+              title: "Related link 1",
+              link: "/related-link-1",
+            }
+          ],
+        },
+      ],
+      collections: [
+        {
+          text: "Collection 1",
+          path: "/some-collection"
+        }
+      ]
+    )
+
+    assert_select "h3.govuk-taxonomy-sidebar__collections-heading", "Collections"
+    assert_select "a.govuk-taxonomy-sidebar__collections-link", "Collection 1"
+  end
 end

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -27,7 +27,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    taxon_titles = css_select(".sidebar-taxon h2").map { |taxon_title| taxon_title.text.strip }
+    taxon_titles = css_select(".sidebar-taxon h3").map { |taxon_title| taxon_title.text.strip }
     assert_equal ["Item 1 title", "Item 2 title"], taxon_titles
   end
 
@@ -70,7 +70,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
     total_sections = 2
     total_links_in_section_1 = 3
 
-    assert_select 'h2 a', "Item title"
+    assert_select 'h3 a', "Item title"
     assert_select '.govuk-taxonomy-sidebar[data-module="track-click"]', 1
     assert_tracking_link("category", "relatedLinkClicked", 6)
 
@@ -94,7 +94,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
   end
 
 
-  test "renders without url on the h2 heading" do
+  test "renders without url on the h3 heading" do
     render_component(
       items: [
         {
@@ -114,7 +114,7 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    assert_select 'h2', "Without an url"
-    assert_select 'h2 a', false
+    assert_select 'h3', "Without an url"
+    assert_select 'h3 a', false
   end
 end

--- a/test/govuk_component/taxonomy_sidebar_test.rb
+++ b/test/govuk_component/taxonomy_sidebar_test.rb
@@ -27,8 +27,8 @@ class TaxonomySidebarTestCase < ComponentTestCase
       ]
     )
 
-    taxon_titles = css_select(".sidebar-taxon h3").map { |taxon_title| taxon_title.text.strip }
-    assert_equal ["Item 1 title", "Item 2 title"], taxon_titles
+    taxon_titles = css_select(".govuk-taxonomy-sidebar__heading").map { |taxon_title| taxon_title.text.strip }
+    assert_equal ["Related content", "Item 1 title", "Item 2 title"], taxon_titles
   end
 
   test "renders all data attributes for tracking" do


### PR DESCRIPTION
https://trello.com/c/zzot5dZq/157-taxonomy-sidebar-add-link-to-collections
https://trello.com/c/NtD5rC4S/121-taxonomy-sidebar

![screenshot from 2017-12-12 16-36-52](https://user-images.githubusercontent.com/93511/33896764-92275270-df5b-11e7-93fe-967b36c66e93.png)

This combines the changes from https://github.com/alphagov/static/pull/1200 to make the taxonomy sidebar styles similar to the related-navigation component and also the feature of rendering collections links below the taxon links.


