### PR TITLE
Update cookie banner

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -1,0 +1,115 @@
+<%= yield :top_of_page %>
+<!DOCTYPE html>
+<!--[if lt IE 9]><html class="lte-ie8" lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><![endif]-->
+<!--[if gt IE 8]><!--><html lang="<%= content_for?(:html_lang) ? yield(:html_lang) : "en" %>"><!--<![endif]-->
+  <head>
+    <meta charset="utf-8" />
+    <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
+
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+    <!--[if IE 6]><%= stylesheet_link_tag "govuk-template-ie6.css" %><![endif]-->
+    <!--[if IE 7]><%= stylesheet_link_tag "govuk-template-ie7.css" %><![endif]-->
+    <!--[if IE 8]><%= stylesheet_link_tag "govuk-template-ie8.css" %><![endif]-->
+    <%= stylesheet_link_tag "govuk-template-print.css", media: "print", integrity: true, crossorigin: "anonymous" %>
+
+    <%= stylesheet_link_tag "fonts.css", media: "all", integrity: true, crossorigin: "anonymous" %>
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
+
+    <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
+    <%# the colour used for mask-icon is the standard palette $black from
+        https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
+    <link rel="mask-icon" href="<%= asset_path 'gov.uk_logotype_crown.svg' %>" color="#0b0c0c">
+    <link rel="apple-touch-icon" sizes="180x180" href="<%= asset_path "apple-touch-icon-180x180.png" %>">
+    <link rel="apple-touch-icon" sizes="167x167" href="<%= asset_path "apple-touch-icon-167x167.png" %>">
+    <link rel="apple-touch-icon" sizes="152x152" href="<%= asset_path "apple-touch-icon-152x152.png" %>">
+    <link rel="apple-touch-icon" href="<%= asset_path "apple-touch-icon.png" %>">
+
+    <%# the colour used for theme-color is the standard palette $black from
+        https://github.com/alphagov/govuk_frontend_toolkit/blob/master/stylesheets/colours/_palette.scss %>
+    <meta name="theme-color" content="#0b0c0c" />
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <%= yield :head %>
+
+    <%# The default og:image is added below :head so that scrapers see any custom metatags first, and this is just a fallback %>
+    <meta property="og:image" content="<%= asset_path "opengraph-image.png" %>">
+  </head>
+
+  <body<%= content_for?(:body_classes) ? raw(" class=\"#{yield(:body_classes)}\"") : '' %>>
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    <%= yield :body_start %>
+
+    <div id="skiplink-container">
+      <div>
+        <a href="#content" class="skiplink"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : "Skip to main content" %></a>
+      </div>
+    </div>
+
+    <div id="global-cookie-message">
+      <% if content_for?(:cookie_message) %>
+        <%= yield :cookie_message %>
+      <% else %>
+        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a></p>
+      <% end %>
+    </div>
+
+    <% unless @omit_header %>
+    <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
+      <div class="header-wrapper">
+        <div class="header-global">
+          <div class="header-logo">
+            <a href="<%= content_for?(:homepage_url) ? yield(:homepage_url) : "https://www.gov.uk/" %>" title="<%= content_for?(:logo_link_title) ? yield(:logo_link_title) : "Go to the GOV.UK homepage" %>" id="logo" class="content" data-module="track-click" data-track-category="homeLinkClicked" data-track-action="homeHeader">
+              <img src="<%= asset_path 'gov.uk_logotype_crown_invert_trans.png' %>" width="36" height="32" alt=""> <%= content_for?(:global_header_text) ? yield(:global_header_text) : "GOV.UK" %>
+            </a>
+          </div>
+          <%= yield :inside_header %>
+        </div>
+        <%= yield :proposition_header %>
+      </div>
+    </header>
+    <% end %>
+
+    <%= yield :after_header %>
+
+    <div id="global-header-bar"></div>
+
+    <%= content_for?(:content) ? yield(:content) : yield %>
+
+    <footer class="group js-footer" id="footer" role="contentinfo">
+
+      <div class="footer-wrapper">
+        <%= yield :footer_top %>
+
+        <div class="footer-meta">
+          <div class="footer-meta-inner">
+            <%= yield :footer_support_links %>
+
+            <div class="open-government-licence">
+              <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
+              <% if content_for?(:licence_message) %>
+                <%= yield :licence_message %>
+              <% else %>
+                <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>
+              <% end %>
+            </div>
+          </div>
+
+          <div class="copyright">
+            <a href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"><%= content_for?(:crown_copyright_message) ? yield(:crown_copyright_message) : "© Crown copyright" %></a>
+          </div>
+        </div>
+      </div>
+    </footer>
+
+    <div id="global-app-error" class="app-error hidden"></div>
+
+    <% javascript_include_tag "govuk-template.js", integrity: true, crossorigin: "anonymous" %>
+
+    <%= yield :body_end %>
+
+    <%# if no GOVUK-namespaced module has loaded we can assume JS has failed and remove the class %>
+    <script>if (typeof window.GOVUK === 'undefined') document.body.className = document.body.className.replace('js-enabled', '');</script>
+  </body>
+</html>

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -47,13 +47,7 @@
       </div>
     </div>
 
-    <div id="global-cookie-message">
-      <% if content_for?(:cookie_message) %>
-        <%= yield :cookie_message %>
-      <% else %>
-        <p>GOV.UK uses cookies to make the site simpler. <a href="https://www.gov.uk/help/cookies" data-module="track-click" data-track-category="cookieBanner" data-track-action="Cookie banner clicked">Find out more about cookies</a></p>
-      <% end %>
-    </div>
+    <%= render "govuk_publishing_components/components/cookie_banner" %>
 
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
@@ -104,8 +98,6 @@
     </footer>
 
     <div id="global-app-error" class="app-error hidden"></div>
-
-    <% javascript_include_tag "govuk-template.js", integrity: true, crossorigin: "anonymous" %>
 
     <%= yield :body_end %>
 


### PR DESCRIPTION
This PR aims to update the cookie banner coming from govuk_template.

Limitations taken into consideration:
- govuk_template is deprecated (additional work should not be done in that repository) 
- there's no option to pass custom content to replace the cookie banner container
- there's no way to overwrite the cookie banner script because it's being shipped as an IIFE

In order to achieve that I:
- copied over the main layout file ([govuk_template.html.erb](https://github.com/alphagov/govuk_template/blob/f83f1de/source/views/layouts/govuk_template.html.erb)) from govuk_template
- updated the main layout file to replace the cookie banner with the component from govuk_publishing_components (~~[unreleased at this very moment](https://github.com/alphagov/govuk_publishing_components/pull/795); hence the CI errors, but tested with a local version and all tests pass~~)

As non-ideal as this may seem, the long term plan is to replace other parts of this template file (e.g. skip_link, header, footer and even the  rest of the template itself) with components from govuk_publishing_components and one way to make it so is to bring it in and break replace it piece by piece.

### Preview
<img width="1440" alt="Screen Shot 2019-03-21 at 16 08 46" src="https://user-images.githubusercontent.com/788096/54766674-9c202800-4bf3-11e9-8906-f4ba5bb322b9.png">

[Trello card](https://trello.com/c/y8JyxGL9)