### PR TITLE
Update finder links in footer. 

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -86,8 +86,12 @@
           <li><a href="/government/how-government-works">How government works</a></li>
           <li><a href="/government/organisations">Departments</a></li>
           <li><a href="/world">Worldwide</a></li>
-          <li><a href="/government/publications">Publications</a></li>
-          <li><a href="/news-and-communications">News and communications</a></li>
+          <li><a href="/search/services">Services</a></li>
+          <li><a href="/search/guidance-and-regulation">Guidance and regulation</a></li>
+          <li><a href="/search/news-and-communications">News and communications</a></li>
+          <li><a href="/search/statistics">Research and statistics</a></li>
+          <li><a href="/search/policy-papers-and-consultations">Policy papers and consultations</a></li>
+          <li><a href="/search/transparency-and-freedom-of-information-releases">Transparency and freedom of information releases</a></li>
         </ul>
       </div>
       <hr>


### PR DESCRIPTION
This change updates the links in the footer to point to our new
supergroup finders.

Trello: https://trello.com/c/oNnbf7b8/512-add-5-supergroup-finders-to-govuk-footer-s

![image](https://user-images.githubusercontent.com/6050162/54358078-6a3d1d80-4657-11e9-9294-6184b55b898f.png)
