### PR TITLE
Deduplicate trackers regardless of context

### DIFF
--- a/app/assets/javascripts/modules/cross-domain-tracking.js
+++ b/app/assets/javascripts/modules/cross-domain-tracking.js
@@ -17,24 +17,24 @@ window.GOVUK.Modules = window.GOVUK.Modules || {};
         $context
           .find(trackableLinkSelector)
           .each(function () {
-            var $element = $(this)
-            var trackerName = $element.attr('data-tracking-name')
-            if (Modules.crossDomainLinkedTrackers.indexOf(trackerName) === -1) {
-              addLinkedTrackerDomain($element)
-              Modules.crossDomainLinkedTrackers.push(trackerName)
-            }
+            addLinkedTrackerDomain($(this))
           })
       }
     }
 
     function addLinkedTrackerDomain ($element) {
-      var code = $element.attr('data-tracking-code')
       var name = $element.attr('data-tracking-name')
+      var code = $element.attr('data-tracking-code')
       var trackEvent = ($element.attr('data-tracking-track-event') === 'true')
-      var hostname = $element.prop('hostname')
 
       if (GOVUK.analytics !== 'undefined') {
-        GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
+        if (Modules.crossDomainLinkedTrackers.indexOf(name) === -1) {
+          var hostname = $element.prop('hostname')
+
+          GOVUK.analytics.addLinkedTrackerDomain(code, name, hostname)
+
+          Modules.crossDomainLinkedTrackers.push(name)
+        }
 
         if (trackEvent) {
           $element.click({ text: $element.text(), name: name }, function (e) {

--- a/spec/javascripts/modules/cross-domain-tracking.spec.js
+++ b/spec/javascripts/modules/cross-domain-tracking.spec.js
@@ -121,18 +121,24 @@ describe('Cross Domain Tracking', function () {
     ).toHaveBeenCalledWith('External Link Clicked', 'Do some voting', { trackerName: 'govspeakButtonTracker' })
   })
 
-  it('adds the linked tracker domain once', function () {
+  it('adds the linked tracker domain once for multiple cross domain tracking elements', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
     var anchor1 = document.createElement('a')
-    anchor1.href = 'https://www.gov.uk/browse/citizenship/voting'
+    anchor1.href = 'https://www.gov.uk/browse/citizenship/surfing'
     anchor1.setAttribute('data-module', 'cross-domain-tracking')
     anchor1.setAttribute('data-tracking-code', 'UA-XXXXXXXXX-Y')
     anchor1.setAttribute('data-tracking-name', 'govspeakButtonTracker')
+    anchor1.setAttribute('data-tracking-track-event', 'true')
+    anchor1.innerText = 'Do some surfing'
 
     var anchor2 = document.createElement('a')
     anchor2.href = 'https://www.gov.uk/browse/citizenship/shopping'
     anchor2.setAttribute('data-module', 'cross-domain-tracking')
     anchor2.setAttribute('data-tracking-code', 'UA-XXXXXXXXX-Y')
     anchor2.setAttribute('data-tracking-name', 'govspeakButtonTracker')
+    anchor2.setAttribute('data-tracking-track-event', 'true')
+    anchor2.innerText = 'Do some shopping'
 
     var wrapperDiv = document.createElement('div')
     wrapperDiv.appendChild(anchor1)
@@ -141,8 +147,20 @@ describe('Cross Domain Tracking', function () {
     module.start($(wrapperDiv))
 
     var moduleDup = new GOVUK.Modules.CrossDomainTracking()
-    moduleDup.start($(wrapperDiv))
+    moduleDup.start($(anchor2))
 
     expect(GOVUK.analytics.addLinkedTrackerDomain.calls.count()).toBe(1)
+
+    $(anchor1).trigger('click')
+
+    expect(
+      GOVUK.analytics.trackEvent
+    ).toHaveBeenCalledWith('External Link Clicked', 'Do some surfing', { trackerName: 'govspeakButtonTracker' })
+
+    $(anchor2).trigger('click')
+
+    expect(
+      GOVUK.analytics.trackEvent
+    ).toHaveBeenCalledWith('External Link Clicked', 'Do some shopping', { trackerName: 'govspeakButtonTracker' })
   })
 })


### PR DESCRIPTION
https://trello.com/c/CbTYssq1/478-enable-cross-domain-tracking-for-cysp-govuk-sign-in-pages

[The initial attempt at deduplicating tracker configuration didn't completely cover this](https://github.com/alphagov/static/pull/1556)

The cross domain tracking module can be applied to a block level element
containing matching elements or to an element suchas an anchor tag.
In the case of multiple start buttons GOVUK.Modules attempts to initialize
trackers on a per button basis, so it's important that both recursive and
explicit element contexts are covered.
This means moving the check for duplicate trackers into the addLinkedTrackerDomain
function as this is called for either element context lookup.