### PR TITLE
Fix global bar dupe attribute definition

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -12,7 +12,7 @@
     <!--<![endif]-->
   <% end %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="global-bar" data-module="global-bar" class="dont-print">
+  <div id="global-bar" class="global-bar dont-print" data-module="global-bar">
     <div class="global-bar-message-container">
     <p class="global-bar-message">
       <span class="global-bar-title"><%= title %></span>


### PR DESCRIPTION
Bug found via e2e test output: https://ci.integration.publishing.service.gov.uk/job/publishing-e2e-tests/job/test-against/17090/artifact/tmp/errors-verbose.log

2nd commit is to demonstrate the bug is fixed and will be removed as we don't want to enable this banner.

cc @nickcolley 