### PR TITLE
Add an optional environment variable for the Google Analytics ID

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -8,7 +8,7 @@
   // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
   var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
-  var universalId = 'UA-26179049-1';
+  var universalId = '<%= Rails.application.config.ga_universal_id %>';
 
   // Configure profiles, setup custom vars, track initial pageview
   var analytics = new GOVUK.StaticAnalytics({

--- a/config/application.rb
+++ b/config/application.rb
@@ -52,6 +52,9 @@ module Static
 
     config.paths["log"] = ENV["LOG_PATH"] if ENV["LOG_PATH"]
 
+    # Google Analytics ID
+    config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-UNSET")
+
     # Slimmer is used by the govuk_publishing_components gem, however it inserts itself
     # automatically as middleware in the host Rails application
     # Disable Slimmer middleware for Static and enable for use in gem only

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,4 +67,6 @@ Rails.application.configure do
   config.action_controller.asset_host = ENV['GOVUK_ASSET_HOST']
 
   config.eager_load = true
+
+  config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-26179049-1")
 end


### PR DESCRIPTION
If the env var `GA_UNIVERSAL_ID` is set, that is used for the Google Analytics ID.  If it's not set, the ID defaults to `UA-26179049-1` in production, and `UA-UNSET` in development and test.

---

This will let us use a different Google Analytics ID in staging and integration: https://trello.com/c/uLUgPcvI/50-stop-sending-staging-and-integration-data-to-same-ga-property-as-live-site-2