### PR TITLE
Add symbolic link for jquery-1.7.2 in assets precompile

### DIFF
--- a/lib/tasks/asset_compile.rake
+++ b/lib/tasks/asset_compile.rake
@@ -17,6 +17,12 @@ namespace :asset_precompile do
         full_nondigested_path = File.join(Rails.root, relative_asset_path, logical_path)
 
         FileUtils.ln_s full_digested_path, full_nondigested_path, force: true
+
+        if logical_path == 'libs/jquery/jquery-1.12.4.js'
+          jquery_nondigested_path = File.join(Rails.root, relative_asset_path, 'libs/jquery/jquery-1.7.2.js')
+
+          FileUtils.ln_s full_digested_path, jquery_nondigested_path, force: true
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds a missing symbolic link which maps jquery-1.7.2 to jquery-1.12.4. This is a temporary fix until such time as we update the test wrapper to reference a fingerprinted version of jquery-1.12.4, and is necessary to ensure that all apps using Static continue to pass tests on CI.