### PR TITLE
Remove feature to target surveys by breadcrumb

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -657,15 +657,6 @@
       }
     },
 
-    breadcrumbMatch: function (breadcrumbs) {
-      if (breadcrumbs === undefined) {
-        return false
-      } else {
-        var breadcrumbMatchingExpr = new RegExp($.makeArray(breadcrumbs).join('|'), 'i')
-        return breadcrumbMatchingExpr.test(userSurveys.currentBreadcrumb())
-      }
-    },
-
     sectionMatch: function (sections) {
       if (sections === undefined) {
         return false
@@ -696,17 +687,15 @@
     activeWhen: function (survey) {
       if (survey.hasOwnProperty('activeWhen')) {
         if (survey.activeWhen.hasOwnProperty('path') ||
-          survey.activeWhen.hasOwnProperty('breadcrumb') ||
           survey.activeWhen.hasOwnProperty('section') ||
           survey.activeWhen.hasOwnProperty('organisation') ||
           survey.activeWhen.hasOwnProperty('tlsCookieVersionLimit')) {
           var matchType = (survey.activeWhen.matchType || 'include')
           var matchByTlsCookie = userSurveys.tlsCookieMatch(survey.activeWhen.tlsCookieVersionLimit)
           var matchByPath = userSurveys.pathMatch(survey.activeWhen.path)
-          var matchByBreadcrumb = userSurveys.breadcrumbMatch(survey.activeWhen.breadcrumb)
           var matchBySection = userSurveys.sectionMatch(survey.activeWhen.section)
           var matchByOrganisation = userSurveys.organisationMatch(survey.activeWhen.organisation)
-          var pageMatches = (matchByTlsCookie || matchByPath || matchByBreadcrumb || matchBySection || matchByOrganisation)
+          var pageMatches = (matchByTlsCookie || matchByPath || matchBySection || matchByOrganisation)
 
           if (matchType !== 'exclude') {
             return pageMatches
@@ -723,7 +712,6 @@
 
     currentTime: function () { return new Date().getTime() },
     currentPath: function () { return window.location.pathname },
-    currentBreadcrumb: function () { return $('.govuk-breadcrumbs').text() || '' },
     currentSection: function () { return $('meta[name="govuk:section"]').attr('content') || '' },
     currentThemes: function () { return $('meta[name="govuk:themes"]').attr('content') || '' },
     currentOrganisation: function () { return $('meta[name="govuk:analytics:organisations"]').attr('content') || '' },

--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -23,7 +23,6 @@ Once a user takes the survey (clicks the link or fills in their email address an
   activeWhen: {
     section: ['education and learning'],
     path: ['guidance/social-care-common-inspection-framework-sccif-boarding-schools'],
-    breadcrumb: ['Schools'],
     organisation: ['<D106>'],
     matchType: 'include'
   },
@@ -191,7 +190,6 @@ By default a survey will run on all pages on GOV.UK. If you specify parameters i
 
 * `matchType` - (optional) the default is "include". This tells us how to interpret the other params. For "include" we treat the params as limiting the survey to only display on those pages that match one or more of the params. For "exclude" we treat the params as limiting the survey to only display on those pages that do not match any of the params. If the value is other than "include" or "exclude" it is assumed to be "include".
 * `path` - (optional). If present this is used to match complete path segments in the path of the page. Each entry is turned into a regexp as follows: `statistcis` becomes `/\/statistics(\/|$)/` and this means that a value of "statistics" would match a path like "/government/statistics/a-very-large-report", but not a path like "/guidance/how-to-download-statistics-and-announcements". If you use regex special characters `^` or `$` then the string is not changed before being turned into a regexp to match paths.
-* `breadcrumb` - (optional). If present this is used to match against the text in the `.govuk-breadcrumb` element on the page. The text match is case-insensitive and does not attempt to match complete words so `hats` would match `Hats` and `Chats`.
 * `section` - (optional). If present this is used to match against the value of the content attribute of the `govuk:section` (old style mainstream navigation hierarchy) and `govuk:themes` (new style taxonomy-based navigation hierarchy) meta tags on the page. The text match is case-insensitive and does not attempt to match complete words so `hats` would match `Hats` and `Chats`.  Note that `govuk:section` usually contains `Human Readable` values, whereas `govuk:themes` usually contains `machine-readable` values, but the matcher does not try to normalise these values, so bear that in mind while using this to target a survey.
 * `organisation` - (optional). If present this is used to match against the value of the content attribute of the `govuk:analytics:organisations` meta tag on the page. The text match is case-sensitive and does not attempt to match complete words so `hats` would match `hats` and `Chats`, but not `Hats`. You can find the organisation's analytics identifier using the content store, e.g. for HM Revenue Customs ([api/content/government/organisations/hm-revenue-customs](https://www.gov.uk/api/content/government/organisations/hm-revenue-customs)), the identifier is `D25`. This would typically be represented as `<D25>` in the meta tag.
 * `tlsCookieVersionLimit` - (optional). If present this is used to compare the TLS version stored in the `TLSVersion` cookie.
@@ -203,13 +201,12 @@ In the example above, the survey will only be considered "active" on pages with 
 1. a govuk:section meta tag with "education and learning",
 2. a path that includes `guidance/social-care-common-inspection-framework-sccif-boarding-schools`
 3. a govuk:analytics:organisation that includes `<D106>`
-4. the word `Schools` appearing in the text of the `.govuk-breadcrumb` element on the page
 
 Not providing any `activeWhen` parameters, or providing an empty `activeWhen` parameter will apply the survey to all pages on GOV.UK between `startTime` and `endTime`, so take care when doing this.
 
 #### Performance considerations
 
-Remember that the decision to show a survey or not is done on the client browser and happens on every request.  We first throw away any surveys that haven't started yet, or have ended already and then we check the `activeWhen` parameters.  So if you have a survey with lots of parameters and values in `activeWhen` this could cause performance issues for the browser so you should be careful when describing which pages the survey should appear on.  If you have 100s of pages to run the survey on, can you target them all by a single breadcrumb or organisation instead of doing 100s of path comparisons?  If none of the parameters can be combined to cover all the pages without requiring lots of comparisons you may need to add new parameter types to the surveys code, or come up with a different set of pages to target.
+Remember that the decision to show a survey or not is done on the client browser and happens on every request.  We first throw away any surveys that haven't started yet, or have ended already and then we check the `activeWhen` parameters.  So if you have a survey with lots of parameters and values in `activeWhen` this could cause performance issues for the browser so you should be careful when describing which pages the survey should appear on.  If you have 100s of pages to run the survey on, can you target them all by a organisation instead of doing 100s of path comparisons?  If none of the parameters can be combined to cover all the pages without requiring lots of comparisons you may need to add new parameter types to the surveys code, or come up with a different set of pages to target.
 
 ### TLS Version detection ###
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -1223,53 +1223,6 @@ describe('Surveys', function () {
         })
       })
 
-      describe('breadcrumb matches', function () {
-        it('returns true if the breadcrumb definition matches something in the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education']
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools')
-          expect(surveys.activeWhen(survey)).toBe(true)
-        })
-
-        it('returns false if the breadcrumb definition does not match the breadcrumb text at all', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['childcare']
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools')
-          expect(surveys.activeWhen(survey)).toBe(false)
-        })
-
-        it('returns true if any of the breadcrumb definitions matches the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education', 'childcare']
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValues('Home  Education and learning  Schools', 'Home  Childcare and parenting  Maternity leave')
-          expect(surveys.activeWhen(survey)).toBe(true)
-          expect(surveys.activeWhen(survey)).toBe(true)
-        })
-
-        it('returns false if none of the breadcrumb definitions matches the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education', 'childcare']
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Benefits  Benfits for families')
-          expect(surveys.activeWhen(survey)).toBe(false)
-        })
-      })
-
       describe('section matches', function () {
         it('returns true if the section definition matches something in the section meta tag', function () {
           var survey = {
@@ -1433,18 +1386,15 @@ describe('Surveys', function () {
           identifier: 'a_survey',
           activeWhen: {
             path: ['^/government/statistics/?$'],
-            breadcrumb: ['education'],
             section: ['schools'],
             organisation: ['<D10>']
           }
         }
 
         spyOn(surveys, 'currentPath').and.returnValues('/government/statistics/a-long-detailed-report.xls', '/government/statistics', '/government/publications/', '/find-your-local-council', '/')
-        spyOn(surveys, 'currentBreadcrumb').and.returnValues('Home  Education', 'Home', 'Home  Schools  Applying for a place', 'Home  Benefits  Family benefits', 'Home')
         spyOn(surveys, 'currentSection').and.returnValues('education', '', 'schools', 'benefits', 'homepage')
         spyOn(surveys, 'currentOrganisation').and.returnValues('<E1555><F12>', '<D20>', '<E1234>', '<D20><F10>', '<D10><E134>')
 
-        expect(surveys.activeWhen(survey)).toBe(true) // because of the breadcrumb
         expect(surveys.activeWhen(survey)).toBe(true) // because of the path
         expect(surveys.activeWhen(survey)).toBe(true) // because of the section
         expect(surveys.activeWhen(survey)).toBe(false) // because nothing matches
@@ -1536,57 +1486,6 @@ describe('Surveys', function () {
           expect(surveys.activeWhen(survey)).toBe(true)
           expect(surveys.activeWhen(survey)).toBe(true)
           expect(surveys.activeWhen(survey)).toBe(true)
-          expect(surveys.activeWhen(survey)).toBe(true)
-        })
-      })
-
-      describe('breadcrumb matches', function () {
-        it('returns false if the breadcrumb definition matches something in the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education'],
-              matchType: 'exclude'
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools')
-          expect(surveys.activeWhen(survey)).toBe(false)
-        })
-
-        it('returns true if the breadcrumb definition does not match the breadcrumb text at all', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['childcare'],
-              matchType: 'exclude'
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Education and learning  Schools')
-          expect(surveys.activeWhen(survey)).toBe(true)
-        })
-
-        it('returns false if any of the breadcrumb definitions matches the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education', 'childcare'],
-              matchType: 'exclude'
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValues('Home  Education and learning  Schools', 'Home  Childcare and parenting  Maternity leave')
-          expect(surveys.activeWhen(survey)).toBe(false)
-          expect(surveys.activeWhen(survey)).toBe(false)
-        })
-
-        it('returns true if none of the breadcrumb definitions matches the breadcrumb text', function () {
-          var survey = {
-            identifier: 'a_survey',
-            activeWhen: {
-              breadcrumb: ['education', 'childcare'],
-              matchType: 'exclude'
-            }
-          }
-          spyOn(surveys, 'currentBreadcrumb').and.returnValue('Home  Benefits  Benfits for families')
           expect(surveys.activeWhen(survey)).toBe(true)
         })
       })


### PR DESCRIPTION
Using this feature is currently broken because the CSS of the breadcrumbs changed from `govuk-breadcrumbs` to `gem-c-breadcrumbs` in https://github.com/alphagov/govuk_publishing_components/pull/309.

Instead of repairing it we remove it here, because the matching on breadcrumbs seems like a fragile method of implementing the matching since it relies on the internals of a component.

We're not currently using this feature, so we can remove it now without problems. If we want a replacement, perhaps looking at the `govuk:taxons` meta tag would be a more reliable way of determining the subject of the page.

https://trello.com/c/XLuzv0pB