### PR TITLE
Update govuk_template gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ end
 
 gem 'plek', '2.1.1'
 gem 'govuk_frontend_toolkit', '~> 7.5.0'
-gem 'govuk_template', '0.24.0'
+gem 'govuk_template', '0.24.1'
 gem 'gds-api-adapters', '~> 52.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
-    govuk_template (0.24.0)
+    govuk_template (0.24.1)
       rails (>= 3.1)
     hashdiff (0.3.7)
     highline (1.7.10)
@@ -349,7 +349,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.5.1)
   govuk_frontend_toolkit (~> 7.5.0)
   govuk_publishing_components (~> 9.3.1)
-  govuk_template (= 0.24.0)
+  govuk_template (= 0.24.1)
   image_optim (= 0.26.1)
   jasmine-rails (~> 0.14.1)
   minitest


### PR DESCRIPTION
This commit updates the version of `govuk_template` to pull a change to the crown copyright URL in the template footer.