### PR TITLE
[DO NOT MERGE] BEM the search component

### DIFF
--- a/app/assets/stylesheets/govuk-component/_search.scss
+++ b/app/assets/stylesheets/govuk-component/_search.scss
@@ -1,14 +1,14 @@
-.govuk-search {
+.pub-c-search {
   position: relative;
   margin-bottom: 30px;
 
   $input-size: 40px;
 
-  .search-label {
+  .pub-c-search__label {
     display: block;
   }
 
-  .search-input {
+  .pub-c-search__input {
     padding: 6px;
     margin: 0.5em 0;
     width: 100%;
@@ -21,7 +21,7 @@
     @include appearance(none);
   }
 
-  .search-submit {
+  .pub-c-search__submit {
     padding: 6px;
     border: 0;
     cursor: pointer;
@@ -31,7 +31,7 @@
   // IE6 + IE7 always get the simplest version, regardless of whether javascript is enabled
   @if ($is-ie == false) or ($ie-version >= 8) {
     .js-enabled & {
-      .search-label {
+      .pub-c-search__label {
         position: absolute;
         left: 15px;
         top: 1px;
@@ -41,20 +41,20 @@
       }
     }
 
-    .search-wrapper {
+    .pub-c-search__item-wrapper {
       display: table;
       width: 100%;
       background: $white;
     }
 
     //general class applied to search input and button wrapper
-    .search-element {
+    .pub-c-search__item {
       position: relative;
       display: table-cell;
       vertical-align: top;
     }
 
-    .search-input {
+    .pub-c-search__input {
       margin: 0;
 
       // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
@@ -64,11 +64,11 @@
       }
     }
 
-    .search-submit-wrapper {
+    .pub-c-search__submit-wrapper {
       width: 1%;
     }
 
-    .search-submit {
+    .pub-c-search__submit {
       position: relative;
       padding: 0;
       width: $input-size;
@@ -94,12 +94,12 @@
     }
   }
 
-  &.on-govuk-blue {
-    .search-label {
+  &.pub-c-search--on-govuk-blue {
+    .pub-c-search__label {
       color: $white;
     }
 
-    .search-submit {
+    .pub-c-search__submit {
       background-color: $black;
       color: $white;
 
@@ -110,7 +110,7 @@
 
     @if ($is-ie == false) or ($ie-version >= 8) {
       .js-enabled & {
-        .search-label {
+        .pub-c-search__label {
           color: $secondary-text-colour;
         }
       }
@@ -118,16 +118,16 @@
   }
 
 
-  &.on-white {
-    .search-label {
+  &.pub-c-search--on-white {
+    .pub-c-search__label {
       color: $black;
     }
 
-    .search-input {
+    .pub-c-search__input {
       border: solid 1px $grey-2;
     }
 
-    .search-submit {
+    .pub-c-search__submit {
       background-color: $light-blue;
       color: $white;
 
@@ -137,30 +137,30 @@
     }
 
     @if ($is-ie == false) or ($ie-version >= 8) {
-      .search-input {
+      .pub-c-search__input {
         border-right: 0;
       }
 
       .js-enabled & {
-        .search-label {
+        .pub-c-search__label {
           color: $secondary-text-colour;
         }
       }
     }
   }
 
-  &.search-large {
+  &.pub-c-search--large {
     $input-size: 50px;
 
-    .search-label {
+    .pub-c-search__label {
       @include core-19($line-height: $input-size, $line-height-640: $input-size);
     }
 
-    .search-input {
+    .pub-c-search__input {
       height: $input-size;
     }
 
-    .search-submit {
+    .pub-c-search__submit {
       width: $input-size;
       height: $input-size;
       background-position: 8px 50%;
@@ -172,8 +172,8 @@
     }
   }
 
-  &.search-separate-label {
-    .search-label {
+  &.pub-c-search--separate-label {
+    .pub-c-search__label {
       position: relative;
       left: auto;
     }

--- a/app/assets/stylesheets/govuk-component/_search.scss
+++ b/app/assets/stylesheets/govuk-component/_search.scss
@@ -1,181 +1,182 @@
+$input-size: 40px;
+$large-input-size: 50px;
+
 .pub-c-search {
   position: relative;
   margin-bottom: 30px;
+}
 
-  $input-size: 40px;
+.pub-c-search__label {
+  display: block;
+}
 
-  .pub-c-search__label {
-    display: block;
+.pub-c-search__input[type="search"] { // overly specific to prevent some overrides from outside
+  @include box-sizing(border-box);
+  @include core-19($line-height: (28 / 19), $line-height-640: (28 / 16));
+  @include appearance(none);
+
+  padding: 6px;
+  margin: 0.5em 0;
+  width: 100%;
+  height: $input-size;
+  border: 0;
+  background: $white;
+  border-radius: 0; //otherwise iphones apply an automatic border radius
+}
+
+.pub-c-search__submit {
+  padding: 6px;
+  border: 0;
+  cursor: pointer;
+  border-radius: 0;
+}
+
+// IE6 + IE7 always get the simplest version, regardless of whether javascript is enabled
+@if ($is-ie == false) or ($ie-version >= 8) {
+  .js-enabled {
+    .pub-c-search__label {
+      @include core-19($line-height: $input-size, $line-height-640: $input-size);
+
+      position: absolute;
+      left: 15px;
+      top: 1px;
+      z-index: 1;
+      color: $secondary-text-colour;
+    }
   }
 
-  .pub-c-search__input {
-    padding: 6px;
-    margin: 0.5em 0;
+  .pub-c-search__item-wrapper {
+    display: table;
     width: 100%;
-    height: $input-size;
-    border: 0;
-    @include box-sizing(border-box);
-    @include core-19($line-height: (28 / 19), $line-height-640: (28 / 16));
     background: $white;
-    border-radius: 0; //otherwise iphones apply an automatic border radius
-    @include appearance(none);
+  }
+
+  //general class applied to search input and button wrapper
+  .pub-c-search__item {
+    position: relative;
+    display: table-cell;
+    vertical-align: top;
+  }
+
+  .pub-c-search__input[type="search"] {
+    margin: 0;
+
+    // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
+    &:focus,
+    &.focus {
+      z-index: 2;
+    }
+  }
+
+  .pub-c-search__submit-wrapper {
+    width: 1%;
   }
 
   .pub-c-search__submit {
-    padding: 6px;
-    border: 0;
-    cursor: pointer;
-    border-radius: 0;
+    position: relative;
+    padding: 0;
+    width: $input-size;
+    height: $input-size;
+    background-image: image-url("search-button.png");
+    background-repeat: no-repeat;
+    background-position: 2px 50%;
+    text-indent: -5000px;
+    overflow: hidden;
+
+    &:focus {
+      z-index: 2;
+    }
+
+    &::-moz-focus-inner {
+      border: 0;
+    }
+
+    @include device-pixel-ratio() {
+      background-size: 52.5px auto;
+      background-position: 115% 50%;
+    }
+  }
+}
+
+.pub-c-search--on-govuk-blue {
+  .pub-c-search__label {
+    color: $white;
   }
 
-  // IE6 + IE7 always get the simplest version, regardless of whether javascript is enabled
+  .pub-c-search__submit {
+    background-color: $black;
+    color: $white;
+
+    &:hover {
+      background-color: lighten($black, 5%);
+    }
+  }
+
   @if ($is-ie == false) or ($ie-version >= 8) {
     .js-enabled & {
       .pub-c-search__label {
-        position: absolute;
-        left: 15px;
-        top: 1px;
-        z-index: 1;
-        @include core-19($line-height: $input-size, $line-height-640: $input-size);
         color: $secondary-text-colour;
       }
     }
+  }
+}
 
-    .pub-c-search__item-wrapper {
-      display: table;
-      width: 100%;
-      background: $white;
-    }
 
-    //general class applied to search input and button wrapper
-    .pub-c-search__item {
-      position: relative;
-      display: table-cell;
-      vertical-align: top;
-    }
+.pub-c-search--on-white {
+  .pub-c-search__label {
+    color: $black;
+  }
 
-    .pub-c-search__input {
-      margin: 0;
+  .pub-c-search__input[type="search"] {
+    border: solid 1px $grey-2;
+  }
 
-      // the .focus class is added by JS and ensures that the input remains above the label once clicked/filled in
-      &:focus,
-      &.focus {
-        z-index: 2;
-      }
-    }
+  .pub-c-search__submit {
+    background-color: $light-blue;
+    color: $white;
 
-    .pub-c-search__submit-wrapper {
-      width: 1%;
-    }
-
-    .pub-c-search__submit {
-      position: relative;
-      padding: 0;
-      width: $input-size;
-      height: $input-size;
-      background-image: image-url("search-button.png");
-      background-repeat: no-repeat;
-      background-position: 2px 50%;
-      text-indent: -5000px;
-      overflow: hidden;
-
-      &:focus {
-        z-index: 2;
-      }
-
-      &::-moz-focus-inner {
-        border: 0;
-      }
-
-      @include device-pixel-ratio() {
-        background-size: 52.5px auto;
-        background-position: 115% 50%;
-      }
+    &:hover {
+      background-color: lighten($light-blue, 5%);
     }
   }
 
-  &.pub-c-search--on-govuk-blue {
-    .pub-c-search__label {
-      color: $white;
+  @if ($is-ie == false) or ($ie-version >= 8) {
+    .pub-c-search__input[type="search"] {
+      border-right: 0;
     }
 
-    .pub-c-search__submit {
-      background-color: $black;
-      color: $white;
-
-      &:hover {
-        background-color: lighten($black, 5%);
-      }
-    }
-
-    @if ($is-ie == false) or ($ie-version >= 8) {
-      .js-enabled & {
-        .pub-c-search__label {
-          color: $secondary-text-colour;
-        }
+    .js-enabled & {
+      .pub-c-search__label {
+        color: $secondary-text-colour;
       }
     }
   }
+}
 
-
-  &.pub-c-search--on-white {
-    .pub-c-search__label {
-      color: $black;
-    }
-
-    .pub-c-search__input {
-      border: solid 1px $grey-2;
-    }
-
-    .pub-c-search__submit {
-      background-color: $light-blue;
-      color: $white;
-
-      &:hover {
-        background-color: lighten($light-blue, 5%);
-      }
-    }
-
-    @if ($is-ie == false) or ($ie-version >= 8) {
-      .pub-c-search__input {
-        border-right: 0;
-      }
-
-      .js-enabled & {
-        .pub-c-search__label {
-          color: $secondary-text-colour;
-        }
-      }
-    }
+.pub-c-search--large {
+  .pub-c-search__label {
+    @include core-19($line-height: $large-input-size, $line-height-640: $large-input-size);
   }
 
-  &.pub-c-search--large {
-    $input-size: 50px;
-
-    .pub-c-search__label {
-      @include core-19($line-height: $input-size, $line-height-640: $input-size);
-    }
-
-    .pub-c-search__input {
-      height: $input-size;
-    }
-
-    .pub-c-search__submit {
-      width: $input-size;
-      height: $input-size;
-      background-position: 8px 50%;
-
-      @include device-pixel-ratio() {
-        background-size: 60px auto;
-        background-position: 160% 50%;
-      }
-    }
+  .pub-c-search__input[type="search"] {
+    height: $large-input-size;
   }
 
-  &.pub-c-search--separate-label {
-    .pub-c-search__label {
-      position: relative;
-      left: auto;
+  .pub-c-search__submit {
+    width: $large-input-size;
+    height: $large-input-size;
+    background-position: 8px 50%;
+
+    @include device-pixel-ratio() {
+      background-size: 60px auto;
+      background-position: 160% 50%;
     }
+  }
+}
+
+.pub-c-search--separate-label {
+  .pub-c-search__label {
+    position: relative;
+    left: auto;
   }
 }

--- a/app/views/govuk_component/search.raw.html.erb
+++ b/app/views/govuk_component/search.raw.html.erb
@@ -1,9 +1,9 @@
 <%
-  class_name = "on-white"
-  class_name = "on-govuk-blue" if local_assigns.include?(:on_govuk_blue)
+  class_name = "pub-c-search--on-white"
+  class_name = "pub-c-search--on-govuk-blue" if local_assigns.include?(:on_govuk_blue)
   size ||= ""
-  class_name = "#{class_name} search-large" if size == 'large'
-  class_name = "#{class_name} search-separate-label" if local_assigns.include?(:inline_label)
+  class_name = "#{class_name} pub-c-search--large" if size == 'large'
+  class_name = "#{class_name} pub-c-search--separate-label" if local_assigns.include?(:inline_label)
 
   value ||= ""
   id ||= "search-main-" + SecureRandom.hex(4)
@@ -11,14 +11,14 @@
   label_text = "#{label_text}".html_safe
 %>
 
-<div class="govuk-search <%= class_name %>" data-module="toggle-input-class-on-focus">
-  <label for="<%= id %>" class="search-label">
+<div class="pub-c-search <%= class_name %>" data-module="toggle-input-class-on-focus">
+  <label for="<%= id %>" class="pub-c-search__label">
     <%= label_text %>
   </label>
-  <div class="search-wrapper">
-    <input type="search" value="<%= value %>" id="<%= id %>" name="q" title="Search" class="search-element search-input js-class-toggle">
-    <div class="search-element search-submit-wrapper">
-      <button type="submit" class="search-submit">Search</button>
+  <div class="pub-c-search__item-wrapper">
+    <input type="search" value="<%= value %>" id="<%= id %>" name="q" title="Search" class="pub-c-search__item pub-c-search__input js-class-toggle">
+    <div class="pub-c-search__item pub-c-search__submit-wrapper">
+      <button type="submit" class="pub-c-search__submit">Search</button>
     </div>
   </div>
 </div>

--- a/test/govuk_component/search_test.rb
+++ b/test/govuk_component/search_test.rb
@@ -7,39 +7,39 @@ class SearchTestCase < ComponentTestCase
 
   test "renders a search box with default options" do
     render_component({})
-    assert_select ".govuk-search.on-white"
+    assert_select ".pub-c-search.pub-c-search--on-white"
   end
 
   test "renders a search box for a dark background" do
     render_component(on_govuk_blue: true)
-    assert_select ".govuk-search.on-govuk-blue"
+    assert_select ".pub-c-search.pub-c-search--on-govuk-blue"
   end
 
   test "renders a search box with a custom label text" do
     render_component(label_text: "This is my new label")
-    assert_select ".govuk-search .search-label", text: "This is my new label"
+    assert_select ".pub-c-search .pub-c-search__label", text: "This is my new label"
   end
 
   test "renders a search box with a custom label content" do
     render_component(inline_label: false, label_text: "<h1>This is a heading 1</h1>")
-    assert_select ".govuk-search .search-label h1", text: "This is a heading 1"
-    assert_select ".govuk-search.search-separate-label"
+    assert_select ".pub-c-search .pub-c-search__label h1", text: "This is a heading 1"
+    assert_select ".pub-c-search.pub-c-search--separate-label"
   end
 
   test "renders a search box with a value" do
     render_component(value: "I searched for this")
-    assert_select ".govuk-search .search-input" do
+    assert_select ".pub-c-search .pub-c-search__input" do
       assert_select "[value=?]", "I searched for this"
     end
   end
 
   test "renders a search box with a custom id" do
     render_component(id: "my-unique-id")
-    assert_select ".govuk-search #my-unique-id.search-input"
+    assert_select ".pub-c-search #my-unique-id.pub-c-search__input"
   end
 
   test "renders a large search box" do
     render_component(size: "large")
-    assert_select ".govuk-search.search-large"
+    assert_select ".pub-c-search.pub-c-search--large"
   end
 end


### PR DESCRIPTION
**UPDATE: going to simply move this as it is into the components gem since it'll be better there. Superseded by https://github.com/alphagov/govuk_publishing_components/pull/267** 

Update the search component to use BEM as per our component principles.

I've done two separate commits to clearly show the naming change, and then the reformatting.