### PR TITLE
Remove outdated supertypes

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -52,8 +52,6 @@
       'rendering-application': {dimension: 20},
       'navigation-legacy': {dimension: 30, defaultValue: 'none'},
       'navigation-page-type': {dimension: 32, defaultValue: 'none'},
-      'user-journey-stage': {dimension: 33, defaultValue: 'thing'},
-      'navigation-document-type': {dimension: 34, defaultValue: 'other'},
       'taxon-slug': {dimension: 56, defaultValue: 'other'},
       'taxon-id': {dimension: 57, defaultValue: 'other'},
       'taxon-slugs': {dimension: 58, defaultValue: 'other'},

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -228,8 +228,6 @@ describe('Ecommerce reporter for results pages', function() {
       dimension26: '0',
       dimension27: '0',
       dimension32: 'none',
-      dimension33: 'thing',
-      dimension34: 'other',
       dimension39: 'false',
       dimension56: 'other',
       dimension57: 'other',

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -184,16 +184,6 @@ describe("GOVUK.StaticAnalytics", function() {
           defaultValue: 'none'
         },
         {
-          name: 'user-journey-stage',
-          number: 33,
-          defaultValue: 'thing'
-        },
-        {
-          name: 'navigation-document-type',
-          number: 34,
-          defaultValue: 'other'
-        },
-        {
           name: 'content-id',
           number: 4,
           defaultValue: '00000000-0000-0000-0000-000000000000'


### PR DESCRIPTION
We're currently sending the value of two meta tags, `govuk:user-journey-stage` and `govuk:navigation-document-type` to Analytics. These supertypes are out of date and deprecated. They've been removed from the meta tags in https://github.com/alphagov/govuk_publishing_components/pull/709. This also removes the code to send them to analytics.

https://trello.com/c/hp5BJD2i