### PR TITLE
Remove HMRC surveys for February

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -60,40 +60,6 @@
   var SURVEY_SEEN_TOO_MANY_TIMES_LIMIT = 2
   var MAX_MOBILE_WIDTH = "(max-width: 800px)"
 
-  var hmrcSurveysFeb2018Url = function () {
-    var path = window.location.pathname
-    switch (true) {
-      case /^\/correct-your-business-rates(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=VOAgov&utm_source=Other&utm_medium=gov.uk&t=HMRC&id=125'
-      case /^\/guidance\/soft-drinks-industry-levy(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=SoftDrinksGOV&utm_source=Other&utm_medium=other&t=HMRC&id=100'
-      case /^\/guidance\/tell-hmrc-if-youve-underpaid-national-minimum-wage-in-the-social-care-sector(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=MinWageSocialCareGOV&utm_source=Other&utm_medium=other&t=HMRC&id=101'
-      case /^\/child-benefit(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=ChildBenefitGOV&utm_source=Other&utm_medium=other&t=HMRC&id=26'
-      case /^\/tax-overpayments-and-underpayments(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=OverpayUnderpayGOV&utm_source=Other&utm_medium=other&t=HMRC&id=27'
-      case /^\/pay-tax-debit-credit-card(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=onlinepaymentsGOV&utm_source=Other&utm_medium=other&t=HMRC&id=32'
-      case /^\/eori(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=EORIgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=61'
-      case /^\/starting-to-import(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=EORIgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=61'
-      case /^\/starting-to-export(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=EORIgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=61'
-      case /^\/duty-deferment-statements(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=DDESgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=60'
-      case /^\/government\/publications\/notice-101-deferring-duty-vat-and-other-charges\/notice-101-deferring-duty-vat-and-other-charges(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=DDESgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=61'
-      case /^\/government\/publications\/notice-100-customs-flexible-accounting-system\/notice-100-customs-flexible-accounting-system(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=DDESgov&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=62'
-      case /^\/working-tax-credit(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=workingtaxcreditGOV&utm_source=Other&utm_medium=other&t=HMRC&id=12'
-      case /^\/guidance\/money-laundering-regulations-register-with-hmrc(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=MoneyLaundering RegulationsGOV&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=45'
-      case /^\/child-tax-credit(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=ChildTaxCreditGOV&utm_source=Other&utm_medium=gov.uk%20survey&t=HMRC&id=10'
-      case /^\/check-state-pension(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=checkstatepensionGOV&utm_source=Other&utm_medium=other&t=HMRC&id=46'
-      case /^\/apply-marriage-allowance(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=marriageallowanceGOV&utm_source=Other&utm_medium=other&t=HMRC&id=47'
-      case /^\/stamp-duty-land-tax(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=StampDutyLandTaxGOV&utm_source=Other&utm_medium=other&t=HMRC&id=48'
-      case /^\/guidance\/pay-apprenticeship-levy(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=Apprenticeship Levy&utm_source=Money_and_tax&utm_medium=gov.uk&t=HMRC&id=7'
-      case /^\/update-company-car-details(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=CompanyCarGOV&utm_source=Other&utm_medium=other&t=HMRC&id=49'
-      case /^\/guidance\/paying-your-employees-expenses-and-benefits-through-your-payroll(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=PayrollExpensesBenefitsGOV&utm_source=Other&utm_medium=other&t=HMRC&id=50'
-      case /^\/guidance\/pension-schemes-protect-your-lifetime-allowance(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=PensionSchemeLifetimeAllowanceGOV&utm_source=Other&utm_medium=other&t=HMRC&id=51'
-      case /^\/send-employment-intermediary-report(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=EmploymentIntermediaryReportGOV&utm_source=Other&utm_medium=other&t=HMRC&id=52'
-      case /^\/guidance\/tell-hmrc-about-your-employment-related-securities(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=EmploymentRelatedSecuritiesGOV&utm_source=Other&utm_medium=other&t=HMRC&id=53'
-      case /^\/guidance\/pension-administrators-check-a-members-gmp(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=PensionAdministratorsGMPGOV&utm_source=Other&utm_medium=other&t=HMRC&id=54'
-      case /^\/simple-assessment(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=simpleassessmentGOV&utm_source=Other&utm_medium=other&t=HMRC&id=55'
-      case /^\/tax-on-your-private-pension\/lifetime-allowance(?:\/|$)/.test(path) : return 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=PrivatePensionContributionsGOV&utm_source=govukother&utm_medium=gov.uk&t=HMRC&id=105'
-      default: return ''
-    }
-  }
-
   /* This data structure is explained in `doc/surveys.md` */
   var userSurveys = {
     defaultSurvey: {
@@ -103,70 +69,6 @@
       surveyType: 'email'
     },
     smallSurveys: [
-      {
-        identifier: 'hmrc_february',
-        surveyType: 'url',
-        frequency: 5,
-        startTime: new Date('February 14, 2018').getTime(),
-        endTime: new Date('May 14, 2018').getTime(),
-        url: hmrcSurveysFeb2018Url(),
-        templateArgs: {
-          title: 'Get involved in making government services better',
-          surveyCta: 'Take the 3 minute survey.',
-          surveyCtaPostscript: 'This will open a short survey on another website.'
-        },
-        activeWhen: {
-          path: [
-            '^/correct-your-business-rates(?:/|$)',
-            '^/guidance/soft-drinks-industry-levy(?:/|$)',
-            '^/guidance/tell-hmrc-if-youve-underpaid-national-minimum-wage-in-the-social-care-sector(?:/|$)',
-            '^/child-benefit(?:/|$)',
-            '^/tax-overpayments-and-underpayments(?:/|$)',
-            '^/pay-tax-debit-credit-card(?:/|$)',
-            '^/eori(?:/|$)',
-            '^/starting-to-import(?:/|$)',
-            '^/starting-to-export(?:/|$)',
-            '^/duty-deferment-statements(?:/|$)',
-            '^/government/publications/notice-101-deferring-duty-vat-and-other-charges/notice-101-deferring-duty-vat-and-other-charges(?:/|$)',
-            '^/government/publications/notice-100-customs-flexible-accounting-system/notice-100-customs-flexible-accounting-system(?:/|$)',
-            '^/working-tax-credit(?:/|$)',
-            '^/guidance/money-laundering-regulations-register-with-hmrc(?:/|$)',
-            '^/child-tax-credit(?:/|$)',
-            '^/check-state-pension(?:/|$)',
-            '^/apply-marriage-allowance(?:/|$)',
-            '^/stamp-duty-land-tax(?:/|$)',
-            '^/guidance/pay-apprenticeship-levy(?:/|$)',
-            '^/update-company-car-details(?:/|$)',
-            '^/guidance/paying-your-employees-expenses-and-benefits-through-your-payroll(?:/|$)',
-            '^/guidance/pension-schemes-protect-your-lifetime-allowance(?:/|$)',
-            '^/send-employment-intermediary-report(?:/|$)',
-            '^/guidance/tell-hmrc-about-your-employment-related-securities(?:/|$)',
-            '^/guidance/pension-administrators-check-a-members-gmp(?:/|$)',
-            '^/simple-assessment(?:/|$)',
-            '^/tax-on-your-private-pension/lifetime-allowance(?:/|$)'
-          ]
-        },
-        allowedOnMobile: true
-      },
-      {
-        identifier: 'hmrc_february_due_dilligence',
-        surveyType: 'url',
-        frequency: 1,
-        startTime: new Date('February 14, 2018').getTime(),
-        endTime: new Date('May 14, 2018').getTime(),
-        url: 'https://signup.take-part-in-research.service.gov.uk/?utm_campaign=FHDDSgov&utm_source=Other&utm_medium=other&t=HMRC&id=99',
-        templateArgs: {
-          title: 'Get involved in making government services better',
-          surveyCta: 'Take the 3 minute survey.',
-          surveyCtaPostscript: 'This will open a short survey on another website.'
-        },
-        activeWhen: {
-          path: [
-            '^/guidance/fulfilment-house-due-diligence-scheme(?:/|$)'
-          ]
-        },
-        allowedOnMobile: true
-      },
       {
         identifier: 'hmrc_march_duty_free',
         surveyType: 'url',


### PR DESCRIPTION
Removed HMRC surveys which expired recently.

There was another one not in the ticket which also expired, so I removed that too.

https://trello.com/c/Wz9ppQon/43-1-february-hmrc-surveys-expire-may-14-2018

Tested to make sure the remaining surveys still work:

<img width="692" alt="screenshot 2018-05-18 12 20 06" src="https://user-images.githubusercontent.com/109225/40232353-522616c8-5a96-11e8-9cc7-587ba0d4bf5a.png">
