### PR TITLE
Document development VM timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ are wrapped around feedback pages, run `bowl feedback
 in a separate terminal. Following local edits to `static`, restarting just
 `feedback` should be sufficient.
 
+If you repeatedly see 504 Gateway Timeout errors when developing with static in your
+development VM it's possible to increase the `proxy_read_timeout` value in
+`/etc/nginx/sites-available/static.dev.gov.uk` and restart nginx on the VM.
+
 ### Running the test suite
 
 `bundle exec rake` runs the test suite.


### PR DESCRIPTION
Gateway timeouts are common when developing static on the VM.
Usually this occurs when running static on the vm with another
frontend app. It's possible to circumvent the problem with an
nginx config update.