### PR TITLE
Add stepnavs to GA custom dimension 96

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -186,7 +186,7 @@ GEM
       mini_portile2 (~> 2.3.0)
     null_logger (0.0.1)
     parallel (1.12.1)
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     plek (2.1.1)

--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -58,7 +58,8 @@
       'taxon-slugs': {dimension: 58, defaultValue: 'other'},
       'taxon-ids': {dimension: 59, defaultValue: 'other'},
       'content-has-history': {dimension: 39, defaultValue: 'false'},
-      'navigation-legacy': {dimension: 30, defaultValue: 'none'}
+      'navigation-legacy': {dimension: 30, defaultValue: 'none'},
+      'stepnavs': {dimension: 96}
     };
 
     var $metas = $('meta[name^="govuk:"]');

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -104,7 +104,7 @@
 
   stepnavs = links_hash[:part_of_step_navs] || []
   stepnavs_content = stepnavs.map { |stepnav| stepnav[:content_id] }.join(",")
-  meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content
+  meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content.present?
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">

--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -101,6 +101,10 @@
   end
 
   meta_tags["govuk:static-analytics:strip-postcodes"] = "true" if should_strip_postcode_pii?(content_item_hash, local_assigns)
+
+  stepnavs = links_hash[:part_of_step_navs] || []
+  stepnavs_content = stepnavs.map { |stepnav| stepnav[:content_id] }.join(",")
+  meta_tags["govuk:stepnavs"] = stepnavs_content if stepnavs_content
 %>
 <% meta_tags.each do |name, content| %>
   <meta name="<%= name %>" content="<%= content %>">


### PR DESCRIPTION
A page can be part of none, one or multiple step by step navigations.
The GA custom dimension 96 should include all step navs the current page is part of in order to be able to differentiate specific step nav elements which might appear in more than one step nav.

[Trello card](https://trello.com/c/QCdTZ8cg)