### PR TITLE
Add tracking to organisation logos

### DIFF
--- a/app/views/govuk_component/docs/organisation_logo.yml
+++ b/app/views/govuk_component/docs/organisation_logo.yml
@@ -5,6 +5,9 @@ body: |
   These cannot be inferred from the name alone.
 
   Alternatively a custom organisation logo can be provided as an image.
+
+  Data tracking attributes can be provided to add tracking to each organisation logo.
+  This will only apply to organisations with a link. Example here: [with_data_attributes](/component-guide/organisation_logo/with_data_attributes)
 accessibility_criteria: |
   The crest image itself must be presentational and ignored by screen readers.
 
@@ -139,3 +142,17 @@ examples:
         image:
           url: 'https://assets.publishing.service.gov.uk/government/uploads/system/uploads/organisation/logo/321/HMPS.jpg'
           alt_text: 'HM Prison Service'
+  with_data_attributes:
+    data:
+      organisation:
+        name: Cabinet Office
+        url: '/government/organisations/cabinet-office'
+        brand: cabinet-office
+        crest: 'single-identity'
+        data_attributes:
+          track_category: "navOrganisationLinkClicked"
+          track_action: 1
+          track_label: '/government/organisations/cabinet-office'
+          track_options:
+            dimension28: 2
+            dimension29: Cabinet Office

--- a/app/views/govuk_component/organisation_logo.raw.html.erb
+++ b/app/views/govuk_component/organisation_logo.raw.html.erb
@@ -4,10 +4,11 @@
   logo_container_class = "#{logo_container_class} logo-link" if organisation[:url]
   logo_container_class = "#{logo_container_class} logo-with-crest crest-#{organisation[:crest]}" if organisation[:crest]
 %>
-<div class="govuk-organisation-logo <%= organisation[:brand] %>">
+<div class="govuk-organisation-logo <%= organisation[:brand] %>" <%= "data-module=track-click" if organisation[:data_attributes] %>>
   <% if organisation[:url] %>
     <%= link_to organisation[:url],
-        class: logo_container_class do %>
+        class: logo_container_class,
+        data: organisation[:data_attributes] do %>
       <%= render file: 'govuk_component/organisation_logo_section.raw', locals: { organisation: organisation } %>
     <% end %>
   <% else %>

--- a/app/views/govuk_component/organisation_logo.raw.html.erb
+++ b/app/views/govuk_component/organisation_logo.raw.html.erb
@@ -6,24 +6,13 @@
 %>
 <div class="govuk-organisation-logo <%= organisation[:brand] %>">
   <% if organisation[:url] %>
-    <a href="<%= organisation[:url] %>" class="<%= logo_container_class %>">
+    <%= link_to organisation[:url],
+        class: logo_container_class do %>
+      <%= render file: 'govuk_component/organisation_logo_section.raw', locals: { organisation: organisation } %>
+    <% end %>
   <% else %>
     <div class="<%= logo_container_class %>">
-  <% end %>
-
-  <% if organisation[:image] %>
-    <img
-      class="logo-image"
-      src="<%= organisation[:image][:url] %>"
-      <% if organisation[:image][:alt_text] %>alt="<%= organisation[:image][:alt_text] %>"<% end %>
-    />
-  <% else %>
-    <span><%= raw organisation[:name] %></span>
-  <% end %>
-
-  <% if organisation[:url] %>
-    </a>
-  <% else %>
+      <%= render file: 'govuk_component/organisation_logo_section.raw', locals: { organisation: organisation } %>
     </div>
   <% end %>
 </div>

--- a/app/views/govuk_component/organisation_logo_section.raw.html.erb
+++ b/app/views/govuk_component/organisation_logo_section.raw.html.erb
@@ -1,0 +1,9 @@
+ <% if organisation[:image] %>
+  <img
+    class="logo-image"
+    src="<%= organisation[:image][:url] %>"
+    <% if organisation[:image][:alt_text] %>alt="<%= organisation[:image][:alt_text] %>"<% end %>
+  />
+<% else %>
+  <span><%= raw organisation[:name] %></span>
+<% end %>

--- a/test/govuk_component/organisation_logo_test.rb
+++ b/test/govuk_component/organisation_logo_test.rb
@@ -36,4 +36,33 @@ class OrganisationLogoTestCase < ComponentTestCase
     render_component(organisation: { name: "Custom image", image: { url: "url", "alt_text": "alt" } })
     assert_select ".logo-container img[src='url'][alt='alt']"
   end
+
+  test "data tracking attributes are added to the link when specified" do
+    data_attributes = {
+      track_category: "someLinkClicked",
+      track_action: 1,
+      track_label: "/some-link",
+      track_options: {
+        dimension28: 2,
+        dimension29: "Organisation link"
+      }
+    }
+
+    render_component(organisation: { url: "/some-link", data_attributes: data_attributes })
+
+    assert_select ".govuk-organisation-logo[data-module='track-click']"
+    assert_select ".govuk-organisation-logo a.logo-container.logo-link[data-track-category='someLinkClicked']"
+    assert_select ".govuk-organisation-logo a.logo-container.logo-link[data-track-action='1']"
+    assert_select ".govuk-organisation-logo a.logo-container.logo-link[data-track-label='/some-link']"
+    assert_select ".govuk-organisation-logo a.logo-container.logo-link[data-track-options='{\"dimension28\":2,\"dimension29\":\"Organisation link\"}']"
+  end
+
+  test "data tracking attributes are not added when no link is specified" do
+    data_attributes = {
+      track_category: "someLinkClicked"
+    }
+
+    render_component(organisation: { data_attributes: data_attributes })
+    assert_select ".govuk-organisation-logo a.logo-container.logo-link[data-track-category='someLinkClicked']", false
+  end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/xYWhPOMg

## Changes

* Split the organisation image into a separate partial template to allow us to use it as part of a link or by itself.
* Added `data-module=track-click` when `data_attributes` are passed in so that no further configuration is required in views to get the tracking to work.

![screen shot 2018-05-11 at 14 57 01](https://user-images.githubusercontent.com/5793815/39927871-95817860-552b-11e8-8431-365fa90f1504.png)
