### PR TITLE
Foreman dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
+RUN gem install foreman
 
 ENV GOVUK_APP_NAME static
 ENV RAILS_ENV development
@@ -18,4 +19,4 @@ ADD . $APP_HOME
 
 RUN RAILS_ENV=production bundle exec rails assets:precompile
 
-CMD bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p $PORT -b '0.0.0.0'"
+CMD foreman run web

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: PLEK_SERVICE_STATIC_URI=${HEROKU_APP_NAME}.herokuapp.com GOVUK_ASSET_ROOT=https://${HEROKU_APP_NAME}.herokuapp.com bin/rails server -p $PORT -e $RAILS_ENV
+web: bin/rails server -p $PORT -e $RAILS_ENV

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: bin/rails server -p $PORT -e $RAILS_ENV
+web: bundle exec unicorn -c ./config/unicorn.rb -p ${PORT:-3013}

--- a/app.json
+++ b/app.json
@@ -5,9 +5,6 @@
     "GOVUK_APP_DOMAIN": {
       "value": "www.gov.uk"
     },
-    "GOVUK_ASSET_ROOT": {
-      "value": "https://govuk-static.herokuapp.com"
-    },
     "GOVUK_WEBSITE_ROOT": {
       "value": "https://www.gov.uk"
     },

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,14 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  # Set GOVUK_ASSET_ROOT & PLEK_SERVICE_STATIC_URI for heroku - for review
+  # apps we have the hostname set at the time of the app being built so can't
+  # be set up in the app.json
+  if ENV["HEROKU_APP_NAME"]
+    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("GOVUK_ASSET_ROOT")
+    ENV["PLEK_SERVICE_STATIC_URI"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("PLEK_SERVICE_STATIC_URI")
+  end
+
   # Code is not reloaded between requests
   config.cache_classes = true
 


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This PR adds foreman as a gem dependency of docker (as per [foreman instructions](https://github.com/ddollar/foreman#installation)) as the means to run the processes for this app.

It also changes the Procfile configuration to allow this app to be run using it outside of a heroku context.