### PR TITLE
Update govuk frontend toolkit to 8.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,6 @@ group :development, :test do
 end
 
 gem 'plek', '2.1.1'
-gem 'govuk_frontend_toolkit', '~> 8.0.0'
+gem 'govuk_frontend_toolkit', '~> 8.1.0'
 gem 'govuk_template', '0.24.1'
 gem 'gds-api-adapters', '~> 53.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_frontend_toolkit (8.0.0)
+    govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
     govuk_publishing_components (11.2.0)
@@ -361,7 +361,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint (~> 3.9.0)
   govuk_app_config (~> 1.9.3)
-  govuk_frontend_toolkit (~> 8.0.0)
+  govuk_frontend_toolkit (~> 8.1.0)
   govuk_publishing_components (~> 11.2.0)
   govuk_template (= 0.24.1)
   govuk_test

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -70,8 +70,8 @@
     this.analytics.trackShare(network, trackingOptions);
   };
 
-  StaticAnalytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain) {
-    this.analytics.addLinkedTrackerDomain(trackerId, name, domain);
+  StaticAnalytics.prototype.addLinkedTrackerDomain = function (trackerId, name, domain, sendPageView) {
+    this.analytics.addLinkedTrackerDomain(trackerId, name, domain, sendPageView);
   };
 
   StaticAnalytics.prototype.setOptionsForNextPageview = function (options) {


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

Enables cross domain event tracking features.