### PR TITLE
Re-size the ul which contains the /government navbar

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -23,6 +23,10 @@
     }
   }
 
+  #proposition-links {
+    width: 90%;
+  }
+
   .search-toggle {
     display: none;
 


### PR DESCRIPTION
This is because the `Policies` link from the government navbar
has been removed in this PR:
https://github.com/alphagov/whitehall/pull/4354

When the `Policies` link is removed the format of the nav-bar elements
is distorted. Setting the width to 90% re-aligns the elements into a
nice format.