### PR TITLE
Memoize linked trackers in the GOVUK.Modules namespace

### DIFF
--- a/app/assets/javascripts/modules/cross-domain-tracking.js
+++ b/app/assets/javascripts/modules/cross-domain-tracking.js
@@ -5,6 +5,8 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
 
   var $ = global.$
 
+  Modules.crossDomainLinkedTrackers = []
+
   Modules.CrossDomainTracking = function () {
     this.start = function ($context) {
       var trackableLinkSelector = '[href][data-tracking-code][data-tracking-name]'
@@ -12,15 +14,14 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
       if ($context.is(trackableLinkSelector)) {
         addLinkedTrackerDomain($context)
       } else {
-        var linkedTrackers = []
         $context
           .find(trackableLinkSelector)
           .each(function () {
             var $element = $(this)
             var trackerName = $element.attr('data-tracking-name')
-            if (linkedTrackers.indexOf(trackerName) === -1) {
+            if (Modules.crossDomainLinkedTrackers.indexOf(trackerName) === -1) {
               addLinkedTrackerDomain($element)
-              linkedTrackers.push(trackerName)
+              Modules.crossDomainLinkedTrackers.push(trackerName)
             }
           })
       }

--- a/spec/javascripts/modules/cross-domain-tracking.spec.js
+++ b/spec/javascripts/modules/cross-domain-tracking.spec.js
@@ -3,9 +3,9 @@ describe('Cross Domain Tracking', function () {
   var module
 
   beforeEach(function () {
+    GOVUK.Modules.crossDomainLinkedTrackers = []
     GOVUK.analytics = GOVUK.analytics || {}
-    GOVUK.analytics.addLinkedTrackerDomain = function () {
-    }
+    GOVUK.analytics.addLinkedTrackerDomain = function () {}
 
     spyOn(GOVUK.analytics, 'addLinkedTrackerDomain')
     module = new GOVUK.Modules.CrossDomainTracking()
@@ -139,6 +139,9 @@ describe('Cross Domain Tracking', function () {
     wrapperDiv.appendChild(anchor2)
 
     module.start($(wrapperDiv))
+
+    var moduleDup = new GOVUK.Modules.CrossDomainTracking()
+    moduleDup.start($(wrapperDiv))
 
     expect(GOVUK.analytics.addLinkedTrackerDomain.calls.count()).toBe(1)
   })


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

[GOVUK.Modules initializes and starts a module for every element
with a data-module attribute](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/modules.js#L35-L37). 
This causes errors for cross-domain-tracking if two elements should send data to the same tracker because the underlying ga library raises  the error`Command ignored. Plugin "linker" has already been required on tracker "govspeakButtonTracker".`

The trackers are memoized by name at the Modules level so that new instances of CrossDomainTracking can be initialized and started without reconfiguring the same ga tracker.