### PR TITLE
Add tracking module to next/prev component

### DIFF
--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -4,10 +4,18 @@
   role="navigation"
   aria-label="<%= t("govuk_component.previous_and_next_navigation.pagination", default: "Pagination") %>"
 >
-  <ul class="pub-c-pagination__list">
+  <ul class="pub-c-pagination__list" data-module="track-click">
     <% if local_assigns.include?(:previous_page) %>
       <li class="pub-c-pagination__item pub-c-pagination__item--previous">
-        <a href="<%= previous_page[:url] %>" class="pub-c-pagination__link" rel="prev">
+        <a href="<%= previous_page[:url] %>"
+          class="pub-c-pagination__link"
+          rel="prev"
+          data-track-category="contentsClicked"
+          data-track-action="previous"
+          data-track-label="<%= previous_page[:url] %>"
+          data-track-dimension="previous"
+          data-track-dimension-index="29"
+        >
           <span class="pub-c-pagination__link-title">
             <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">
               <path fill="currentColor" d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"/>
@@ -23,7 +31,15 @@
     <% end %>
     <% if local_assigns.include?(:next_page) %>
       <li class="pub-c-pagination__item pub-c-pagination__item--next">
-        <a href="<%= next_page[:url] %>" class="pub-c-pagination__link" rel="next">
+        <a href="<%= next_page[:url] %>"
+          class="pub-c-pagination__link"
+          rel="next"
+          data-track-category="contentsClicked"
+          data-track-action="next"
+          data-track-label="<%= next_page[:url] %>"
+          data-track-dimension="next"
+          data-track-dimension-index="29"
+        >
           <span class="pub-c-pagination__link-title">
             <%= next_page[:title] %>
             <svg class="pub-c-pagination__link-icon" xmlns="http://www.w3.org/2000/svg" height="13" width="17" viewBox="0 0 17 13">


### PR DESCRIPTION
Uses the standard tracking module.

Can be tested here: https://govuk-static-pr-1359.herokuapp.com/component-guide/previous_and_next_navigation

Trello card: https://trello.com/c/y3aYUbL1/519-add-previous-next-tracking-to-mainstream-guide-content-click-events