### PR TITLE
Remove autolinker for planforbritain.gov.uk

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -1,4 +1,4 @@
-(function(global) {
+(function() {
   "use strict";
 
   // Load Google Analytics libraries
@@ -21,10 +21,4 @@
 
   // Make interface public for virtual pageviews and events
   GOVUK.analytics = analytics;
-
-  if (global.ga) {
-    var ga = global.ga;
-    ga('require', 'linker');
-    ga('linker:autoLink', ['planforbritain.gov.uk']);
-  }
-})(window);
+})();


### PR DESCRIPTION
Background:

> When the planforbritain website went live we implemented full dual tracking on both sites so that each site had visibility of complete use journeys across both sites.
> 
> At some point (not sure when) the planforbritain site was taken off line.
> I imagine that around the same time the extra tracking on GOV.UK was removed so that the page view and event hits were no longer duplicated to the planforbritain GA property.
But it looks as if the code to do the autolinking was left in place. We should tidy up by removing that as well.
