### PR TITLE
T117: Update govuk_template to 0.25.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,5 +38,5 @@ end
 
 gem 'plek', '2.1.1'
 gem 'govuk_frontend_toolkit', '~> 8.1.0'
-gem 'govuk_template', '0.24.1'
+gem 'govuk_template', '0.25.0'
 gem 'gds-api-adapters', '~> 54.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       rouge
       sass-rails (>= 5.0.4)
       slimmer (>= 11.1.0)
-    govuk_template (0.24.1)
+    govuk_template (0.25.0)
       rails (>= 3.1)
     govuk_test (0.2.1)
       capybara
@@ -363,7 +363,7 @@ DEPENDENCIES
   govuk_app_config (~> 1.10.0)
   govuk_frontend_toolkit (~> 8.1.0)
   govuk_publishing_components (~> 11.2.0)
-  govuk_template (= 0.24.1)
+  govuk_template (= 0.25.0)
   govuk_test
   image_optim (= 0.26.3)
   jasmine-rails (~> 0.14.8)


### PR DESCRIPTION
This commit updates the gem _govuk_template_ to version `0.25.0`, in order to serve the header with event tracking on the GOV.UK logo.

Solo: @karlbaker02