### PR TITLE
Compile assets into the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,6 @@ RUN bundle install
 
 ADD . $APP_HOME
 
+RUN RAILS_ENV=production bundle exec rails assets:precompile
+
 CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"


### PR DESCRIPTION
We use the docker image as part of the publishing end to end tests.
We also run the publishing-e2e-tests in Rails production mode, so
want to pre-compile the assets in the same way that production will.