### PR TITLE
Rename publishing-app custom dimension

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -59,7 +59,7 @@
       'taxon-slugs': {dimension: 58, defaultValue: 'other'},
       'taxon-ids': {dimension: 59, defaultValue: 'other'},
       'content-has-history': {dimension: 39, defaultValue: 'false'},
-      'publishing-app': {dimension: 89},
+      'publishing-application': {dimension: 89},
       'stepnavs': {dimension: 96}
     };
 


### PR DESCRIPTION
There is a GA custom dimension called "rendering-application" so it makes sense
to call this metatag "publishing-application", as suggested by @thomasleese 

https://trello.com/c/vhfMGngX/239-investigate-and-correct-smart-answer-google-analytics-tracking