### PR TITLE
[Do not merge ]Add IPO user panel survey

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -68,7 +68,32 @@
       frequency: 6,
       surveyType: 'email'
     },
-    smallSurveys: [],
+    smallSurveys: [
+      {
+        identifier: '#Userpanel',
+        surveyType: 'url',
+        frequency: 10,
+        startTime: new Date("February 01, 2019").getTime(),
+        endTime: new Date("December 31, 2019").getTime(),
+        url: 'https://response.questback.com/intellectualpropertyoffice/ipocustomerpanel?c={{currentPath}}',
+        templateArgs: {
+          title: "Help improve online services by joining the IPO user panel (opens in new window)",
+          surveyCta: 'Help improve online services by joining the IPO user panel (opens in new window)',
+          surveyCtaPostscript: 'Help improve online services by joining the IPO user panel (opens in new window)'
+        },
+        activeWhen: {
+          path: [
+            '^/topic/intellectual-property/trade-marks',
+            '^/topic/intellectual-property/patents',
+            '^/topic/intellectual-property/designs',
+            '^/government/organisations/intellectual-property-office',
+            '^/how-to-register-a-trade-mark',
+            '^/apply-for-a-patent',
+            '^/apply-register-design'
+          ]
+        }
+      }
+    ],
 
     init: function () {
       if (userSurveys.canShowAnySurvey()) {


### PR DESCRIPTION
This adds a new survey which will appear

* for 10% of users
* on these paths
```
  '/topic/intellectual-property/trade-marks'
  '/topic/intellectual-property/patents'
  '/topic/intellectual-property/designs'
  '/government/organisations/intellectual-property-office'
  '/how-to-register-a-trade-mark'
  '/apply-for-a-patent'
  '/apply-register-design'
```
* between Feb 1st and Dec 31st 2019