### PR TITLE
[DO NOT MERGE] Add feedback component

### DIFF
--- a/app/assets/javascripts/govuk-component/feedback.js
+++ b/app/assets/javascripts/govuk-component/feedback.js
@@ -66,7 +66,7 @@
       that.updateAriaAttributes(formIsVisible)
 
       if (formIsVisible) {
-        $('.form-control', that.$feedbackFormContainer).first().focus();
+        $('.pub-c-feedback__form-field', that.$feedbackFormContainer).first().focus();
       }
     }
 
@@ -125,7 +125,7 @@
 
       if (genericErrors.length) {
         that.addGenericError(
-          '<h1 class="heading-medium error-summary-heading" id="generic-error-message">' +
+          '<h1 class="pub-c-feedback__error-heading" id="generic-error-message">' +
             'There is a problem' +
           '</h1>' +
           $('<p>').text(genericErrors.join(' ')).html()
@@ -137,10 +137,10 @@
 
     this.clearErrors = function () {
       // Reset form groups
-      $('.form-group', that.$feedbackFormContainer).removeClass('error');
+      $('.js-form-group', that.$feedbackFormContainer).removeClass('error');
 
       // Remove error messages and summaries
-      $('.error-message, .error-summary', that.$feedbackFormContainer).remove();
+      $('.js-error-message, .js-error-summary', that.$feedbackFormContainer).remove();
 
       // Reset aria-describedby associations
       $('[name]', that.$feedbackFormContainer).attr({
@@ -150,14 +150,14 @@
     }
 
     this.focusFirstError = function() {
-      $('.error-summary, .form-group.error .form-control', that.$feedbackFormContainer)
+      $('.js-error-summary, .js-form-group.error .pub-c-feedback__form-field', that.$feedbackFormContainer)
         .first()
         .focus();
     }
 
     this.addErrorToField = function (field, error) {
       var $field = that.$feedbackFormContainer.find('[name="'+ field + '"]');
-      var $group = $field.parents('.form-group');
+      var $group = $field.parents('.js-form-group');
 
       if (!$field.length || !$group.length) {
         return false;
@@ -168,7 +168,7 @@
       $group.addClass('error');
       $('label', $group).append(
         $('<span />', {
-          'class': 'error-message',
+          'class': 'pub-c-feedback__error-message js-error-message',
           'text': error,
           'id': id
         })
@@ -183,7 +183,7 @@
 
     this.addGenericError = function (errorMessage) {
       var $errorNode = $('<div/>', {
-        'class': 'error-summary',
+        'class': 'pub-c-feedback__error-summary js-error-summary',
         'role': 'group',
         'aria-labelledby': 'generic-error-message',
         'html': errorMessage,
@@ -290,10 +290,10 @@
           view.clearErrors();
           view.addGenericError(
             [
-              '<h1 class="heading-medium error-summary-heading" id="generic-error-message">',
+              '<h1 class="pub-c-feedback__error-heading" id="generic-error-message">',
               '  Sorry, we’re unable to receive your message right now. ',
               '</h1>',
-              '<p>If the problem persists, we have other ways for you to provide',
+              '<p class="pub-c-feedback__error-text">If the problem persists, we have other ways for you to provide',
               ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
             ].join('')
           );

--- a/app/assets/javascripts/govuk-component/feedback.js
+++ b/app/assets/javascripts/govuk-component/feedback.js
@@ -1,0 +1,313 @@
+(function (Modules) {
+  "use strict";
+  window.GOVUK = window.GOVUK || {};
+
+  function ImproveThisPage () {
+    this.controller = null;
+    this.view = null;
+
+    this.start = function ($element) {
+      this.view = new View($element);
+      this.controller = new Controller(this.view);
+
+      this.controller.init();
+    }
+  };
+
+  function View ($element) {
+    var that = this;
+
+    this.$pageIsUsefulButton = $element.find('.js-page-is-useful');
+    this.$pageIsNotUsefulButton = $element.find('.js-page-is-not-useful');
+    this.$somethingIsWrongButton = $element.find('.js-something-is-wrong');
+    this.$feedbackFormContainer = $element.find('.js-feedback-form');
+    this.$feedbackForm = that.$feedbackFormContainer.find('form');
+    this.$feedbackFormSubmitButton = that.$feedbackFormContainer.find('[type=submit]');
+    this.$feedbackFormCloseButton = that.$feedbackFormContainer.find('.js-close-feedback-form');
+    this.$prompt = $element.find('.js-prompt');
+
+    this.onPageIsUsefulButtonClicked = function (callback) {
+      that.$pageIsUsefulButton.on('click', preventingDefault(callback));
+    }
+
+    this.onPageIsNotUsefulButtonClicked = function (callback) {
+      that.$pageIsNotUsefulButton.on('click', preventingDefault(callback));
+    }
+
+    this.onSomethingIsWrongButtonClicked = function (callback) {
+      that.$somethingIsWrongButton.on('click', preventingDefault(callback));
+    }
+
+    this.onFeedbackFormCloseButtonClicked = function (callback) {
+      that.$feedbackFormCloseButton.on('click', preventingDefault(callback));
+    }
+
+    this.onSubmitFeedbackForm = function (callback) {
+      that.$feedbackForm.on('submit', preventingDefault(callback));
+    }
+
+    this.showSuccess = function () {
+      that.$prompt.html('<span id="feedback-success-message">Thanks for your feedback.</span>');
+
+      if (that.$prompt.hasClass('js-hidden')) {
+        that.toggleFeedbackForm();
+      }
+
+      that.$prompt.attr('aria-labelledby', 'feedback-success-message');
+      that.$prompt.focus();
+    }
+
+    this.toggleFeedbackForm = function () {
+      that.$prompt.toggleClass('js-hidden');
+      that.$feedbackFormContainer.toggleClass('js-hidden');
+
+      var formIsVisible = !that.$feedbackFormContainer.hasClass('js-hidden');
+
+      that.updateAriaAttributes(formIsVisible)
+
+      if (formIsVisible) {
+        $('.form-control', that.$feedbackFormContainer).first().focus();
+      }
+    }
+
+    this.updateAriaAttributes = function (formIsVisible) {
+      that.$feedbackFormContainer.attr('aria-hidden', !formIsVisible);
+      $('[aria-controls=improveThisPageForm]').attr('aria-expanded', formIsVisible);
+    }
+
+    this.feedbackFormContainerData = function () {
+      return that.$feedbackFormContainer.find('input, textarea').serialize();
+    }
+
+    this.feedbackFormContainerTrackEventParams = function () {
+      return that.getTrackEventParams(that.$feedbackFormContainer);
+    }
+
+    this.pageIsUsefulTrackEventParams = function () {
+      return that.getTrackEventParams(that.$pageIsUsefulButton);
+    }
+
+    this.pageIsNotUsefulTrackEventParams = function () {
+      return that.getTrackEventParams(that.$pageIsNotUsefulButton);
+    }
+
+    this.somethingIsWrongTrackEventParams = function () {
+      return that.getTrackEventParams(that.$somethingIsWrongButton);
+    }
+
+    this.getTrackEventParams = function ($node) {
+      return {
+        category: $node.data('track-category'),
+        action: $node.data('track-action')
+      }
+    }
+
+    this.renderErrors = function (errors) {
+      this.clearErrors();
+      var genericErrors = [];
+
+      $.each(errors, function (attrib, messages) {
+        $.each(messages, function (index, message) {
+          // Uppercase first character of field name
+          var fieldDescription = attrib.charAt(0).toUpperCase() + attrib.slice(1);
+          var errorMessage = fieldDescription + ' ' + message + '.';
+
+          // If there is a field with the same name as the error attribute
+          // then display the error inline with the field.
+          if (that.addErrorToField(attrib, errorMessage)) {
+            return;
+          }
+
+          // If a matching field doesn't exist then display it above the form.
+          genericErrors.push(errorMessage);
+        });
+      });
+
+      if (genericErrors.length) {
+        that.addGenericError(
+          '<h1 class="heading-medium error-summary-heading" id="generic-error-message">' +
+            'There is a problem' +
+          '</h1>' +
+          $('<p>').text(genericErrors.join(' ')).html()
+        );
+      }
+
+      that.focusFirstError();
+    }
+
+    this.clearErrors = function () {
+      // Reset form groups
+      $('.form-group', that.$feedbackFormContainer).removeClass('error');
+
+      // Remove error messages and summaries
+      $('.error-message, .error-summary', that.$feedbackFormContainer).remove();
+
+      // Reset aria-describedby associations
+      $('[name]', that.$feedbackFormContainer).attr({
+        'aria-describedby': '',
+        'aria-invalid': ''
+      });
+    }
+
+    this.focusFirstError = function() {
+      $('.error-summary, .form-group.error .form-control', that.$feedbackFormContainer)
+        .first()
+        .focus();
+    }
+
+    this.addErrorToField = function (field, error) {
+      var $field = that.$feedbackFormContainer.find('[name="'+ field + '"]');
+      var $group = $field.parents('.form-group');
+
+      if (!$field.length || !$group.length) {
+        return false;
+      }
+
+      var id = that.generateIdFromError(error)
+
+      $group.addClass('error');
+      $('label', $group).append(
+        $('<span />', {
+          'class': 'error-message',
+          'text': error,
+          'id': id
+        })
+      );
+      $field.attr({
+        'aria-describedby': id,
+        'aria-invalid': 'true'
+      });
+
+      return true;
+    }
+
+    this.addGenericError = function (errorMessage) {
+      var $errorNode = $('<div/>', {
+        'class': 'error-summary',
+        'role': 'group',
+        'aria-labelledby': 'generic-error-message',
+        'html': errorMessage,
+        'tabindex': -1
+      });
+
+      $('.js-errors', that.$feedbackFormContainer).html($errorNode);
+    }
+
+    this.generateIdFromError = function (text) {
+      return 'error-' + text.toString().toLowerCase().trim()
+        .replace(/&/g, '-and-')    // Replace & with 'and'
+        .replace(/[\s\W-]+/g, '-') // Replace spaces, non-word characters and
+                                   // dashes with a single dash (-)
+    }
+
+    this.disableSubmitFeedbackButton = function () {
+      that.$feedbackFormSubmitButton.prop('disabled', true);
+    }
+
+    this.enableSubmitFeedbackButton = function () {
+      that.$feedbackFormSubmitButton.removeAttr('disabled');
+    }
+
+    function preventingDefault(callback) {
+      return function (event) {
+        event.preventDefault();
+        callback();
+      }
+    }
+  };
+
+  function Controller (view) {
+    var that = this;
+
+    this.init = function () {
+      that.bindPageIsUsefulButton();
+      that.bindPageIsNotUsefulButton();
+      that.bindSomethingIsWrongButton();
+      that.bindSubmitFeedbackButton();
+      this.bindCloseFeedbackFormButton();
+
+      // Add initial ARIA attributes
+      view.updateAriaAttributes(false);
+    }
+
+    this.bindPageIsUsefulButton = function () {
+      var handler = function () {
+        that.trackEvent(view.pageIsUsefulTrackEventParams());
+
+        view.showSuccess();
+      }
+
+      view.onPageIsUsefulButtonClicked(handler);
+    }
+
+    this.bindPageIsNotUsefulButton = function () {
+      var handler = function () {
+        that.trackEvent(view.pageIsNotUsefulTrackEventParams());
+
+        view.toggleFeedbackForm();
+      }
+
+      view.onPageIsNotUsefulButtonClicked(handler);
+    }
+
+    this.bindSomethingIsWrongButton = function () {
+      var handler = function () {
+        that.trackEvent(view.somethingIsWrongTrackEventParams());
+
+        view.toggleFeedbackForm();
+      }
+
+      view.onSomethingIsWrongButtonClicked(handler);
+    }
+
+    this.bindCloseFeedbackFormButton = function () {
+      var handler = function () {
+        view.toggleFeedbackForm();
+      }
+
+      view.onFeedbackFormCloseButtonClicked(handler);
+    }
+
+    this.bindSubmitFeedbackButton = function () {
+      view.onSubmitFeedbackForm(that.handleSubmitFeedback);
+    }
+
+    this.handleSubmitFeedback = function () {
+      $.ajax({
+        type: "POST",
+        url: "/contact/govuk/page_improvements",
+        data: view.feedbackFormContainerData(),
+        beforeSend: view.disableSubmitFeedbackButton
+      }).done(function () {
+        that.trackEvent(view.feedbackFormContainerTrackEventParams());
+
+        view.showSuccess();
+      }).fail(function (xhr) {
+        view.enableSubmitFeedbackButton();
+        if (xhr.status == 422) {
+          view.renderErrors(xhr.responseJSON.errors);
+        } else {
+          view.clearErrors();
+          view.addGenericError(
+            [
+              '<h1 class="heading-medium error-summary-heading" id="generic-error-message">',
+              '  Sorry, we’re unable to receive your message right now. ',
+              '</h1>',
+              '<p>If the problem persists, we have other ways for you to provide',
+              ' feedback on the <a href="/contact/govuk">contact page</a>.</p>'
+            ].join('')
+          );
+          view.focusFirstError();
+        }
+      });
+    }
+
+    this.trackEvent = function(trackEventParams) {
+      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent(trackEventParams.category, trackEventParams.action);
+      }
+    }
+  };
+
+  Modules.ImproveThisPage = ImproveThisPage;
+})(window.GOVUK.Modules);

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -4,6 +4,7 @@
 // = require modules/toggle-input-class-on-focus
 // = require modules/track-click
 // = require modules/cross-domain-tracking
+// = require govuk-component/feedback
 
 $(document).ready(function () {
   GOVUK.modules.start()

--- a/app/assets/stylesheets/govuk-component/_component.scss
+++ b/app/assets/stylesheets/govuk-component/_component.scss
@@ -24,3 +24,4 @@
 @import "search";
 @import "button";
 @import "lead-paragraph";
+@import "feedback";

--- a/app/assets/stylesheets/govuk-component/_feedback-print.scss
+++ b/app/assets/stylesheets/govuk-component/_feedback-print.scss
@@ -1,0 +1,3 @@
+.pub-c-feedback {
+  display: none;
+}

--- a/app/assets/stylesheets/govuk-component/_feedback.scss
+++ b/app/assets/stylesheets/govuk-component/_feedback.scss
@@ -1,0 +1,62 @@
+// add print styles to hide everything
+
+// scss-lint:disable SelectorFormat
+.pub-c-feedback {
+  max-width: 960px;
+  margin: 0 auto;
+}
+
+.pub-c-feedback__prompt {
+  @extend %contain-floats;
+  background-color: $govuk-blue;
+  color: $white;
+  padding: 10px $gutter-half 0;
+  outline: 0;
+}
+
+.pub-c-feedback__prompt-question {
+  @include bold-16;
+  display: inline;
+}
+
+.pub-c-feedback__prompt-link:link,
+.pub-c-feedback__prompt-link:visited {
+  color: $white;
+  display: inline-block;
+}
+
+.pub-c-feedback__prompt-link--useful {
+  margin-right: 0.2em;
+}
+
+.pub-c-feedback__prompt-link--wrong {
+  float: right;
+}
+
+.pub-c-feedback__form {
+  margin-top: $gutter;
+  padding: $gutter-half 0;
+  border-top: 10px solid $govuk-blue;
+}
+
+.pub-c-feedback__form-control {
+  width: 100%;
+}
+
+.pub-c-feedback__close {
+  @include core-16;
+  text-align: right;
+  display: block;
+  margin-bottom: 10px;
+
+  @include media(tablet) {
+    display: inherit;
+    float: right;
+    padding-top: 0;
+  }
+}
+
+.pub-c-feedback__submit {
+  @extend %pub-c-button;
+}
+// scss-lint:enable SelectorFormat

--- a/app/assets/stylesheets/govuk-component/_feedback.scss
+++ b/app/assets/stylesheets/govuk-component/_feedback.scss
@@ -1,9 +1,31 @@
-// add print styles to hide everything
+// govuk_frontend_toolkit
+@import 'grid_layout';
 
-// scss-lint:disable SelectorFormat
 .pub-c-feedback {
   max-width: 960px;
   margin: 0 auto;
+}
+
+// hide without js
+// show with js, unless also has the js-hidden class
+.pub-c-feedback__js-show {
+  display: none;
+
+  .js-enabled & {
+    display: block;
+
+    &.js-hidden {
+      display: none;
+    }
+  }
+}
+
+.pub-c-feedback__grid-row {
+  @extend %grid-row;
+}
+
+.pub-c-feedback__column-two-thirds {
+  @include grid-column( 2 / 3 );
 }
 
 .pub-c-feedback__prompt {
@@ -14,9 +36,14 @@
   outline: 0;
 }
 
-.pub-c-feedback__prompt-question {
+.pub-c-feedback__prompt-question,
+.pub-c-feedback__prompt-success {
   @include bold-16;
   display: inline;
+
+  &:focus {
+    outline: solid $yellow 3px;
+  }
 }
 
 .pub-c-feedback__prompt-link:link,
@@ -34,17 +61,28 @@
 }
 
 .pub-c-feedback__error-summary {
-  margin: $gutter-half 0;
+  margin-bottom: $gutter-half;
   padding: $gutter-half;
   border: solid 4px $red;
 
+  &:focus {
+    outline: solid 3px $yellow;
+  }
+
   @include media(tablet) {
-    margin: $gutter 0;
     border-width: 5px;
   }
 
-  &:focus {
-    outline: solid 3px $yellow;
+  // this comes from the backend so we can't put a class on it
+  h2,
+  .pub-c-feedback__heading {
+    @include bold-19;
+    margin: 0;
+  }
+
+  p {
+    @include core-16;
+    margin: 10px 0;
   }
 }
 
@@ -55,19 +93,24 @@
   color: $red;
 }
 
-.pub-c-feedback__error-heading {
-  @include bold-24;
-}
-
-.pub-c-feedback__error-text {
-  padding: 0;
-  margin: 0;
-}
-
 .pub-c-feedback__form {
-  margin-top: $gutter;
+  margin-top: $gutter-half;
   padding: $gutter-half 0;
   border-top: 10px solid $govuk-blue;
+
+  @include media(tablet) {
+    padding: $gutter 0;
+  }
+}
+
+.pub-c-feedback__form-heading {
+  @include bold-19;
+  margin-bottom: $gutter-half;
+}
+
+.pub-c-feedback__form-paragraph {
+  @include core-16;
+  margin-bottom: $gutter;
 }
 
 .pub-c-feedback__form-group {
@@ -79,36 +122,29 @@
 }
 
 .pub-c-feedback__form-label {
-  @include core-19;
+  @include core-16;
   display: block;
-  padding-bottom: 2px;
+  padding-bottom: $gutter-half;
 }
 
-.pub-c-feedback__form-label--bold {
-  font-weight: bold;
-}
-
-.pub-c-feedback__form-hint {
-  display: block;
-  color: $grey-1;
-}
-
-.pub-c-feedback__form-field {
-  @include core-19;
-  @include box-sizing(border-box);
-  padding: 5px;
-  width: 100%;
-  border: solid 2px $black;
+// nesting this in order to override other page styles for form fields
+.pub-c-feedback {
+  .pub-c-feedback__form-field {
+    @include core-19;
+    @include box-sizing(border-box);
+    padding: 5px;
+    margin: 0;
+    width: 100%;
+    border: solid 2px $black;
+  }
 }
 
 .pub-c-feedback__close {
   @include core-16;
   text-align: right;
-  display: block;
   margin-bottom: 10px;
 
   @include media(tablet) {
-    display: inherit;
     float: right;
     padding-top: 0;
   }
@@ -117,4 +153,3 @@
 .pub-c-feedback__submit {
   @extend %pub-c-button;
 }
-// scss-lint:enable SelectorFormat

--- a/app/assets/stylesheets/govuk-component/_feedback.scss
+++ b/app/assets/stylesheets/govuk-component/_feedback.scss
@@ -33,14 +33,72 @@
   float: right;
 }
 
+.pub-c-feedback__error-summary {
+  margin: $gutter-half 0;
+  padding: $gutter-half;
+  border: solid 4px $red;
+
+  @include media(tablet) {
+    margin: $gutter 0;
+    border-width: 5px;
+  }
+
+  &:focus {
+    outline: solid 3px $yellow;
+  }
+}
+
+.pub-c-feedback__error-message {
+  @include bold-19;
+  display: block;
+  padding: 4px 0 0;
+  color: $red;
+}
+
+.pub-c-feedback__error-heading {
+  @include bold-24;
+}
+
+.pub-c-feedback__error-text {
+  padding: 0;
+  margin: 0;
+}
+
 .pub-c-feedback__form {
   margin-top: $gutter;
   padding: $gutter-half 0;
   border-top: 10px solid $govuk-blue;
 }
 
-.pub-c-feedback__form-control {
+.pub-c-feedback__form-group {
+  padding-bottom: $gutter-half;
+
+  @include media(tablet) {
+    padding-bottom: $gutter;
+  }
+}
+
+.pub-c-feedback__form-label {
+  @include core-19;
+  display: block;
+  padding-bottom: 2px;
+}
+
+.pub-c-feedback__form-label--bold {
+  font-weight: bold;
+}
+
+.pub-c-feedback__form-hint {
+  display: block;
+  color: $grey-1;
+}
+
+.pub-c-feedback__form-field {
+  @include core-19;
+  @include box-sizing(border-box);
+  padding: 5px;
   width: 100%;
+  border: solid 2px $black;
 }
 
 .pub-c-feedback__close {

--- a/app/assets/stylesheets/static-print.scss
+++ b/app/assets/stylesheets/static-print.scss
@@ -4,3 +4,4 @@
 // The following files and inline CSS will form the output of print.css
 @import "header-footer-only-print";
 @import "helpers/core-print";
+@import "govuk-component/feedback-print"

--- a/app/views/govuk_component/docs/feedback.yml
+++ b/app/views/govuk_component/docs/feedback.yml
@@ -1,0 +1,22 @@
+name: Feedback
+description: Invites user feedback on the current page
+body: |
+  This component is designed to sit at the bottom of pages on GOV.UK to allow users to submit feedback on that page. It is based on the 'improve this page' component from the Service manual, but changes have been made.
+
+  This component depends upon the [button component](/component-guide/button) for imported styles. This is a non-ideal situation (styles are duplicated) and should be addressed.
+accessibility_criteria: |
+  Form elements in the component must:
+
+  * accept focus
+  * be focusable with a keyboard
+  * be usable with a keyboard
+  * be usable with touch
+  * indicate when they have focus
+  * be recognisable as form input elements
+  * have correctly associated labels
+  * be of the appropriate type for their use, e.g. password inputs should be of type 'password'
+shared_accessibility_criteria:
+  - link
+examples:
+  default:
+    data: {}

--- a/app/views/govuk_component/feedback.raw.html.erb
+++ b/app/views/govuk_component/feedback.raw.html.erb
@@ -1,70 +1,110 @@
 <%
-  contact_govuk_path = "/contact/govuk" #defined in a helper in service manual
+  contact_govuk_path = "/contact/govuk"
 %>
 
-<div class="pub-c-feedback" data-module="improve-this-page">
-  <div class="pub-c-feedback__prompt js-prompt" tabindex="-1">
-    <h3 class="pub-c-feedback__prompt-question">Is this page useful?</h3>
+<div class="pub-c-feedback" data-module="feedback">
+  <div class="pub-c-feedback__prompt pub-c-feedback__js-show js-prompt" tabindex="-1">
+    <div class="js-prompt-questions">
+      <h3 class="pub-c-feedback__prompt-question">Is this page useful?</h3>
 
-    <%= link_to contact_govuk_path, {
-          class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--useful js-page-is-useful',
-          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffYesClick' },
+      <%= link_to contact_govuk_path, {
+        class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--useful js-page-is-useful',
+        data: {
+          'track-category' => 'manualFeedbackForm',
+          'track-action' => 'ffYesClick'
+          },
         } do %>
-      Yes <span class="visually-hidden">this page is useful</span>
-    <% end %>
+          Yes <span class="visually-hidden">this page is useful</span>
+      <% end %>
 
-    <%= link_to contact_govuk_path, {
-          class: 'pub-c-feedback__prompt-link js-page-is-not-useful',
-          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffNoClick' },
-          'aria-controls': 'improveThisPageForm',
+      <%= link_to contact_govuk_path, {
+        class: 'pub-c-feedback__prompt-link js-toggle-form js-page-is-not-useful',
+        data: {
+          'track-category' => 'manualFeedbackForm',
+          'track-action' => 'ffNoClick'
+          },
+          'aria-controls': 'page-is-not-useful',
           'aria-expanded': false
         } do %>
-      No <span class="visually-hidden">this page is not useful</span>
-    <% end %>
+          No <span class="visually-hidden">this page is not useful</span>
+      <% end %>
 
-    <%= link_to contact_govuk_path, {
-          class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--wrong js-something-is-wrong',
-          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffWrongClick' },
-          'aria-controls': 'improveThisPageForm',
+      <%= link_to contact_govuk_path, {
+        class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong',
+        data: {
+          'track-category' => 'manualFeedbackForm',
+          'track-action' => 'ffWrongClick'
+          },
+          'aria-controls': 'something-is-wrong',
           'aria-expanded': false
         } do %>
-      Is there anything wrong with this page?
-    <% end %>
-  </div>
+          Is there anything wrong with this page?
+      <% end %>
+    </div>
 
-  <div id="improveThisPageForm" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">
-    <a href="#" class="pub-c-feedback__close js-close-feedback-form" aria-controls="improveThisPageForm" aria-expanded="true">Close</a>
-
-    <div class="grid-row">
-      <div class="column-two-thirds">
-        <div class="js-errors"></div>
-        <form>
-          <input type="hidden" name="url" value="<%= request.original_url -%>">
-          <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
-
-          <div class="pub-c-feedback__form-group js-form-group">
-            <label class="pub-c-feedback__form-label pub-c-feedback__form-label--bold" for="description-field">
-              How should we improve this page?
-            </label>
-            <textarea id="description-field" class="pub-c-feedback__form-field" name="description" rows="5" aria-required="true"></textarea>
-          </div>
-
-          <div class="pub-c-feedback__form-group js-form-group">
-            <label class="pub-c-feedback__form-label" for="name-field">
-              Name (optional)
-              <span class="pub-c-feedback__form-hint">Include your name and email address if you'd like us to get back to you.</span>
-            </label>
-            <input id="name-field" class="pub-c-feedback__form-field" type="text" name="name">
-          </div>
-
-          <div class="pub-c-feedback__form-group js-form-group">
-            <label class="pub-c-feedback__form-label" for="email-field">Email (optional)</label>
-            <input id="email-field" class="pub-c-feedback__form-field" type="text" name="email">
-          </div>
-
-          <input class="pub-c-feedback__submit" type="submit" value="Send message">
-        </form>
-      </div>
+    <div class="pub-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">
+      Thank you for your feedback
     </div>
   </div>
+
+  <form action="/contact/govuk/problem_reports" id="something-is-wrong" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">
+    <a href="#" class="pub-c-feedback__close pub-c-feedback__js-show js-close-form" aria-controls="something-is-wrong" aria-expanded="true" role="button">Close</a>
+
+    <div class="pub-c-feedback__grid-row">
+      <div class="pub-c-feedback__column-two-thirds">
+        <div class="pub-c-feedback__error-summary pub-c-feedback__js-show js-hidden js-errors" tabindex="-1"></div>
+
+        <input type="hidden" name="url" value="<%= request.original_url -%>">
+        <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
+
+        <h2 class="pub-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <p id="feedback_explanation" class="pub-c-feedback__form-paragraph">Don’t include personal or financial information like your National Insurance number or credit card details.</p>
+
+        <div class="pub-c-feedback__form-group js-form-group">
+          <label class="pub-c-feedback__form-label" for="what_doing">
+            What were you doing?
+          </label>
+          <input type="text" id="what_doing" class="pub-c-feedback__form-field" name="what_doing" rows="4" aria-required="true" aria-describedby="feedback_explanation"/>
+        </div>
+
+        <div class="pub-c-feedback__form-group js-form-group">
+          <label class="pub-c-feedback__form-label" for="what_wrong">
+            What went wrong?
+          </label>
+          <input type="text" id="what_wrong" class="pub-c-feedback__form-field" name="what_wrong" rows="4" aria-required="true"/>
+        </div>
+
+        <input class="pub-c-feedback__submit" type="submit" value="Send">
+      </div>
+    </div>
+  </form>
+
+  <form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="pub-c-feedback__form pub-c-feedback__form--email pub-c-feedback__js-show js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">
+    <a href="#" class="pub-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true" role="button">Close</a>
+
+    <div class="pub-c-feedback__grid-row">
+      <div class="pub-c-feedback__column-two-thirds">
+        <div class="pub-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>
+
+        <input type="hidden" name="url" value="<%= request.original_url -%>">
+        <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
+
+        <input name="email_survey_signup[survey_id]" type="hidden" value="user_satisfaction_survey">
+        <input name="email_survey_signup[survey_source]" type="hidden" value="<%= request.original_url -%>">
+        <input name="email_survey_signup[ga_client_id]" type="hidden" value="1627485790.1515403243">
+
+        <h2 class="pub-c-feedback__form-heading">Help us improve GOV.UK</h2>
+        <p id="survey_explanation" class="pub-c-feedback__form-paragraph">To help us improve GOV.UK, we’d like to know more about your visit today. We’ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don’t worry we won’t send you spam or share your email address with anyone.</p>
+
+        <div class="pub-c-feedback__form-group js-form-group">
+          <label class="pub-c-feedback__form-label" for="email-field">Email address</label>
+          <input id="email-field" class="pub-c-feedback__form-field" type="text" name="email_survey_signup[email_address]" aria-describedby="survey_explanation">
+        </div>
+
+        <input class="pub-c-feedback__submit" type="submit" value="Send me the survey">
+        <a href="https://www.smartsurvey.co.uk/s/gov-uk-banner/?c=<%= request.fullpath -%>&amp;gcl=1627485790.1515403243" id="take-survey" target="_blank" rel="noopener noreferrer">Don’t have an email address?</a>
+      </div>
+    </div>
+  </form>
+
 </div>

--- a/app/views/govuk_component/feedback.raw.html.erb
+++ b/app/views/govuk_component/feedback.raw.html.erb
@@ -1,0 +1,70 @@
+<%
+  contact_govuk_path = "/contact/govuk" #defined in a helper in service manual
+%>
+
+<div class="pub-c-feedback" data-module="improve-this-page">
+  <div class="pub-c-feedback__prompt js-prompt" tabindex="-1">
+    <h3 class="pub-c-feedback__prompt-question">Is this page useful?</h3>
+
+    <%= link_to contact_govuk_path, {
+          class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--useful js-page-is-useful',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffYesClick' },
+        } do %>
+      Yes <span class="visually-hidden">this page is useful</span>
+    <% end %>
+
+    <%= link_to contact_govuk_path, {
+          class: 'pub-c-feedback__prompt-link js-page-is-not-useful',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffNoClick' },
+          'aria-controls': 'improveThisPageForm',
+          'aria-expanded': false
+        } do %>
+      No <span class="visually-hidden">this page is not useful</span>
+    <% end %>
+
+    <%= link_to contact_govuk_path, {
+          class: 'pub-c-feedback__prompt-link pub-c-feedback__prompt-link--wrong js-something-is-wrong',
+          data: { 'track-category' => 'manualFeedbackForm', 'track-action' => 'ffWrongClick' },
+          'aria-controls': 'improveThisPageForm',
+          'aria-expanded': false
+        } do %>
+      Is there anything wrong with this page?
+    <% end %>
+  </div>
+
+  <div id="improveThisPageForm" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">
+    <a href="#" class="pub-c-feedback__close js-close-feedback-form" aria-controls="improveThisPageForm" aria-expanded="true">Close</a>
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+        <div class="js-errors"></div>
+        <form>
+          <input type="hidden" name="url" value="<%= request.original_url -%>">
+          <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
+
+          <div class="form-group">
+            <label class="form-label-bold" for="description-field">
+              How should we improve this page?
+            </label>
+            <textarea id="description-field" class="pub-c-feedback__form-control" name="description" rows="5" aria-required="true"></textarea>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="name-field">
+              Name (optional)
+              <span class="form-hint">Include your name and email address if you'd like us to get back to you.</span>
+            </label>
+            <input id="name-field" class="pub-c-feedback__form-control" type="text" name="name">
+          </div>
+
+          <div class="form-group">
+            <label class="form-label" for="email-field">Email (optional)</label>
+            <input id="email-field" class="pub-c-feedback__form-control" type="text" name="email">
+          </div>
+
+          <input class="pub-c-feedback__submit" type="submit" value="Send message">
+        </form>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/govuk_component/feedback.raw.html.erb
+++ b/app/views/govuk_component/feedback.raw.html.erb
@@ -42,24 +42,24 @@
           <input type="hidden" name="url" value="<%= request.original_url -%>">
           <input type="hidden" name="user_agent" value="<%= request.user_agent -%>">
 
-          <div class="form-group">
-            <label class="form-label-bold" for="description-field">
+          <div class="pub-c-feedback__form-group js-form-group">
+            <label class="pub-c-feedback__form-label pub-c-feedback__form-label--bold" for="description-field">
               How should we improve this page?
             </label>
-            <textarea id="description-field" class="pub-c-feedback__form-control" name="description" rows="5" aria-required="true"></textarea>
+            <textarea id="description-field" class="pub-c-feedback__form-field" name="description" rows="5" aria-required="true"></textarea>
           </div>
 
-          <div class="form-group">
-            <label class="form-label" for="name-field">
+          <div class="pub-c-feedback__form-group js-form-group">
+            <label class="pub-c-feedback__form-label" for="name-field">
               Name (optional)
-              <span class="form-hint">Include your name and email address if you'd like us to get back to you.</span>
+              <span class="pub-c-feedback__form-hint">Include your name and email address if you'd like us to get back to you.</span>
             </label>
-            <input id="name-field" class="pub-c-feedback__form-control" type="text" name="name">
+            <input id="name-field" class="pub-c-feedback__form-field" type="text" name="name">
           </div>
 
-          <div class="form-group">
-            <label class="form-label" for="email-field">Email (optional)</label>
-            <input id="email-field" class="pub-c-feedback__form-control" type="text" name="email">
+          <div class="pub-c-feedback__form-group js-form-group">
+            <label class="pub-c-feedback__form-label" for="email-field">Email (optional)</label>
+            <input id="email-field" class="pub-c-feedback__form-field" type="text" name="email">
           </div>
 
           <input class="pub-c-feedback__submit" type="submit" value="Send message">

--- a/spec/javascripts/govuk-component/feedback-spec.js
+++ b/spec/javascripts/govuk-component/feedback-spec.js
@@ -1,0 +1,516 @@
+describe("Improve this page", function () {
+   var FIXTURE =
+    '<div class="pub-c-feedback">' +
+      '<div class="js-prompt">' +
+        '<span class="pub-c-feedback__is-useful-question">Is this page useful?</span>' +
+        '<a href="/contact/govuk" class="js-page-is-useful" data-track-category="improve-this-page" data-track-action="page-is-useful">Yes</a>' +
+        '<a href="/contact/govuk" class="js-page-is-not-useful" data-track-category="improve-this-page" data-track-action="page-is-not-useful" aria-controls="improveThisPageForm">No</a>' +
+        '<div class="pub-c-feedback__anything-wrong">' +
+          '<a href="/contact/govuk" class="js-something-is-wrong" data-track-category="improve-this-page" data-track-action="something-is-wrong" aria-controls="improveThisPageForm">Is there anything wrong with this page?</a>' +
+        '</div>' +
+      '</div>' +
+      '<div id="improveThisPageForm" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="improve-this-page" data-track-action="give-feedback">' +
+        '<a href="#" class="pub-c-feedback__close js-close-feedback-form">Close</a>' +
+        '<div class="js-errors"></div>' +
+        '<form>' +
+          '<input type="hidden" name="url" value="http://example.com/path/to/page"></input>' +
+          '<input type="hidden" name="user_agent" value="Safari"></input>' +
+          '<div class="form-group">' +
+            '<label class="form-label-bold" for="description-field">' +
+              'How should we improve this page?' +
+            '</label>' +
+            '<textarea id="description-field" class="form-control" name="description" rows="5" aria-required="true"></textarea>' +
+          '</div>' +
+          '<div class="form-group">' +
+            '<label class="form-label" for="name-field">' +
+              'Name (optional)' +
+              '<span class="form-hint">Include your name and email address if you\'d like us to get back to you.</span>' +
+            '</label>' +
+            '<input id="name-field" class="form-control" type="text" name="name">' +
+          '</div>' +
+          '<div class="form-group">' +
+            '<label class="form-label" for="email-field">Email (optional)</label>' +
+            '<input id="email-field" class="form-control" type="text" name="email">' +
+          '</div>' +
+          '<div>' +
+            '<input class="button" type="submit" value="Send message">' +
+          '</div>' +
+        '</form>' +
+      '</div>' +
+    '</div>';
+
+  beforeEach(function () {
+    setFixtures(FIXTURE);
+  });
+
+  it("hides the form", function () {
+    loadImproveThisPage();
+
+    expect($('.js-feedback-form')).toHaveClass('js-hidden');
+  });
+
+  it("shows the prompt", function () {
+    loadImproveThisPage();
+
+    expect($('.pub-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+  });
+
+  it("conveys that the feedback form is hidden", function() {
+    loadImproveThisPage();
+
+    expect($('.js-feedback-form').attr('aria-hidden')).toBe('true');
+  });
+
+  it("conveys that the form is not expanded", function () {
+    loadImproveThisPage();
+
+    expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+    expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+  });
+
+  describe("Clicking the 'page was useful' link", function () {
+    it("displays a success message", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-useful').click();
+
+      var $prompt = $('.pub-c-feedback .js-prompt')
+
+      expect($prompt).not.toHaveClass('js-hidden');
+      expect($prompt).toHaveText("Thanks for your feedback.");
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+
+        $('a.js-page-is-useful').click();
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'page-is-useful');
+      });
+    });
+  });
+
+  describe("Clicking the 'page was not useful' link", function () {
+    it("shows the feedback form", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.pub-c-feedback .js-feedback-form')).not.toHaveClass('js-hidden');
+    });
+
+    it("hides the prompt", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.pub-c-feedback .js-prompt')).toHaveClass('js-hidden');
+    });
+
+    it("conveys that the form is now visible", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.js-feedback-form').attr('aria-hidden')).toBe('false');
+    });
+
+    it("conveys that the form is now expanded", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true');
+    });
+
+    it("focusses the first field in the form", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect(document.activeElement).toBe($('.form-control').get(0));
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+
+        $('a.js-page-is-not-useful').click();
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'page-is-not-useful');
+      });
+    });
+  });
+
+  describe("Clicking the 'something is wrong with the page' link", function () {
+    it("shows the feedback form", function () {
+      loadImproveThisPage();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.pub-c-feedback .js-feedback-form')).not.toHaveClass('js-hidden');
+    });
+
+    it("hides the prompt", function () {
+      loadImproveThisPage();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.pub-c-feedback .js-prompt')).toHaveClass('js-hidden');
+    });
+
+    it("conveys that the form is now visible", function () {
+      loadImproveThisPage();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.js-feedback-form').attr('aria-hidden')).toBe('false');
+    });
+
+    it("conveys that the form is now expanded", function () {
+      loadImproveThisPage();
+      $('a.js-something-is-wrong').click();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true');
+    });
+
+    it("focusses the first field in the form", function () {
+      loadImproveThisPage();
+      $('a.js-page-is-not-useful').click();
+
+      expect(document.activeElement).toBe($('.form-control').get(0));
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+
+        $('a.js-something-is-wrong').click();
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'something-is-wrong');
+      });
+    });
+  });
+
+  describe("Clicking the close link", function () {
+    beforeEach(function () {
+      loadImproveThisPage();
+
+      $('a.js-something-is-wrong').click();
+      $('a.js-close-feedback-form').click();
+    })
+
+    it("hides the form", function() {
+      expect($('.pub-c-feedback .js-feedback-form')).toHaveClass('js-hidden');
+    });
+
+    it("shows the prompt", function() {
+      expect($('.pub-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    });
+
+    it("conveys that the feedback form is hidden", function() {
+      loadImproveThisPage();
+
+      expect($('.js-feedback-form').attr('aria-hidden')).toBe('true');
+    });
+
+    it("conveys that the form is not expanded", function () {
+      loadImproveThisPage();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+  })
+
+  describe("Successfully submitting the feedback form", function () {
+
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      withGovukAnalytics(analytics, function () {
+        spyOn(GOVUK.analytics, 'trackEvent');
+
+        loadImproveThisPage();
+        fillAndSubmitFeedbackForm();
+
+        jasmine.Ajax.requests.mostRecent().respondWith({
+          status: 200,
+          contentType: 'text/plain',
+          responseText: ''
+        });
+
+        expect(GOVUK.analytics.trackEvent).
+          toHaveBeenCalledWith('improve-this-page', 'give-feedback');
+      });
+    });
+
+    it("submits the feedback to the feedback frontend", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      request = jasmine.Ajax.requests.mostRecent();
+      expect(request.url).toBe('/contact/govuk/page_improvements');
+      expect(request.method).toBe('POST');
+      expect(request.data()).toEqual({
+        url: ["http://example.com/path/to/page"],
+        description: ["The background should be green."],
+        name: ["Henry"],
+        email: ["henry@example.com"],
+        user_agent: ["Safari"]
+      });
+    });
+
+    it("displays a success message", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $prompt = $('.pub-c-feedback .js-prompt');
+
+      expect($prompt).not.toHaveClass('js-hidden');
+      expect($prompt).toHaveText("Thanks for your feedback.");
+    });
+
+    if("focusses the success message", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $prompt = $('.pub-c-feedback .js-prompt');
+      expect(document.activeElement).toBe($prompt);
+    })
+
+    it("hides the form", function() {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-feedback-form')).toHaveClass('js-hidden');
+    });
+
+    it("removes the links to show the feedback form", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-page-is-not-useful, .js-something-is-wrong').length).toBe(0);
+    });
+  });
+
+  describe("Submitting a form with invalid data", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("disables the submit button until the server responds", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      expect($('.pub-c-feedback form [type=submit]')).toBeDisabled();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('.pub-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('[name=description]').val()).toEqual('The background should be green.');
+      expect($('[name=name]').val()).toEqual('Henry');
+      expect($('[name=email]').val()).toEqual('henry@example.com');
+    });
+
+    it("displays validation errors in the label of each field", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('label[for=description-field]')).toContainText("Description can't be blank.");
+    });
+
+    it("marks fields with validation errors as invalid", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('[name=description]')).toHaveAttr('aria-invalid', 'true');
+    });
+
+    it("focusses the first form group if there are no generic errors", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect(document.activeElement).toBe($('[name=description]').get(0));
+    });
+
+    it("displays a generic error if the field isn't a visible part of the form", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+      });
+
+      expect($('.pub-c-feedback .error-summary')).toContainText("Path can't be blank. Another weird error.");
+    });
+
+    it("focusses the generic error if there is one", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
+      });
+
+      expect(document.activeElement).toBe($('.error-summary').get(0));
+    });
+
+    it("associates the error summary with its message so screen readers will read it when the div is focussed", function () {
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
+      });
+
+      var $genericErrorMessage = $('#generic-error-message');
+
+      expect($('.error-summary').attr('aria-labelledby')).toEqual(
+        $genericErrorMessage.attr('id')
+      );
+    });
+  })
+
+  describe("Submitting a form that fails for some reason", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+
+      loadImproveThisPage();
+      fillAndSubmitFeedbackForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 500,
+        contentType: 'text/plain',
+        responseText: ''
+      });
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("displays a generic error message", function () {
+      expect($('.pub-c-feedback').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      expect($('[name=description]').val()).toEqual('The background should be green.');
+      expect($('[name=name]').val()).toEqual('Henry');
+      expect($('[name=email]').val()).toEqual('henry@example.com');
+    });
+
+    it('re-enables the submit button', function () {
+      expect($('.pub-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+  })
+
+  function loadImproveThisPage () {
+    var improveThisPage = new GOVUK.Modules.ImproveThisPage();
+    improveThisPage.start($('.pub-c-feedback'));
+  }
+
+  function fillAndSubmitFeedbackForm () {
+    $form = $('.pub-c-feedback form');
+    $form.find("[name=description]").val("The background should be green.");
+    $form.find("[name=name]").val("Henry");
+    $form.find("[name=email]").val("henry@example.com");
+    $form.find("[type=submit]").click();
+  }
+});

--- a/spec/javascripts/govuk-component/feedback-spec.js
+++ b/spec/javascripts/govuk-component/feedback-spec.js
@@ -15,22 +15,22 @@ describe("Improve this page", function () {
         '<form>' +
           '<input type="hidden" name="url" value="http://example.com/path/to/page"></input>' +
           '<input type="hidden" name="user_agent" value="Safari"></input>' +
-          '<div class="form-group">' +
-            '<label class="form-label-bold" for="description-field">' +
+          '<div class="pub-c-feedback__form-group js-form-group">' +
+            '<label class="pub-c-feedback__form-label pub-c-feedback__form-label--bold" for="description-field">' +
               'How should we improve this page?' +
             '</label>' +
-            '<textarea id="description-field" class="form-control" name="description" rows="5" aria-required="true"></textarea>' +
+            '<textarea id="description-field" class="pub-c-feedback__form-field" name="description" rows="5" aria-required="true"></textarea>' +
           '</div>' +
-          '<div class="form-group">' +
-            '<label class="form-label" for="name-field">' +
+          '<div class="pub-c-feedback__form-group js-form-group">' +
+            '<label class="pub-c-feedback__form-label" for="name-field">' +
               'Name (optional)' +
-              '<span class="form-hint">Include your name and email address if you\'d like us to get back to you.</span>' +
+              '<span class="pub-c-feedback__form-hint">Include your name and email address if you\'d like us to get back to you.</span>' +
             '</label>' +
-            '<input id="name-field" class="form-control" type="text" name="name">' +
+            '<input id="name-field" class="pub-c-feedback__form-field" type="text" name="name">' +
           '</div>' +
-          '<div class="form-group">' +
-            '<label class="form-label" for="email-field">Email (optional)</label>' +
-            '<input id="email-field" class="form-control" type="text" name="email">' +
+          '<div class="pub-c-feedback__form-group js-form-group">' +
+            '<label class="pub-c-feedback__form-label" for="email-field">Email (optional)</label>' +
+            '<input id="email-field" class="pub-c-feedback__form-field" type="text" name="email">' +
           '</div>' +
           '<div>' +
             '<input class="button" type="submit" value="Send message">' +
@@ -131,7 +131,7 @@ describe("Improve this page", function () {
       loadImproveThisPage();
       $('a.js-page-is-not-useful').click();
 
-      expect(document.activeElement).toBe($('.form-control').get(0));
+      expect(document.activeElement).toBe($('.pub-c-feedback__form-field').get(0));
     });
 
     it("triggers a Google Analytics event", function () {
@@ -186,7 +186,7 @@ describe("Improve this page", function () {
       loadImproveThisPage();
       $('a.js-page-is-not-useful').click();
 
-      expect(document.activeElement).toBe($('.form-control').get(0));
+      expect(document.activeElement).toBe($('.pub-c-feedback__form-field').get(0));
     });
 
     it("triggers a Google Analytics event", function () {
@@ -430,7 +430,7 @@ describe("Improve this page", function () {
         responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
       });
 
-      expect($('.pub-c-feedback .error-summary')).toContainText("Path can't be blank. Another weird error.");
+      expect($('.pub-c-feedback .js-error-summary')).toContainText("Path can't be blank. Another weird error.");
     });
 
     it("focusses the generic error if there is one", function () {
@@ -443,7 +443,7 @@ describe("Improve this page", function () {
         responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
       });
 
-      expect(document.activeElement).toBe($('.error-summary').get(0));
+      expect(document.activeElement).toBe($('.js-error-summary').get(0));
     });
 
     it("associates the error summary with its message so screen readers will read it when the div is focussed", function () {
@@ -458,7 +458,7 @@ describe("Improve this page", function () {
 
       var $genericErrorMessage = $('#generic-error-message');
 
-      expect($('.error-summary').attr('aria-labelledby')).toEqual(
+      expect($('.js-error-summary').attr('aria-labelledby')).toEqual(
         $genericErrorMessage.attr('id')
       );
     });

--- a/spec/javascripts/govuk-component/feedback-spec.js
+++ b/spec/javascripts/govuk-component/feedback-spec.js
@@ -1,82 +1,123 @@
-describe("Improve this page", function () {
+describe("Feedback component", function () {
    var FIXTURE =
     '<div class="pub-c-feedback">' +
-      '<div class="js-prompt">' +
-        '<span class="pub-c-feedback__is-useful-question">Is this page useful?</span>' +
-        '<a href="/contact/govuk" class="js-page-is-useful" data-track-category="improve-this-page" data-track-action="page-is-useful">Yes</a>' +
-        '<a href="/contact/govuk" class="js-page-is-not-useful" data-track-category="improve-this-page" data-track-action="page-is-not-useful" aria-controls="improveThisPageForm">No</a>' +
-        '<div class="pub-c-feedback__anything-wrong">' +
-          '<a href="/contact/govuk" class="js-something-is-wrong" data-track-category="improve-this-page" data-track-action="something-is-wrong" aria-controls="improveThisPageForm">Is there anything wrong with this page?</a>' +
+      '<div class="pub-c-feedback__prompt js-prompt" tabindex="-1">' +
+        '<div class="js-prompt-questions">' +
+          '<h3 class="pub-c-feedback__is-useful-question">Is this page useful?</h3>' +
+          '<a href="/contact/govuk" class="pub-c-feedback__prompt-link pub-c-feedback__prompt-link--useful js-page-is-useful" data-track-category="manualFeedbackForm" data-track-action="ffYesClick">Yes <span class="visually-hidden">this page is useful</span></a>' +
+          '<a href="/contact/govuk" class="pub-c-feedback__prompt-link js-toggle-form js-page-is-not-useful" data-track-category="manualFeedbackForm" data-track-action="ffNoClick" aria-controls="page-is-not-useful" aria-expanded="false">No <span class="visually-hidden">this page is not useful</span></a>' +
+          '<a href="/contact/govuk" class="pub-c-feedback__prompt-link pub-c-feedback__prompt-link--wrong js-toggle-form js-something-is-wrong" data-track-category="manualFeedbackForm" data-track-action="ffWrongClick" aria-controls="something-is-wrong" aria-expanded="false">Is there anything wrong with this page?</a>' +
+        '</div>' +
+
+        '<div class="pub-c-feedback__prompt-success js-prompt-success js-hidden" tabindex="-1">' +
+          'Thanks for your feedback.' +
         '</div>' +
       '</div>' +
-      '<div id="improveThisPageForm" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="improve-this-page" data-track-action="give-feedback">' +
-        '<a href="#" class="pub-c-feedback__close js-close-feedback-form">Close</a>' +
-        '<div class="js-errors"></div>' +
-        '<form>' +
-          '<input type="hidden" name="url" value="http://example.com/path/to/page"></input>' +
-          '<input type="hidden" name="user_agent" value="Safari"></input>' +
-          '<div class="pub-c-feedback__form-group js-form-group">' +
-            '<label class="pub-c-feedback__form-label pub-c-feedback__form-label--bold" for="description-field">' +
-              'How should we improve this page?' +
-            '</label>' +
-            '<textarea id="description-field" class="pub-c-feedback__form-field" name="description" rows="5" aria-required="true"></textarea>' +
+
+      '<form action="/contact/govuk/page_improvements" id="something-is-wrong" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="manualFeedbackForm" data-track-action="ffFormSubmit">' +
+        '<a href="#" class="pub-c-feedback__close js-close-form" aria-controls="something-is-wrong" aria-expanded="true">Close</a>' +
+
+        '<div class="grid-row">' +
+          '<div class="column-two-thirds">' +
+            '<div class="pub-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+
+            '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
+            '<input type="hidden" name="user_agent" value="Safari">' +
+
+            '<h2 class="pub-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
+            '<p class="pub-c-feedback__form-paragraph">Don\'t include personal or financial information like your National Insurance number or credit card details.</p>' +
+
+            '<div class="pub-c-feedback__form-group js-form-group">' +
+              '<label class="pub-c-feedback__form-label" for="description-field">' +
+                'What were you doing on this page?' +
+              '</label>' +
+              '<textarea id="what_doing" class="pub-c-feedback__form-field" name="what_doing" rows="4" aria-required="true"></textarea>' +
+            '</div>' +
+
+            '<div class="pub-c-feedback__form-group js-form-group">' +
+              '<label class="pub-c-feedback__form-label" for="wrong-field">' +
+                'What is wrong with this page?' +
+              '</label>' +
+              '<textarea id="what_wrong" class="pub-c-feedback__form-field" name="what_wrong" rows="4" aria-required="true"></textarea>' +
+            '</div>' +
+
+            '<input class="pub-c-feedback__submit" type="submit" value="Submit">' +
           '</div>' +
-          '<div class="pub-c-feedback__form-group js-form-group">' +
-            '<label class="pub-c-feedback__form-label" for="name-field">' +
-              'Name (optional)' +
-              '<span class="pub-c-feedback__form-hint">Include your name and email address if you\'d like us to get back to you.</span>' +
-            '</label>' +
-            '<input id="name-field" class="pub-c-feedback__form-field" type="text" name="name">' +
+        '</div>' +
+      '</form>' +
+
+      '<form action="/contact/govuk/email-survey-signup" id="page-is-not-useful" class="pub-c-feedback__form js-feedback-form js-hidden" data-track-category="user_satisfaction_survey" data-track-action="banner_taken">' +
+        '<a href="#" class="pub-c-feedback__close js-close-form" aria-controls="page-is-not-useful" aria-expanded="true">Close</a>' +
+
+        '<div class="grid-row">' +
+          '<div class="column-two-thirds">' +
+            '<div class="pub-c-feedback__error-summary js-hidden js-errors" tabindex="-1"></div>' +
+
+            '<input type="hidden" name="url" value="http://example.com/path/to/page">' +
+            '<input type="hidden" name="user_agent" value="Safari">' +
+
+            '<h2 class="pub-c-feedback__form-heading">Help us improve GOV.UK</h2>' +
+            '<p class="pub-c-feedback__form-paragraph">To help us improve GOV.UK, we\'d like to know more about your visit today. We\'ll send you a link to a feedback form. It will take only 2 minutes to fill in. Don\'t worry we won\'t send you spam or share your email address with anyone.</p>' +
+
+            '<div class="pub-c-feedback__form-group js-form-group">' +
+              '<label class="pub-c-feedback__form-label" for="email-field">Email address</label>' +
+              '<input id="email-field" class="pub-c-feedback__form-field" type="text" name="email_survey_signup[email_address]">' +
+            '</div>' +
+
+            '<input class="pub-c-feedback__submit" type="submit" value="Send me the survey">' +
+            '<a href="FIXME" class="">Don\'t have an email address?</a>' +
           '</div>' +
-          '<div class="pub-c-feedback__form-group js-form-group">' +
-            '<label class="pub-c-feedback__form-label" for="email-field">Email (optional)</label>' +
-            '<input id="email-field" class="pub-c-feedback__form-field" type="text" name="email">' +
-          '</div>' +
-          '<div>' +
-            '<input class="button" type="submit" value="Send message">' +
-          '</div>' +
-        '</form>' +
-      '</div>' +
+        '</div>' +
+      '</form>' +
     '</div>';
 
   beforeEach(function () {
     setFixtures(FIXTURE);
   });
 
-  it("hides the form", function () {
-    loadImproveThisPage();
+  it("hides the forms", function () {
+    loadFeedbackComponent();
 
-    expect($('.js-feedback-form')).toHaveClass('js-hidden');
+    expect($('.pub-c-feedback .js-feedback-form')).toHaveClass('js-hidden');
   });
 
   it("shows the prompt", function () {
-    loadImproveThisPage();
+    loadFeedbackComponent();
 
     expect($('.pub-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    expect($('.pub-c-feedback .js-prompt-questions')).not.toHaveClass('js-hidden');
   });
 
-  it("conveys that the feedback form is hidden", function() {
-    loadImproveThisPage();
+  it("conveys that the feedback forms are hidden", function() {
+    loadFeedbackComponent();
 
-    expect($('.js-feedback-form').attr('aria-hidden')).toBe('true');
+    expect($('.js-feedback-form#something-is-wrong').attr('aria-hidden')).toBe('true');
+    expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('true');
   });
 
   it("conveys that the form is not expanded", function () {
-    loadImproveThisPage();
+    loadFeedbackComponent();
 
-    expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
-    expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    expect($('.js-toggle-form[aria-controls="page-is-not-useful"]').attr('aria-expanded')).toBe('false');
+    expect($('.js-toggle-form[aria-controls="something-is-wrong"]').attr('aria-expanded')).toBe('false');
   });
 
-  describe("Clicking the 'page was useful' link", function () {
+  describe("clicking the 'page was useful' link", function () {
     it("displays a success message", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-useful').click();
 
-      var $prompt = $('.pub-c-feedback .js-prompt')
+      var $success = $('.js-prompt-success');
 
-      expect($prompt).not.toHaveClass('js-hidden');
-      expect($prompt).toHaveText("Thanks for your feedback.");
+      expect($success).not.toHaveClass('js-hidden');
+      expect($success).toHaveText("Thanks for your feedback.");
+    });
+
+    it("hides the question links", function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-useful').click();
+
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
     });
 
     it("triggers a Google Analytics event", function () {
@@ -84,54 +125,51 @@ describe("Improve this page", function () {
         trackEvent: function() {}
       };
 
-      withGovukAnalytics(analytics, function () {
-        spyOn(GOVUK.analytics, 'trackEvent');
+      spyOn(GOVUK.analytics, 'trackEvent');
 
-        loadImproveThisPage();
+      loadFeedbackComponent();
+      $('a.js-page-is-useful').click();
 
-        $('a.js-page-is-useful').click();
-
-        expect(GOVUK.analytics.trackEvent).
-          toHaveBeenCalledWith('improve-this-page', 'page-is-useful');
-      });
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('manualFeedbackForm', 'ffYesClick');
     });
   });
 
   describe("Clicking the 'page was not useful' link", function () {
     it("shows the feedback form", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-not-useful').click();
 
-      expect($('.pub-c-feedback .js-feedback-form')).not.toHaveClass('js-hidden');
+      expect($('.pub-c-feedback .js-feedback-form#page-is-not-useful')).not.toHaveClass('js-hidden');
     });
 
     it("hides the prompt", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-not-useful').click();
 
       expect($('.pub-c-feedback .js-prompt')).toHaveClass('js-hidden');
     });
 
     it("conveys that the form is now visible", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-not-useful').click();
 
-      expect($('.js-feedback-form').attr('aria-hidden')).toBe('false');
+      expect($('.js-feedback-form#page-is-not-useful').attr('aria-hidden')).toBe('false');
     });
 
     it("conveys that the form is now expanded", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-not-useful').click();
 
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true');
-      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
     });
 
     it("focusses the first field in the form", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-page-is-not-useful').click();
 
-      expect(document.activeElement).toBe($('.pub-c-feedback__form-field').get(0));
+      expect(document.activeElement).toBe($('#page-is-not-useful .pub-c-feedback__form-field').get(0));
     });
 
     it("triggers a Google Analytics event", function () {
@@ -139,54 +177,51 @@ describe("Improve this page", function () {
         trackEvent: function() {}
       };
 
-      withGovukAnalytics(analytics, function () {
-        spyOn(GOVUK.analytics, 'trackEvent');
+      spyOn(GOVUK.analytics, 'trackEvent');
 
-        loadImproveThisPage();
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
 
-        $('a.js-page-is-not-useful').click();
-
-        expect(GOVUK.analytics.trackEvent).
-          toHaveBeenCalledWith('improve-this-page', 'page-is-not-useful');
-      });
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('manualFeedbackForm', 'ffNoClick');
     });
   });
 
-  describe("Clicking the 'something is wrong with the page' link", function () {
-    it("shows the feedback form", function () {
-      loadImproveThisPage();
+  describe("Clicking the 'is there anything wrong with this page' link", function () {
+    it("shows the form", function () {
+      loadFeedbackComponent();
       $('a.js-something-is-wrong').click();
 
-      expect($('.pub-c-feedback .js-feedback-form')).not.toHaveClass('js-hidden');
+      expect($('.pub-c-feedback .js-feedback-form#something-is-wrong')).not.toHaveClass('js-hidden');
     });
 
     it("hides the prompt", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-something-is-wrong').click();
 
       expect($('.pub-c-feedback .js-prompt')).toHaveClass('js-hidden');
     });
 
     it("conveys that the form is now visible", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-something-is-wrong').click();
 
       expect($('.js-feedback-form').attr('aria-hidden')).toBe('false');
     });
 
     it("conveys that the form is now expanded", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
       $('a.js-something-is-wrong').click();
 
-      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('true');
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('true');
     });
 
     it("focusses the first field in the form", function () {
-      loadImproveThisPage();
-      $('a.js-page-is-not-useful').click();
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
 
-      expect(document.activeElement).toBe($('.pub-c-feedback__form-field').get(0));
+      expect(document.activeElement).toBe($('#something-is-wrong .pub-c-feedback__form-field').get(0));
     });
 
     it("triggers a Google Analytics event", function () {
@@ -194,29 +229,25 @@ describe("Improve this page", function () {
         trackEvent: function() {}
       };
 
-      withGovukAnalytics(analytics, function () {
-        spyOn(GOVUK.analytics, 'trackEvent');
+      spyOn(GOVUK.analytics, 'trackEvent');
 
-        loadImproveThisPage();
+      loadFeedbackComponent();
+      $('a.js-something-is-wrong').click();
 
-        $('a.js-something-is-wrong').click();
-
-        expect(GOVUK.analytics.trackEvent).
-          toHaveBeenCalledWith('improve-this-page', 'something-is-wrong');
-      });
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('manualFeedbackForm', 'ffWrongClick');
     });
   });
 
-  describe("Clicking the close link", function () {
+  describe("Clicking the close link in the 'something is wrong' form", function () {
     beforeEach(function () {
-      loadImproveThisPage();
-
+      loadFeedbackComponent();
       $('a.js-something-is-wrong').click();
-      $('a.js-close-feedback-form').click();
+      $('#something-is-wrong a.js-close-form').click();
     })
 
     it("hides the form", function() {
-      expect($('.pub-c-feedback .js-feedback-form')).toHaveClass('js-hidden');
+      expect($('.pub-c-feedback #something-is-wrong')).toHaveClass('js-hidden');
     });
 
     it("shows the prompt", function() {
@@ -224,21 +255,49 @@ describe("Improve this page", function () {
     });
 
     it("conveys that the feedback form is hidden", function() {
-      loadImproveThisPage();
+      loadFeedbackComponent();
 
-      expect($('.js-feedback-form').attr('aria-hidden')).toBe('true');
+      expect($('#something-is-wrong.js-feedback-form').attr('aria-hidden')).toBe('true');
     });
 
     it("conveys that the form is not expanded", function () {
-      loadImproveThisPage();
+      loadFeedbackComponent();
 
       expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
       expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
     });
   })
 
-  describe("Successfully submitting the feedback form", function () {
+  describe("Clicking the close link in the 'not useful' form", function () {
+    beforeEach(function () {
+      loadFeedbackComponent();
+      $('a.js-page-is-not-useful').click();
+      $('#page-is-not-useful a.js-close-form').click();
+    })
 
+    it("hides the form", function() {
+      expect($('.pub-c-feedback #page-is-not-useful')).toHaveClass('js-hidden');
+    });
+
+    it("shows the prompt", function() {
+      expect($('.pub-c-feedback .js-prompt')).not.toHaveClass('js-hidden');
+    });
+
+    it("conveys that the feedback form is hidden", function() {
+      loadFeedbackComponent();
+
+      expect($('#page-is-not-useful.js-feedback-form').attr('aria-hidden')).toBe('true');
+    });
+
+    it("conveys that the form is not expanded", function () {
+      loadFeedbackComponent();
+
+      expect($('.js-page-is-not-useful').attr('aria-expanded')).toBe('false');
+      expect($('.js-something-is-wrong').attr('aria-expanded')).toBe('false');
+    });
+  })
+
+  describe("successfully submitting the 'is there anything wrong with this page' form", function () {
     beforeEach(function() {
       jasmine.Ajax.install();
     });
@@ -252,42 +311,39 @@ describe("Improve this page", function () {
         trackEvent: function() {}
       };
 
-      withGovukAnalytics(analytics, function () {
-        spyOn(GOVUK.analytics, 'trackEvent');
+      spyOn(GOVUK.analytics, 'trackEvent');
 
-        loadImproveThisPage();
-        fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
-        jasmine.Ajax.requests.mostRecent().respondWith({
-          status: 200,
-          contentType: 'text/plain',
-          responseText: ''
-        });
-
-        expect(GOVUK.analytics.trackEvent).
-          toHaveBeenCalledWith('improve-this-page', 'give-feedback');
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{ "message": "ok" }'
       });
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('manualFeedbackForm', 'ffFormSubmit');
     });
 
     it("submits the feedback to the feedback frontend", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       request = jasmine.Ajax.requests.mostRecent();
       expect(request.url).toBe('/contact/govuk/page_improvements');
       expect(request.method).toBe('POST');
       expect(request.data()).toEqual({
         url: ["http://example.com/path/to/page"],
-        description: ["The background should be green."],
-        name: ["Henry"],
-        email: ["henry@example.com"],
+        what_doing: ["I was looking for some information about local government."],
+        what_wrong: ["The background should be green."],
         user_agent: ["Safari"]
       });
     });
 
     it("displays a success message", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 200,
@@ -295,15 +351,114 @@ describe("Improve this page", function () {
         responseText: '{}'
       });
 
-      var $prompt = $('.pub-c-feedback .js-prompt');
+      var $success = $('.js-prompt-success');
+
+      expect($success).not.toHaveClass('js-hidden');
+      expect($success).toHaveText("Thanks for your feedback.");
+    });
+
+    it("focusses the success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect(document.activeElement).toBe($('.pub-c-feedback .js-prompt').get(0));
+    })
+
+    it("hides the form", function() {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('#something-is-wrong')).toHaveClass('js-hidden');
+    });
+
+    it("hides the links to show the feedback form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
+    });
+  });
+
+  describe("successfully submitting the 'page is not useful' form", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("triggers a Google Analytics event", function () {
+      var analytics = {
+        trackEvent: function() {}
+      };
+
+      spyOn(GOVUK.analytics, 'trackEvent');
+
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'text/plain',
+        responseText: '{ "message": "ok" }'
+      });
+
+      expect(GOVUK.analytics.trackEvent).
+        toHaveBeenCalledWith('user_satisfaction_survey', 'banner_taken');
+    });
+
+    it("submits the feedback to the feedback frontend", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      request = jasmine.Ajax.requests.mostRecent();
+      expect(request.url).toBe('/contact/govuk/email-survey-signup');
+      expect(request.method).toBe('POST');
+      expect(request.data()).toEqual({
+        url: ["http://example.com/path/to/page"],
+        'email_survey_signup[email_address]': ["test@test.com"],
+        user_agent: ["Safari"]
+      });
+    });
+
+    it("displays a success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $prompt = $('.js-prompt-success');
 
       expect($prompt).not.toHaveClass('js-hidden');
       expect($prompt).toHaveText("Thanks for your feedback.");
     });
 
-    if("focusses the success message", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+    it("focusses the success message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 200,
@@ -311,13 +466,12 @@ describe("Improve this page", function () {
         responseText: '{}'
       });
 
-      var $prompt = $('.pub-c-feedback .js-prompt');
-      expect(document.activeElement).toBe($prompt);
+      expect(document.activeElement).toBe($('.pub-c-feedback .js-prompt').get(0));
     })
 
     it("hides the form", function() {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 200,
@@ -328,9 +482,9 @@ describe("Improve this page", function () {
       expect($('.js-feedback-form')).toHaveClass('js-hidden');
     });
 
-    it("removes the links to show the feedback form", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+    it("hides the links to show the feedback form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 200,
@@ -338,11 +492,11 @@ describe("Improve this page", function () {
         responseText: '{}'
       });
 
-      expect($('.js-page-is-not-useful, .js-something-is-wrong').length).toBe(0);
+      expect($('.js-prompt-questions')).toHaveClass('js-hidden');
     });
   });
 
-  describe("Submitting a form with invalid data", function () {
+  describe("submitting the 'is something wrong with this page' form with invalid data", function () {
     beforeEach(function() {
       jasmine.Ajax.install();
     });
@@ -352,8 +506,8 @@ describe("Improve this page", function () {
     });
 
     it("disables the submit button until the server responds", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       expect($('.pub-c-feedback form [type=submit]')).toBeDisabled();
 
@@ -367,8 +521,8 @@ describe("Improve this page", function () {
     });
 
     it('retains the feedback the user originally entered', function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 422,
@@ -376,53 +530,13 @@ describe("Improve this page", function () {
         responseText: '{"errors": {"description": ["can\'t be blank"]}}'
       });
 
-      expect($('[name=description]').val()).toEqual('The background should be green.');
-      expect($('[name=name]').val()).toEqual('Henry');
-      expect($('[name=email]').val()).toEqual('henry@example.com');
-    });
-
-    it("displays validation errors in the label of each field", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
-      });
-
-      expect($('label[for=description-field]')).toContainText("Description can't be blank.");
-    });
-
-    it("marks fields with validation errors as invalid", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
-      });
-
-      expect($('[name=description]')).toHaveAttr('aria-invalid', 'true');
-    });
-
-    it("focusses the first form group if there are no generic errors", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
-      });
-
-      expect(document.activeElement).toBe($('[name=description]').get(0));
+      expect($('[name=what_doing]').val()).toEqual("I was looking for some information about local government.");
+      expect($('[name=what_wrong]').val()).toEqual("The background should be green.");
     });
 
     it("displays a generic error if the field isn't a visible part of the form", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 422,
@@ -430,37 +544,93 @@ describe("Improve this page", function () {
         responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
       });
 
-      expect($('.pub-c-feedback .js-error-summary')).toContainText("Path can't be blank. Another weird error.");
-    });
-
-    it("focusses the generic error if there is one", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
-      });
-
-      expect(document.activeElement).toBe($('.js-error-summary').get(0));
-    });
-
-    it("associates the error summary with its message so screen readers will read it when the div is focussed", function () {
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
-
-      jasmine.Ajax.requests.mostRecent().respondWith({
-        status: 422,
-        contentType: 'application/json',
-        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
-      });
-
-      var $genericErrorMessage = $('#generic-error-message');
-
-      expect($('.js-error-summary').attr('aria-labelledby')).toEqual(
-        $genericErrorMessage.attr('id')
+      expect($('#something-is-wrong .js-errors').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
       );
+    });
+
+    it("focusses the error message", function () {
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{}'
+      });
+
+      var $shouldBe = $('#something-is-wrong .js-errors').get(0);
+      expect(document.activeElement).toBe($shouldBe);
+    });
+  })
+
+  describe("Submitting the 'page is not useful' form with invalid data", function () {
+    beforeEach(function() {
+      jasmine.Ajax.install();
+    });
+
+    afterEach(function() {
+      jasmine.Ajax.uninstall();
+    });
+
+    it("disables the submit button until the server responds", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      expect($('.pub-c-feedback form [type=submit]')).toBeDisabled();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($('.pub-c-feedback form [type=submit]')).not.toBeDisabled();
+    });
+
+    it('retains the feedback the user originally entered', function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"description": ["can\'t be blank"]}}'
+      });
+
+      expect($("[name='email_survey_signup[email_address]']").val()).toEqual("test@test.com");
+    });
+
+    it("displays a generic error if the field isn't a visible part of the form", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "another": ["weird error"]}}'
+      });
+
+      expect($('#page-is-not-useful .js-errors').html()).toContainText(
+        'Sorry, we’re unable to receive your message right now. ' +
+        'If the problem persists, we have other ways for you to provide ' +
+        'feedback on the contact page.'
+      );
+    });
+
+    it("focusses the generic error", function () {
+      loadFeedbackComponent();
+      fillAndSubmitPageIsNotUsefulForm();
+
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 422,
+        contentType: 'application/json',
+        responseText: '{"errors": {"path": ["can\'t be blank"], "description": ["can\'t be blank"]}}'
+      });
+
+      expect(document.activeElement).toBe($('#page-is-not-useful .js-errors').get(0));
     });
   })
 
@@ -468,8 +638,8 @@ describe("Improve this page", function () {
     beforeEach(function() {
       jasmine.Ajax.install();
 
-      loadImproveThisPage();
-      fillAndSubmitFeedbackForm();
+      loadFeedbackComponent();
+      fillAndSubmitSomethingIsWrongForm();
 
       jasmine.Ajax.requests.mostRecent().respondWith({
         status: 500,
@@ -491,9 +661,8 @@ describe("Improve this page", function () {
     });
 
     it('retains the feedback the user originally entered', function () {
-      expect($('[name=description]').val()).toEqual('The background should be green.');
-      expect($('[name=name]').val()).toEqual('Henry');
-      expect($('[name=email]').val()).toEqual('henry@example.com');
+      expect($('[name=what_doing]').val()).toEqual('I was looking for some information about local government.');
+      expect($('[name=what_wrong]').val()).toEqual('The background should be green.');
     });
 
     it('re-enables the submit button', function () {
@@ -501,16 +670,23 @@ describe("Improve this page", function () {
     });
   })
 
-  function loadImproveThisPage () {
-    var improveThisPage = new GOVUK.Modules.ImproveThisPage();
-    improveThisPage.start($('.pub-c-feedback'));
+  function loadFeedbackComponent () {
+    var feedback = new GOVUK.Modules.Feedback();
+    feedback.start($('.pub-c-feedback'));
   }
 
-  function fillAndSubmitFeedbackForm () {
-    $form = $('.pub-c-feedback form');
-    $form.find("[name=description]").val("The background should be green.");
-    $form.find("[name=name]").val("Henry");
-    $form.find("[name=email]").val("henry@example.com");
+  function fillAndSubmitSomethingIsWrongForm () {
+    $('a.js-something-is-wrong').click();
+    $form = $('.pub-c-feedback #something-is-wrong');
+    $form.find("[name=what_doing]").val("I was looking for some information about local government.");
+    $form.find("[name=what_wrong]").val("The background should be green.");
+    $form.find("[type=submit]").click();
+  }
+
+  function fillAndSubmitPageIsNotUsefulForm () {
+    $('a.js-page-is-not-useful').click();
+    $form = $('.pub-c-feedback #page-is-not-useful');
+    $form.find("[name='email_survey_signup[email_address]']").val("test@test.com");
     $form.find("[type=submit]").click();
   }
 });

--- a/spec/javascripts/helpers/with_govuk_analytics.js
+++ b/spec/javascripts/helpers/with_govuk_analytics.js
@@ -1,0 +1,14 @@
+// Temporarily overrides GOVUK.analytics and returns it
+// to it's original state
+function withGovukAnalytics (analytics, callback) {
+  var original = GOVUK.analytics;
+  GOVUK.analytics = analytics;
+
+  callback();
+
+  if (original) {
+    GOVUK.analytics = original;
+  } else {
+    delete GOVUK.analytics;
+  }
+}

--- a/spec/javascripts/support/jasmine.yml
+++ b/spec/javascripts/support/jasmine.yml
@@ -8,6 +8,7 @@ src_dir: "app/assets/javascripts"
 src_files:
  - "../../../spec/javascripts/helpers/jquery-1.12.4.js"
  - "../../../spec/javascripts/helpers/jasmine-jquery-2.0.5.js"
+ - "../../../spec/javascripts/vendor/mock-ajax.js"
  - "../../../spec/javascripts/helpers/cookie-functions.js"
  - "application.js"
 

--- a/spec/javascripts/vendor/mock-ajax.js
+++ b/spec/javascripts/vendor/mock-ajax.js
@@ -1,0 +1,774 @@
+/*
+
+Jasmine-Ajax - v3.2.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+//Module wrapper to support both browser and CommonJS environment
+(function (root, factory) {
+    if (typeof exports === 'object' && typeof exports.nodeName !== 'string') {
+        // CommonJS
+        var jasmineRequire = require('jasmine-core');
+        module.exports = factory(root, function() {
+            return jasmineRequire;
+        });
+    } else {
+        // Browser globals
+        window.MockAjax = factory(root, getJasmineRequireObj);
+    }
+}(typeof window !== 'undefined' ? window : global, function (global, getJasmineRequireObj) {
+
+//
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.event = jRequire.AjaxEvent();
+  $ajax.eventBus = jRequire.AjaxEventBus($ajax.event);
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEvent = function() {
+  function now() {
+    return new Date().getTime();
+  }
+
+  function noop() {
+  }
+
+  // Event object
+  // https://dom.spec.whatwg.org/#concept-event
+  function XMLHttpRequestEvent(xhr, type) {
+    this.type = type;
+    this.bubbles = false;
+    this.cancelable = false;
+    this.timeStamp = now();
+
+    this.isTrusted = false;
+    this.defaultPrevented = false;
+
+    // Event phase should be "AT_TARGET"
+    // https://dom.spec.whatwg.org/#dom-event-at_target
+    this.eventPhase = 2;
+
+    this.target = xhr;
+    this.currentTarget = xhr;
+  }
+
+  XMLHttpRequestEvent.prototype.preventDefault = noop;
+  XMLHttpRequestEvent.prototype.stopPropagation = noop;
+  XMLHttpRequestEvent.prototype.stopImmediatePropagation = noop;
+
+  function XMLHttpRequestProgressEvent() {
+    XMLHttpRequestEvent.apply(this, arguments);
+
+    this.lengthComputable = false;
+    this.loaded = 0;
+    this.total = 0;
+  }
+
+  // Extend prototype
+  XMLHttpRequestProgressEvent.prototype = XMLHttpRequestEvent.prototype;
+
+  return {
+    event: function(xhr, type) {
+      return new XMLHttpRequestEvent(xhr, type);
+    },
+
+    progressEvent: function(xhr, type) {
+      return new XMLHttpRequestProgressEvent(xhr, type);
+    }
+  };
+};
+getJasmineRequireObj().AjaxEventBus = function(eventFactory) {
+  function EventBus(source) {
+    this.eventList = {};
+    this.source = source;
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var evt;
+
+    // Event 'readystatechange' is should be a simple event.
+    // Others are progress event.
+    // https://xhr.spec.whatwg.org/#events
+    if (event === 'readystatechange') {
+      evt = eventFactory.event(this.source, event);
+    } else {
+      evt = eventFactory.progressEvent(this.source, event);
+    }
+
+    var eventListeners = this.eventList[event];
+
+    if (eventListeners) {
+      for (var i = 0; i < eventListeners.length; i++) {
+        eventListeners[i].call(this.source, evt);
+      }
+    }
+  };
+
+  return function(source) {
+    return new EventBus(source);
+  };
+};
+
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName].apply(xhr, arguments);
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('readystatechange', wrapProgressEvent(xhr, 'onreadystatechange'));
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory(this);
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout', 'responseURL'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1];
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = 1;
+        this.requestHeaders = {};
+        this.eventBus.trigger('readystatechange');
+      },
+
+      setRequestHeader: function(header, value) {
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "abort";
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: 0,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+      onreadystatechange: null,
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.eventBus.trigger('loadstart');
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+
+        this.dispatchStub(stub);
+      },
+
+      dispatchStub: function(stub) {
+        if (stub) {
+          if (stub.isReturn()) {
+            this.respondWith(stub);
+          } else if (stub.isError()) {
+            this.responseError();
+          } else if (stub.isTimeout()) {
+            this.responseTimeout();
+          } else if (stub.isCallFunction()) {
+            this.responseCallFunction(stub);
+          }
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        name = name.toLowerCase();
+        var resultHeader;
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+      responseURL: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= 3 ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.readyState = 2;
+        this.eventBus.trigger('readystatechange');
+
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.responseURL = response.responseURL || null;
+        this.readyState = 4;
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        jasmine.clock().tick(30000);
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        this.eventBus.trigger('readystatechange');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseCallFunction: function(stub) {
+        stub.action = undefined;
+        stub.functionToCall(stub, this);
+        this.dispatchStub(stub);
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest === mockAjaxFunction) {
+        throw "MockAjax is already installed.";
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      if (global.XMLHttpRequest !== mockAjaxFunction) {
+        throw "MockAjax not installed.";
+      }
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  var RETURN = 0,
+      ERROR = 1,
+      TIMEOUT = 2,
+      CALL = 3;
+
+  function RequestStub(url, stubData, method) {
+    var normalizeQuery = function(query) {
+      return query ? query.split('&').sort().join('&') : undefined;
+    };
+
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = (stubData instanceof RegExp) ? stubData : normalizeQuery(stubData);
+    this.method = method;
+
+    this.andReturn = function(options) {
+      this.action = RETURN;
+      this.status = options.status || 200;
+
+      this.contentType = options.contentType;
+      this.response = options.response;
+      this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
+      this.responseURL = options.responseURL;
+    };
+
+    this.isReturn = function() {
+      return this.action === RETURN;
+    };
+
+    this.andError = function() {
+      this.action = ERROR;
+    };
+
+    this.isError = function() {
+      return this.action === ERROR;
+    };
+
+    this.andTimeout = function() {
+      this.action = TIMEOUT;
+    };
+
+    this.isTimeout = function() {
+      return this.action === TIMEOUT;
+    };
+
+    this.andCallFunction = function(functionToCall) {
+      this.action = CALL;
+      this.functionToCall = functionToCall;
+    };
+
+    this.isCallFunction = function() {
+      return this.action === CALL;
+    };
+
+    this.matches = function(fullUrl, data, method) {
+      var urlMatches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        urlMatches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        urlMatches = this.url === url && this.query === normalizeQuery(query);
+      }
+      var dataMatches = false;
+      if (this.data instanceof RegExp) {
+        dataMatches = this.data.test(data);
+      } else {
+        dataMatches = !this.data || this.data === normalizeQuery(data);
+      }
+      return urlMatches && dataMatches && (!this.method || this.method === method);
+    };
+  }
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+
+    var jRequire = getJasmineRequireObj();
+    var MockAjax = jRequire.ajax(jRequire);
+    jasmine.Ajax = new MockAjax(global);
+
+    return MockAjax;
+}));

--- a/test/govuk_component/feedback_test.rb
+++ b/test/govuk_component/feedback_test.rb
@@ -1,0 +1,20 @@
+require 'govuk_component_test_helper'
+
+class FeedbackTestCase < ComponentTestCase
+  def component_name
+    "feedback"
+  end
+
+  test "asks the user if the page is useful without javascript enabled" do
+    render_component({})
+
+    assert_select ".pub-c-feedback .pub-c-feedback__prompt-link--useful[href='/contact/govuk']", text: 'Yes this page is useful'
+    assert_select ".pub-c-feedback .pub-c-feedback__prompt-link.js-page-is-not-useful[href='/contact/govuk']", text: 'No this page is not useful'
+  end
+
+  test "asks the user if there is anything wrong with the page without javascript enabled" do
+    render_component({})
+
+    assert_select ".pub-c-feedback .pub-c-feedback__prompt-link--wrong[href='/contact/govuk']", text: 'Is there anything wrong with this page?'
+  end
+end


### PR DESCRIPTION
**This PR has been superseded by https://github.com/alphagov/govuk_publishing_components/pull/163**

---

Build the new feedback form to go at the foot of all GOV.UK pages. This is based on the code from the Service Manual but with some changes, as this version requires additional functionality.

Ultimately this component will be moved to the publishing components gem, but I started building it in static so getting it reviewed here because the commit history might prove useful to that.

Initial state:

![screen shot 2018-02-06 at 14 58 57](https://user-images.githubusercontent.com/861310/35866143-4c06d9c2-0b4e-11e8-92c8-ef46f4a21191.png)

Users have three options:

1. click 'yes' (page is useful) records a GA event and shows a 'thanks for your feedback' message
2. click 'no' (page is not useful) opens a form to take an email address to send a link to a survey to. This is a rework of the form that currently appears underneath the header of GOV.UK for some users at some times (you can trigger this by visiting GOV.UK and running GOVUK.userSurveys.displaySurvey(GOVUK.userSurveys.defaultSurvey) in the browser console)
3. click 'is there anything wrong with this page?' opens a feedback form. This is a rework of the existing feedback form at the foot of GOV.UK

**Result of option 1 (and the others, if submitted successfully):**

![screen shot 2018-02-06 at 15 02 41](https://user-images.githubusercontent.com/861310/35866325-cdcb9268-0b4e-11e8-852b-e2564114ce6b.png)

**'Page is not useful' form:**

![screen shot 2018-02-06 at 15 03 31](https://user-images.githubusercontent.com/861310/35866363-ec492160-0b4e-11e8-8a2e-557e5ab9b61a.png)

**'Something wrong with page' form:**

![screen shot 2018-02-06 at 15 04 01](https://user-images.githubusercontent.com/861310/35866387-fe5f101c-0b4e-11e8-9a49-2630afa35c08.png)

If javascript is disabled, this form should be the only element that appears, and should still function.

- [Trello card](https://trello.com/c/oRLXhaTU/155-make-the-service-manual-feedback-pattern-a-component)
- [Component guide](https://govuk-static-pr-1235.herokuapp.com/component-guide/feedback)