### PR TITLE
Add inverse flag to breadcrumbs component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
+++ b/app/assets/stylesheets/govuk-component/_breadcrumbs.scss
@@ -1,6 +1,7 @@
 // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/design-patterns/_breadcrumbs.scss
 @import "design-patterns/breadcrumbs";
 
+
 .govuk-breadcrumbs {
   // reset the default browser styles
   ol {
@@ -33,4 +34,12 @@
       }
     }
   }
+}
+
+.govuk-breadcrumbs--inverse a {
+  color: $white;
+}
+
+.breadcrumb-for-current-page--inverse a {
+  color: $white;
 }

--- a/app/views/govuk_component/breadcrumbs.raw.html.erb
+++ b/app/views/govuk_component/breadcrumbs.raw.html.erb
@@ -1,11 +1,12 @@
 <%
   breadcrumbs ||= []
   collapse_on_mobile ||= false
+  inverse ||= false
+  collapse_class =  collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } ? "collapse-on-mobile" : ""
+  invert_class = inverse ? "govuk-breadcrumbs--inverse" : ""
 %>
 
-<div
-  class="govuk-breadcrumbs <%= "collapse-on-mobile" if collapse_on_mobile && breadcrumbs.any? { |crumb| crumb[:is_page_parent] } %>"
-  data-module="track-click">
+<div class="govuk-breadcrumbs <%= invert_class %> <%= collapse_class %>" data-module="track-click">
   <ol>
   <% breadcrumbs.each_with_index do |crumb, index| %>
     <%
@@ -13,6 +14,7 @@
       path = crumb[:is_current_page] ? '#content' : crumb[:url]
       aria_current = crumb[:is_current_page] ? 'page' : 'false'
       css_class = crumb[:is_current_page] ? 'breadcrumb-for-current-page' : ''
+      css_class << 'breadcrumb-for-current-page--inverse' if inverse && crumb[:is_current_page]
     %>
 
     <li class='<%= "parent-breadcrumb" if crumb[:is_page_parent] %>'>

--- a/app/views/govuk_component/docs/breadcrumbs.yml
+++ b/app/views/govuk_component/docs/breadcrumbs.yml
@@ -4,6 +4,9 @@ body: |
   Accepts an array of breadcrumb objects. Each crumb must have a title and a URL.
 shared_accessibility_criteria:
   - link
+accessibility_criteria:
+  The breadcrumb links must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA
+  (this especially applies when using the inverse flag).
 examples:
   default:
     data:
@@ -12,6 +15,19 @@ examples:
         url: '/section'
       - title: 'Sub-section'
         url: '/section/sub-section'
+  inverse:
+    description: On a dark background
+    data:
+      breadcrumbs:
+      - title: 'Section'
+        url: '/section'
+      - title: 'Sub-section'
+        url: '/section/sub-section'
+        title: 'Education of disadvantaged children'
+        is_current_page: true
+      inverse: true
+    context:
+      dark_background: true
   no_breadcrumbs:
     data:
       breadcrumbs: []

--- a/test/govuk_component/breadcrumbs_test.rb
+++ b/test/govuk_component/breadcrumbs_test.rb
@@ -64,6 +64,16 @@ class BreadcrumbsTestCase < ComponentTestCase
     assert_link_with_text_in('ol li:last-child', '/sub-section', 'Sub-section')
   end
 
+  test "renders inverted breadcrumbs when passed a flag" do
+    render_component(breadcrumbs: [
+        { title: 'Home', url: '/' },
+        { title: 'Section', url: '/section' },
+        inverse: true
+      ])
+
+    assert_select "div.govuk-breadcrumbs--inverse"
+  end
+
   test "allows the last breadcrumb to be text only" do
     render_component(
       breadcrumbs: [


### PR DESCRIPTION
This allows breadcrumbs to be rendered in white so they can be used on blue backgrounds in Topic pages. 
![screen shot 2018-03-07 at 14 14 44](https://user-images.githubusercontent.com/31649453/37096876-f6fa0b4a-2211-11e8-8f3a-39f32fcf5667.png)

Component guide: https://govuk-static-pr-1321.herokuapp.com/component-guide/breadcrumbs