### PR TITLE
Bump govuk_publishing_components to 16.12.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.7"
 gem 'asset_bom_removal-rails', '~> 1.0.0'
 gem 'nokogiri', "~> 1.10"
 gem 'redis', "~> 4.1.0"
-gem 'govuk_publishing_components', '~> 16.11'
+gem 'govuk_publishing_components', '~> 16.12.0'
 gem 'govuk_app_config', '~> 1.15.1'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     govuk_frontend_toolkit (8.1.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (16.11.0)
+    govuk_publishing_components (16.12.0)
       govspeak (>= 5.0.3)
       govuk_app_config
       govuk_frontend_toolkit
@@ -255,7 +255,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rinku (2.0.5)
+    rinku (2.0.6)
     rouge (3.3.0)
     rubocop (0.64.0)
       jaro_winkler (~> 1.5.1)
@@ -350,7 +350,7 @@ DEPENDENCIES
   govuk-lint (~> 3.10)
   govuk_app_config (~> 1.15.1)
   govuk_frontend_toolkit (~> 8.1.0)
-  govuk_publishing_components (~> 16.11)
+  govuk_publishing_components (~> 16.12.0)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.3)


### PR DESCRIPTION
Includes:

- Fire GA event when cookie banner isn't shown, instead of when it is 