### PR TITLE
Tweak survey banner styling

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -249,11 +249,12 @@
 
     @include media-down(mobile) {
       .survey-close-button {
-        font-size: 20px;
+        font-size: 16px;
       }
       .survey-title {
+        display: inline-block;
         font-size: 18px;
-        margin-top: 2em;
+        width: 75%;
       }
       .survey-primary-link, .postscript-cta {
         font-size: 18px;
@@ -295,7 +296,7 @@
 
   .survey-close-button {
     float: right;
-    @include core-14;
+    @include core-19;
   }
 
   .survey-primary-link {


### PR DESCRIPTION
Brings font size in line with body text font size. Removes the vertical space between the close button and survey title on mobile.

Requested by @markhurrell :
<img width="1086" alt="Screen Shot 2019-04-18 at 12 17 00" src="https://user-images.githubusercontent.com/29889908/56357534-eafdb500-61d3-11e9-865f-b0a4a9d557a0.png">

## Before
<img width="250" alt="Screen Shot 2019-04-18 at 12 14 40" src="https://user-images.githubusercontent.com/29889908/56357403-91958600-61d3-11e9-8671-7ce7ffe7ac92.png">

## After
<img width="254" alt="Screen Shot 2019-04-18 at 12 11 49" src="https://user-images.githubusercontent.com/29889908/56357340-64e16e80-61d3-11e9-8e84-e9f4cad79cc4.png">