### PR TITLE
Mark moved components as deprecated in docs

### DIFF
--- a/app/views/govuk_component/docs/alpha_label.yml
+++ b/app/views/govuk_component/docs/alpha_label.yml
@@ -1,6 +1,5 @@
-name: Alpha Banner
-description: A banner that indicates content is in an alpha phase, with an optional
-  explanation
+name: Alpha Banner (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/phase_banner"
 accessibility_criteria: |
   The alpha label must:
 

--- a/app/views/govuk_component/docs/beta_label.yml
+++ b/app/views/govuk_component/docs/beta_label.yml
@@ -1,5 +1,5 @@
-name: Beta Banner
-description: A banner that indicates content is in a beta phase, with an optional explanation
+name: Beta Banner (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/phase_banner"
 accessibility_criteria: |
   The beta label must:
 

--- a/app/views/govuk_component/docs/government_navigation.yml
+++ b/app/views/govuk_component/docs/government_navigation.yml
@@ -1,7 +1,5 @@
-name: Government navigation
-description: Navigation placed in the header by Slimmer and used by pages which sit
-  under the /government path. This is a markup only component and is not available
-  for preview here. It can be passed a string to mark a link as being active.
+name: Government navigation (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/government_navigation"
 accessibility_criteria: |
   The government navigation component must:
 

--- a/app/views/govuk_component/docs/govspeak.yml
+++ b/app/views/govuk_component/docs/govspeak.yml
@@ -1,16 +1,5 @@
-name: Govspeak content
-description: To display long form text which has been converted from Govspeak
-body: |
-  [Govspeak](https://github.com/alphagov/govspeak) is GOV.UK's extension of Markdown.
-
-  This component has no control over markup, which is passed in to the component pre-generated. It only applies CSS/JS.
-
-  It applies styling to standard Markdown content, eg; paragraphs, headings and lists. It also applies styling to Govspeak specific markup, like [callouts](https://github.com/alphagov/govspeak#callouts), [contacts](https://github.com/alphagov/govspeak#points-of-contact) and [highlights](https://github.com/alphagov/govspeak#highlights).
-
-  In addition to styling, it also applies some Javascript behaviours.
-
-  - Progressively enhanced, accessible charts (using [Magna Charta](https://github.com/alphagov/magna-charta), derived from tabular data (see example below)
-  - Progressively enhanced, accessible embedded YouTube player (using [AccessibleMediaPlayer](https://github.com/alphagov/Accessible-Media-Player))
+name: Govspeak content (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/govspeak"
 accessibility_criteria: |
   - headings must be part of a correct heading structure for the page
   - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA

--- a/app/views/govuk_component/docs/govspeak_html_publication.yml
+++ b/app/views/govuk_component/docs/govspeak_html_publication.yml
@@ -1,9 +1,5 @@
-name: "Govspeak content (HTML Publications)"
-description: "To display long form text with numbered parts, which has been converted from Govspeak"
-body: |
-  This component calls the standard [Govspeak component](/components/govspeak), and layers a set of overriding styles on top. Styles for numbered parts are added, and heading sizes are increased.
-
-  Requires Slimmer >= 9.1.0 for nested component support.
+name: "Govspeak content (HTML Publications) (DEPRECATED)"
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/govspeak_html_publication"
 accessibility_criteria: |
   - headings must be part of a correct heading structure for the page
   - text should have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA

--- a/app/views/govuk_component/docs/lead_paragraph.yml
+++ b/app/views/govuk_component/docs/lead_paragraph.yml
@@ -1,9 +1,5 @@
-name: Lead paragraph
-description: The opening paragraph of content. Typically a content item’s description field.
-accessibility_criteria: |
-  The lead paragraph must be visually distinct from other paragraphs.
-
-  The lead paragraph must have a text contrast ratio higher than 4.5:1 against the background colour to meet WCAG AA (this especially applies when [placed on a darker background](/component-guide/lead_paragraph/on_topic_page)).
+name: Lead paragraph (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/lead_paragraph"
 examples:
   default:
     data:

--- a/app/views/govuk_component/docs/previous_and_next_navigation.yml
+++ b/app/views/govuk_component/docs/previous_and_next_navigation.yml
@@ -1,16 +1,5 @@
-name: Previous and next navigation
-description: Navigational links that allow users to navigate within a series of pages
-  or elements.
-body: |
-  This component accepts 2 optional parameters, previous and next.
-
-  Each optional parameter accepts:
-
-  - an URL for the link
-  - a title for the URL
-  - a label that can add extra info (ie page number) that will be displayed under the title
-
-  If one of the 2 parameters is nil, no link will appear.
+name: Previous and next navigation (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/previous_and_next_navigation"
 accessibility_criteria: |
   Icons in the component must not be announced by screen readers.
 

--- a/app/views/govuk_component/docs/title.yml
+++ b/app/views/govuk_component/docs/title.yml
@@ -1,13 +1,5 @@
-name: Page title
-description: A page title with optional context label
-body: |
-  This contains an optional parameter for average title length. The two valid
-  values for this parameter are 'medium' or 'long'. Medium titles are titles
-  where the average is around 30 characters or less. Long titles would have
-  an average length of nearer 50 characters or more.
-
-  On average the titles on government bits of content are 50 characters. The
-  average for bits of general guidance are nearer 27 characters long.
+name: Page title (DEPRECATED)
+description: "DEPRECATED: Use http://govuk-publishing-components.herokuapp.com/component-guide/title"
 accessibility_criteria: |
   The page title must:
 


### PR DESCRIPTION
We've moved these components to the gem so temporarily their used from both places. This warning intends to prevent confusion.

https://trello.com/c/pU7YINt1