### PR TITLE
Increase environment survey frequency

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -347,7 +347,7 @@
       {
         identifier: 'environment_tree_test',
         surveyType: 'url',
-        frequency: 6,
+        frequency: 2,
         startTime: new Date('August 14, 2018').getTime(),
         endTime: new Date('August 18, 2018').getTime(),
         url: 'https://gdsuserresearch.optimalworkshop.com/treejack/i177xfzs?c={{currentPath}}',


### PR DESCRIPTION
This PR increases the frequency of the appearance of the environment survey banner to 1 every 2. This is to get enough data in the time span set.