### PR TITLE
Fix feature to scope surveys by breadcrumb

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -838,7 +838,7 @@
 
     currentTime: function () { return new Date().getTime() },
     currentPath: function () { return window.location.pathname },
-    currentBreadcrumb: function () { return $('.govuk-breadcrumbs').text() || '' },
+    currentBreadcrumb: function () { return $('.gem-c-breadcrumbs').text() || '' },
     currentSection: function () { return $('meta[name="govuk:section"]').attr('content') || '' },
     currentThemes: function () { return $('meta[name="govuk:themes"]').attr('content') || '' },
     currentOrganisation: function () { return $('meta[name="govuk:analytics:organisations"]').attr('content') || '' },


### PR DESCRIPTION
We're now using the breadcrumbs component everywhere, which is a different class name.

https://govuk-publishing-components.herokuapp.com/component-guide/breadcrumbs

Supersedes https://github.com/alphagov/static/pull/1412.

https://trello.com/c/XLuzv0pB

