### PR TITLE
Temporarily disable the statistics finder link in the footer.

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -89,7 +89,7 @@
           <li><a href="/search/services">Services</a></li>
           <li><a href="/search/guidance-and-regulation">Guidance and regulation</a></li>
           <li><a href="/search/news-and-communications">News and communications</a></li>
-          <li><a href="/search/statistics">Research and statistics</a></li>
+          <!--li><a href="/search/statistics">Research and statistics</a></li-->
           <li><a href="/search/policy-papers-and-consultations">Policy papers and consultations</a></li>
           <li><a href="/search/transparency-and-freedom-of-information-releases">Transparency and freedom of information releases</a></li>
         </ul>


### PR DESCRIPTION
The statistics finder isn't ready yet. Will enable in a later
PR