### PR TITLE
Make barchart govspeak enhancement resilient to re-initialisation

### DIFF
--- a/app/assets/javascripts/govuk-component/govspeak-convert-html-pub-charts.js
+++ b/app/assets/javascripts/govuk-component/govspeak-convert-html-pub-charts.js
@@ -1,8 +1,9 @@
 function govspeakBarcharts() {
-    $('.govuk-govspeak .js-barchart-table').each(function() {
+    $('.govuk-govspeak .js-barchart-table:not(.mc-chart):not(.js-barchart-table-init)').each(function() {
         $.magnaCharta($(this), {
             toggleText: "Change between chart and table"
         });
+      $(this).addClass('js-barchart-table-init')
     })
 }
 $(govspeakBarcharts);


### PR DESCRIPTION
Trello: https://trello.com/c/VDgVNurM/544-extract-govspeak-javascript-functionality-to-govukpublishingcomponents

This barchart initialisation is vulnerable to breaking a component if
the initialisation is called twice. As the code for this is moving to
govuk_publishing_components there is going to be a period of time where
this can quite easily occur while apps are being updated and deployed.

This updates this initialisation code to mark when a chart has been
initialised and be able to ignore being run on charts that have already
been initialised.