### PR TITLE
Allow survey banner to be shown with cookie banner

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -458,7 +458,6 @@
     otherNotificationVisible: function () {
       var notificationIds = [
         '.govuk-emergency-banner:visible',
-        '#global-cookie-message:visible',
         '#global-browser-prompt:visible',
         '#taxonomy-survey:visible'
       ]

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -474,10 +474,10 @@ describe('Surveys', function () {
   })
 
   describe('otherNotificationVisible', function () {
-    it('returns false if the global cookie banner is visible', function () {
+    it('returns true if the global cookie banner is visible', function () {
       $('#global-cookie-message').css('display', 'block')
 
-      expect(surveys.canShowAnySurvey(defaultSurvey)).toBeFalsy()
+      expect(surveys.canShowAnySurvey(defaultSurvey)).toBeTruthy()
     })
 
     it('returns false if the emergency banner is visible', function () {


### PR DESCRIPTION
We were previously preventing the survey banner from being shown when any other banners were present, including the cookie banner. Now that the cookie banner is persistent, we want to allow both to show at the same time.

<img width="1089" alt="Screen Shot 2019-04-18 at 11 47 17" src="https://user-images.githubusercontent.com/29889908/56356066-bdaf0800-61cf-11e9-8365-e057e6ecdee2.png">