### PR TITLE
Add tracking attributes to button component

### DIFF
--- a/app/views/govuk_component/button.raw.html.erb
+++ b/app/views/govuk_component/button.raw.html.erb
@@ -4,28 +4,22 @@
   info_text ||= false
   rel ||= false
   text ||= ""
-  tag_name = href ? "a" : "button"
   margin_bottom ||= false
+  data_attributes ||= false
+  css_classes = %w(pub-c-button)
+  css_classes << "pub-c-button--start" if start
+  css_classes << "pub-c-button--bottom-margin" if margin_bottom
+  css_classes = css_classes.join(" ")
+  html_options = { class: css_classes }
+  html_options[:role] = "button" if href
+  html_options[:rel] = rel if rel
+  html_options[:data] = data_attributes if data_attributes
 %>
-<<%= tag_name %>
-  class="
-    pub-c-button
-    <% if start == true %>
-      pub-c-button--start
-    <% end %>
-    <%= " pub-c-button--bottom-margin" if margin_bottom %>
-  "
-  <% if href %>
-    href="<%= href.try(:html_safe) %>"
-    role="button"
-  <% end %>
-
-  <% if rel %>
-    rel="<%= rel %>"
-  <% end %>
->
-  <%= text %>
-</<%= tag_name %>>
+<% if href %>
+  <%= link_to(text, href.try(:html_safe), html_options) %>
+<% else %>
+  <%= button_tag(text, html_options) %>
+<% end %>
 <% if info_text %>
   <span class="pub-c-button__info-text">
     <%= info_text.try(:html_safe) %>

--- a/app/views/govuk_component/docs/button.yml
+++ b/app/views/govuk_component/docs/button.yml
@@ -62,3 +62,12 @@ examples:
       text: "I'm a start now button with lots of text to test how the component scales at extremes."
       start: true
       href: "#"
+  with_data_attributes:
+    data:
+      text: "Track this!"
+      margin_bottom: true
+      data_attributes: {
+        "module": "cross-domain-tracking",
+        "tracking-code": "GA-123ABC",
+        "tracking-name": "transactionTracker"
+      }

--- a/test/govuk_component/button_test.rb
+++ b/test/govuk_component/button_test.rb
@@ -64,4 +64,35 @@ class ButtonTestCase < ComponentTestCase
     render_component(text: "Submit", margin_bottom: true)
     assert_select ".pub-c-button.pub-c-button--bottom-margin", text: "Submit"
   end
+
+  test "renders data attributes correctly for buttons" do
+    render_component(
+      text: "Submit",
+      data_attributes: {
+        "module": "cross-domain-tracking",
+        "tracking-code": "GA-123ABC",
+        "tracking-name": "transactionTracker"
+      }
+    )
+
+    assert_select "button.pub-c-button[data-module='cross-domain-tracking']"
+    assert_select "button.pub-c-button[data-tracking-code='GA-123ABC']"
+    assert_select "button.pub-c-button[data-tracking-name='transactionTracker']"
+  end
+
+  test "renders data attributes correctly for links" do
+    render_component(
+      text: "Submit",
+      href: "/foo",
+      data_attributes: {
+        "module": "cross-domain-tracking",
+        "tracking-code": "GA-123ABC",
+        "tracking-name": "transactionTracker"
+      }
+    )
+
+    assert_select "a.pub-c-button[data-module='cross-domain-tracking']"
+    assert_select "a.pub-c-button[data-tracking-code='GA-123ABC']"
+    assert_select "a.pub-c-button[data-tracking-name='transactionTracker']"
+  end
 end


### PR DESCRIPTION
Part of https://trello.com/c/3VwTvDrj/256-use-button-component-in-frontend-formats

Updates the button component to accept `extra_attrs`, primarily to support data attributes for tracking eg. https://github.com/alphagov/frontend/blob/master/app/views/transaction/show.html.erb#L22
This should allow us to use the component for Frontend app buttons.

I've refactored this to use Rails `link_to` and `button_tag` helpers as it seemed less noisy.