### PR TITLE
Remove survey earlier than expiration date

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -236,19 +236,6 @@
         }
       },
       {
-        identifier: 'treetest_01',
-        surveyType: 'url',
-        frequency: 6,
-        startTime: new Date('December 20, 2017').getTime(),
-        endTime: new Date('January 15, 2018 23:59:50').getTime(),
-        url: 'https://GDSUserResearch.optimalworkshop.com/treejack/82p1e0a6-0',
-        templateArgs: {
-          title: 'Help us make things easier to find on GOV.UK',
-          surveyCta: 'Answer 3 quick questions.',
-          surveyCtaPostscript: 'This link will open in a new tab.'
-        }
-      },
-      {
         identifier: 'tls_survey',
         surveyType: 'url',
         frequency: 1,


### PR DESCRIPTION
It's been requested that we remove the "Treejack" survey earlier than the expiration date. 