### PR TITLE
Analytics and surveys depend on GOVUK.cookie

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,3 +1,4 @@
+//= require govuk_publishing_components/lib/cookie-functions
 //= require govuk/analytics/google-analytics-universal-tracker
 //= require govuk/analytics/govuk-tracker
 //= require govuk/analytics/analytics

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -1,4 +1,5 @@
-// = require_self
+//= require govuk_publishing_components/lib/cookie-functions
+//= require_self
 
 (function ($) {
   'use strict'


### PR DESCRIPTION
Explicitly add dependencies on cookie function (recently moved from govuk_template to govuk_publishing_components) for analytics and surveys.