### PR TITLE
Re-add old taxonomy styles for better deployment support

### DIFF
--- a/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
+++ b/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss
@@ -2,6 +2,32 @@
   @include core-16;
   border-top: 2px solid $govuk-blue;
   padding-top: $gutter-half;
+
+  // FIXME: These styles can be removed once new
+  // taxonomy template code is populated across all
+  // application caches.
+  h2 {
+    margin-bottom: 0.5em;
+  }
+
+  .taxon-description {
+    margin-bottom: 0.75em;
+  }
+
+  ul {
+    // reset the default browser styles
+    padding: 0;
+    margin: 0;
+    list-style: none;
+    margin-bottom: 1.25em;
+
+    li {
+      // reset the default browser styles
+      padding: 0;
+      margin-bottom: 0.75em;
+    }
+  }
+  // END FIXME
 }
 
 .govuk-taxonomy-sidebar__heading {


### PR DESCRIPTION
Static template code can sit in the application caches long enough
for the wrong combination of CSS and template code to render on page.
This leads to a broken looking component. So add the old styles to support
the deployment of the recent update to the taxonomy sidebar.
These styles can be removed once the applications are up to date.

Old styles taken from: https://github.com/alphagov/static/blob/dda614f2037f75951536af2a10672d1cc4aed1c6/app/assets/stylesheets/govuk-component/_taxonomy-sidebar.scss

cc @nickcolley @vanitabarrett 