### PR TITLE
Change link from Announcements to News and communications

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -87,7 +87,7 @@
           <li><a href="/government/organisations">Departments</a></li>
           <li><a href="/world">Worldwide</a></li>
           <li><a href="/government/publications">Publications</a></li>
-          <li><a href="/government/announcements">Announcements</a></li>
+          <li><a href="/news-and-communications">News and communications</a></li>
         </ul>
       </div>
       <hr>


### PR DESCRIPTION
https://trello.com/c/CvwsYUuD/341-replace-announcements-link-in-header-footer-and-on-homepage

This switches the link from `/government/announcements` to `/news-and-communications` in the **sitewide footer**.

This is a new finder replacing an old finder. View the new finder: https://www.gov.uk/news-and-communications.