### PR TITLE
Extends the duration for HMRC surveys

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -230,7 +230,7 @@
         surveyType: 'url',
         frequency: 5,
         startTime: new Date('February 14, 2018').getTime(),
-        endTime: new Date('March 16, 2018').getTime(),
+        endTime: new Date('May 14, 2018').getTime(),
         url: hmrcSurveysFeb2018Url(),
         templateArgs: {
           title: 'Get involved in making government services better',


### PR DESCRIPTION
Initially this was one month, but it's actually going to last for 3 months, between Feb 14 to May 14 2018.

For: https://trello.com/c/Wz9ppQon/72-1-govuk-survey-hmrc-expires-march-16-2018