### PR TITLE
Adds new custom dimension to track relevant result shown in finders

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -58,7 +58,8 @@
       'taxon-ids': {dimension: 59, defaultValue: 'other'},
       'content-has-history': {dimension: 39, defaultValue: 'false'},
       'publishing-application': {dimension: 89},
-      'stepnavs': {dimension: 96}
+      'stepnavs': {dimension: 96},
+      'relevant-result-shown': {dimension: 83}
     };
 
     var $metas = $('meta[name^="govuk:"]');


### PR DESCRIPTION
The new custom dimension is Relevant result shown (83). This should be set to 'Yes' if a  search in the finder search box results in a 'relevant result'. (The null label is 'No'.) 

https://trello.com/c/lwQK2Pi7/336-set-up-a-b-test-for-answer-boxes