### PR TITLE
Auto-generate non-digest versions of JS assets

### DIFF
--- a/lib/tasks/asset_compile.rake
+++ b/lib/tasks/asset_compile.rake
@@ -1,0 +1,23 @@
+require 'json'
+
+Rake::Task['assets:precompile'].enhance do
+  Rake::Task['asset_precompile:create_non_digest_assets'].invoke
+end
+
+namespace :asset_precompile do
+  task :create_non_digest_assets do
+    relative_asset_path = 'public/static'
+    manifest_path = Dir.glob(File.join(Rails.root, relative_asset_path, '.sprockets-manifest-*.json')).first
+
+    manifest_data = JSON.parse(File.read(manifest_path))
+
+    manifest_data["assets"].each do |logical_path, digested_path|
+      if logical_path.end_with?('.js')
+        full_digested_path = File.join(Rails.root, relative_asset_path, digested_path)
+        full_nondigested_path = File.join(Rails.root, relative_asset_path, logical_path)
+
+        FileUtils.ln_s full_digested_path, full_nondigested_path, force: true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR extends the `assets:precompile` Rake task to automatically generate non-digest versions of all JavaScript files, as an intermediary step to ensure that tests on our CI continue to pass until such time as all tests use fingerprinted versions of dependent JS files.

Influenced in large part by https://bibwild.wordpress.com/2014/10/02/non-digested-asset-names-in-rails-4-your-options (Rails 5 offers us no respite in this area either).