### PR TITLE
Revert "Add a meta noindex tag to any page which isn't first"

### DIFF
--- a/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
+++ b/app/views/govuk_component/previous_and_next_navigation.raw.html.erb
@@ -6,9 +6,6 @@
 >
   <ul class="pub-c-pagination__list" data-module="track-click">
     <% if local_assigns.include?(:previous_page) %>
-      <%# hoisted up to the <head> by slimmer %>
-      <meta name="robots" content="noindex" />
-
       <li class="pub-c-pagination__item pub-c-pagination__item--previous">
         <a href="<%= previous_page[:url] %>"
           class="pub-c-pagination__link"

--- a/test/govuk_component/previous_and_next_navigation_test.rb
+++ b/test/govuk_component/previous_and_next_navigation_test.rb
@@ -16,7 +16,6 @@ class PreviousAndNextNavigationTestCase < ComponentTestCase
       label: "1 of 3"
     })
 
-    assert_select "meta[name='robots'][content='noindex']"
     assert_select ".pub-c-pagination[role='navigation']"
     assert_select ".pub-c-pagination__link-title", text: "Previous page"
     assert_select ".pub-c-pagination__link-label", text: "1 of 3"


### PR DESCRIPTION
This reverts commit 6dbf470a23e3bc6052f3cb1dc3704d030633055d.

Some pages use this component to move between different parts and we don't want to noindex those pages. In particular this is the case for mainstream and travel advice.