### PR TITLE
Show the browser-upgrade banner for old TLS versions

### DIFF
--- a/app/assets/javascripts/browser-check.js
+++ b/app/assets/javascripts/browser-check.js
@@ -15,12 +15,21 @@ $(function() {
 
   // we don't show the message when the cookie warning is also there
   if (GOVUK.cookie('seen_cookie_message')) {
-    if (suchi.isOld(navigator.userAgent)) {
+    var tlsCookie = GOVUK.getCookie('TLSversion');
+    var tlsIsOld = (tlsCookie == 'TLSv1' || tlsCookie == 'TLSv1.1');
+    var browserIsOld = suchi.isOld(navigator.userAgent);
+
+    if (browserIsOld || tlsIsOld) {
       if(GOVUK.cookie('govuk_not_first_visit') !== null && GOVUK.cookie('govuk_browser_upgrade_dismissed') === null){
         var $prompt = browserWarning();
         $('#global-cookie-message').after($prompt);
         $prompt.show();
+
         GOVUK.analytics.trackEvent('browser-check', 'prompt-shown', {value: 1, nonInteraction: true});
+        if (tlsIsOld && !browserIsOld) {
+          GOVUK.analytics.trackEvent('browser-check', 'prompt-shown-tls', {value: 1, nonInteraction: true});
+        }
+
         $prompt.on("click", ".dismiss", function(e) {
           $prompt.hide();
           // the warning is dismissable for 4 weeks, for users who are not in a


### PR DESCRIPTION
To encourage people using browsers that don't support TLS1.2, we're going to start showing the upgrade banner in those cases. For now we'll use the same generic messaging until we've got something better / more specific.

Also pings a new browser-check/prompt-shown-tls GA event to allow us to see how many people we're showing this to who wouldn't have seen it otherwise.