### PR TITLE
Update Testing surveys doc

### DIFF
--- a/doc/surveys.md
+++ b/doc/surveys.md
@@ -239,9 +239,9 @@ We record how many times a given survey is shown to a user and won't show it aga
 You can test if the surveys work locally by starting up the various rendering apps needed for the GOVUK page that you want the survey to be appear on. e.g.
 A link for "government/policies" requires the `finder-frontend` app, so you would need to call `bowl finder-frontend` in the development VM. You can check which rendering app is needed by going to `www.gov.uk/api/content/<path here>`, e.g. `www.gov.uk/api/content/government/policies`
 
-Usually it would be enough to call `bowl government-frontend finder-frontend whitehall router`
+Usually it would be enough to call `bowl frontend government-frontend finder-frontend whitehall router`
 
-The `router` at the end allows you to access the link by `www.dev.gov.uk` in your browser. Following on from the previous example you could go to `www.dev.org.uk/government/policies` to check if the survey will appear.
+The `router` at the end allows you to access the link by `www.dev.gov.uk` in your browser. Following on from the previous example you could go to `www.dev.gov.uk/government/policies` to check if the survey will appear.
 
 You can check if the `activeWhen paths` for your survey are correct by typing `GOVUK.userSurveys.pathMatch(<insert path here>)` into the browser console on the page. A return of `true` indicates that path matches.
 


### PR DESCRIPTION
Add `frontend` to the suggested `bowl` call as it is a common rendering app and
fix typo/mistake in the example link.