### PR TITLE
Add CTTUK tree test survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -286,6 +286,39 @@
           surveyFailure: 'Sorry, we’re unable to send you an email right now. Please try again later.'
         },
         allowedOnMobile: true
+      },
+      {
+        identifier: 'CTTUK_Professionals_Personal',
+        surveyType: 'url',
+        frequency: 3,
+        startTime: new Date('February 7, 2018').getTime(),
+        endTime: new Date('February 10, 2018').getTime(),
+        url: 'https://GDSUserResearch.optimalworkshop.com/treejack/82p1e0a6-0-0-1-0-0?c={{currentPath}}',
+        templateArgs: {
+          title: 'Help us make things easier to find on GOV.UK',
+          surveyCta: 'Answer 3 quick questions.',
+          surveyCtaPostscript: 'This activity will open in a separate window.'
+        },
+        activeWhen: {
+          path: [
+            '^/browse/visas-immigration(?:/|$)',
+            '^/call-charges$',
+            '^/when-do-the-clocks-change$',
+            '^/guidance/immigration-rules$'
+          ],
+          organisation: [
+            '<OT554>', // UK Visas and Immigration
+            '<PB263>', // Office of the Immigration Services Commissioner
+            '<PB275>', // Migration Advisory Committee
+            '<OT535>', // Border Force
+            '<OT1069>', // Immigration Enforcement
+            '<EA67>', // UK Border Agency
+            '<OT885>', // Identity and Passport Service
+            '<EA66>', // HM Passport Office
+            '<OT284>' // Independent Chief Inspector of Borders and Immigration
+          ]
+        },
+        allowedOnMobile: true
       }
     ],
 


### PR DESCRIPTION
https://trello.com/c/jh8HyMZB/120-launch-a-survey-for-tree-testing

The original requirements for this survey was that it should appear on
/browse/visa-immigration and 2641 other unique paths. However, it was
unfeasible to include this list of paths in the survey.js file, which
would considerably increase the size of the file (from ~32kB to 296kB).

As an alternative approach, we have chosen a subset of organisations and
a handful of paths that receive a high volume of pageviews but would not
be covered by the organisations, for this survey to active on.

---

Deployed to integration:

![screen shot 2018-02-07 at 13 14 45](https://user-images.githubusercontent.com/885223/35918259-163a6e38-0c09-11e8-9015-6ebea83a94c7.png)

with the link as `https://gdsuserresearch.optimalworkshop.com/treejack/82p1e0a6-0-0-1-0-0?c=/browse/visas-immigration&gcl=1059145684.1518009280`