### PR TITLE
Remove track-click from footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -79,7 +79,7 @@
         </ul>
       </div>
 
-      <div class="footer-inside-government" data-module="track-click">
+      <div class="footer-inside-government">
         <h2>Departments and policy</h2>
 
         <ul>


### PR DESCRIPTION
This additional track-click would cause two events
to be fired when users clicked the links.

Trello: https://trello.com/c/z9DP4EMK/402