### PR TITLE
Add content ID to analytics component

### DIFF
--- a/app/views/govuk_component/analytics_meta_tags.raw.html.erb
+++ b/app/views/govuk_component/analytics_meta_tags.raw.html.erb
@@ -7,6 +7,7 @@
   details_hash = content_item_hash[:details] || {}
   meta_tags = {}
 
+  meta_tags["govuk:content-id"] = content_item_hash[:content_id] if content_item_hash[:content_id]
   meta_tags["govuk:format"] = content_item_hash[:document_type] if content_item_hash[:document_type]
   meta_tags["govuk:schema-name"] = content_item_hash[:schema_name] if content_item_hash[:schema_name]
   meta_tags["govuk:withdrawn"] = "withdrawn" if content_item_hash[:withdrawn_notice].present?


### PR DESCRIPTION
This metatag is read by the google analytics here:
https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/custom-dimensions.js

For more information see
https://govuk-static.herokuapp.com/component-guide/analytics_meta_tags

I noticed this was missing because certain formats (transaction, simple smart answer) don't include this tag. Before merging, I need to check other rendering apps besides frontend, because it seems that in some places we manually add this meta tag to the template and I don't want to duplicate it.