### PR TITLE
Remove unnecessary bottom margin

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -342,7 +342,6 @@
   }
 }
 
-
 .show-global-bar #global-header-bar {
   display: none;
 }
@@ -350,7 +349,6 @@
 .global-bar {
   background-color: #BFE3E0;
   display: none;
-  margin-bottom: 15px;
   padding: 15px 0;
 
   .show-global-bar & {


### PR DESCRIPTION
https://trello.com/c/STyMu3Cp/97-fix-spacing-below-banner-on-header-ised-pages

This produces whitespace where a blue 'hero' header follows the generic banner, eg. homepage or topic pages.
There's no noticeable difference in spacing on pages without this header.

![screenshot from 2018-12-07 10-50-35](https://user-images.githubusercontent.com/93511/49643605-0e3a7b80-fa0e-11e8-9e06-46ea3e6a6c7f.png)
