### PR TITLE
Set Suvey seen cookie expiry to 2 years

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -400,7 +400,7 @@
       if (cooloff) {
         window.GOVUK.cookie(cookieName, seenCount, { days: cooloff })
       } else {
-        window.GOVUK.cookie(cookieName, seenCount)
+        window.GOVUK.cookie(cookieName, seenCount, { days: 365 * 2 })
       }
     },
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -1089,7 +1089,7 @@ describe('Surveys', function () {
         var cookieName = surveys.surveySeenCookieName(survey)
         spyOn(GOVUK, 'cookie')
         surveys.incrementSurveySeenCounter(survey)
-        expect(GOVUK.cookie).toHaveBeenCalledWith(cookieName, 1)
+        expect(GOVUK.cookie).toHaveBeenCalledWith(cookieName, 1, { days: 365 * 2 })
       })
     })
 


### PR DESCRIPTION
GOV.UK should have a senible expiry date for all cookies.