### PR TITLE
Resolve conflicting surveys

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -184,34 +184,6 @@
         allowedOnMobile: true
       },
       {
-        identifier: 'GOVUK_content_pages_design_survey_1',
-        surveyType: 'url',
-        frequency: 6,
-        startTime: new Date('March 9, 2018').getTime(),
-        endTime: new Date('March 28, 2018, 23:59:59').getTime(),
-        url: 'https://gdsuserresearch.optimalworkshop.com/chalkmark/jz75j0uv',
-        templateArgs: {
-          title: 'Help us make things easier to find on GOV.UK',
-          surveyCta: 'Complete a quick activity',
-          surveyCtaPostscript: 'This activity will open in a separate window.'
-        },
-        allowedOnMobile: true
-      },
-      {
-        identifier: 'GOVUK_content_pages_design_survey_2',
-        surveyType: 'url',
-        frequency: 6,
-        startTime: new Date('March 9, 2018').getTime(),
-        endTime: new Date('March 28, 2018, 23:59:59').getTime(),
-        url: 'https://gdsuserresearch.optimalworkshop.com/chalkmark/twn1i3yt',
-        templateArgs: {
-          title: 'Help us make things easier to find on GOV.UK',
-          surveyCta: 'Complete a quick activity',
-          surveyCtaPostscript: 'This activity will open in a separate window.'
-        },
-        allowedOnMobile: true
-      },
-      {
         identifier: 'Transport_iteration_4',
         surveyType: 'url',
         frequency: 3,


### PR DESCRIPTION
There are two GOV.UK Content Pages Design surveys that are currently
planned to show across the whole of GOV.UK until the end of March.
However, since releasing the CTTUK v10 survey, these three surveys will
potentially conflict with one another, especially given the frequency
and similarity of banner details.

After confirming with the user researchers on the Taxonomy team (Ariana)
and the Content Pages team (Imeh), we have decided to pause the two
Content Pages surveys until they require participants again.