### PR TITLE
Bump govuk_template to 0.23.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ end
 
 gem 'plek', '2.1.1'
 gem 'govuk_frontend_toolkit', '~> 7.4.1'
-gem 'govuk_template', '0.23.0'
+gem 'govuk_template', '0.23.2'
 gem 'gds-api-adapters', '~> 52.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
-    govuk_template (0.23.0)
+    govuk_template (0.23.2)
       rails (>= 3.1)
     hashdiff (0.3.7)
     highline (1.7.10)
@@ -349,7 +349,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.4.1)
   govuk_frontend_toolkit (~> 7.4.1)
   govuk_publishing_components (~> 6.5.0)
-  govuk_template (= 0.23.0)
+  govuk_template (= 0.23.2)
   image_optim (= 0.26.1)
   jasmine-rails (~> 0.14.1)
   minitest


### PR DESCRIPTION
We previously had to revert the bump to 0.23.1 as it contained a breaking change (https://github.com/alphagov/static/pull/1382)

This has now been fixed, so we can update straight from 0.23.0 to 0.23.2