### PR TITLE
Remove the link to `/government/policies` from the shared footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -70,7 +70,6 @@
           <li><a href="/government/how-government-works">How government works</a></li>
           <li><a href="/government/organisations">Departments</a></li>
           <li><a href="/world">Worldwide</a></li>
-          <li><a href="/government/policies">Policies</a></li>
           <li><a href="/government/publications">Publications</a></li>
           <li><a href="/government/announcements">Announcements</a></li>
         </ul>


### PR DESCRIPTION
This is because `Policies` are soon to be retired and so the navigation
to the polcies finder needs to be removed.

Trello:
https://trello.com/c/WyjKeXS4/210-remove-policies-link-from-grey-govuk-footer