### PR TITLE
Upgrade govuk_frontend_toolkit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,6 @@ group :development, :test do
 end
 
 gem 'plek', '2.1.1'
-gem 'govuk_frontend_toolkit', '~> 7.5.0'
+gem 'govuk_frontend_toolkit', '~> 7.6.0'
 gem 'govuk_template', '0.24.1'
 gem 'gds-api-adapters', '~> 52.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (7.5.0)
+    govuk_frontend_toolkit (7.6.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_publishing_components (9.9.0)
@@ -347,7 +347,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint (~> 3.8.0)
   govuk_app_config (~> 1.7.0)
-  govuk_frontend_toolkit (~> 7.5.0)
+  govuk_frontend_toolkit (~> 7.6.0)
   govuk_publishing_components (~> 9.9.0)
   govuk_template (= 0.24.1)
   image_optim (= 0.26.1)
@@ -372,4 +372,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -1160,12 +1160,13 @@ describe("GOVUK.StaticAnalytics", function() {
     // 1. get all arguments to all calls to the ga() function
     universalSetupArguments = window.ga.calls.allArgs()
 
-    // 2. get the ga(function(tracker) { ...}) call - it's the 4th one:
+    // 2. get the ga(function(tracker) { ...}) call - it's the 5th one:
     //    1st is the call to create "universal-id"
     //    2nd is the call to set "anonymizeIp"
     //    3rd is the call to set "displayFeaturesTask"
-    //    4th is the call that sets the tracker function callback
-    bound = universalSetupArguments[3][0];
+    //    4th is the call to set "location"
+    //    5th is the call that sets the tracker function callback
+    bound = universalSetupArguments[4][0];
 
     // 3. trigger the callback with a canned tracker object that has a stubbed
     //    get method that always retuns the same client id.  This is the only


### PR DESCRIPTION
This commit upgrades `govuk_frontend_toolkit` to 7.6.0 and makes a consequent change to the analytics test.

Trello: https://trello.com/c/jKitCyZI/311-remove-emails-from-ga-events-on-email-alert-frontend-pages-reprise