### PR TITLE
Add cookie banner shown dimension to pageview

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -49,6 +49,12 @@
 
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
     GOVUK.Ecommerce.start();
+
+    // Add the cookie banner status as a custom dimension
+    var cookieBannerShown = !this.getCookie("seen_cookie_message");
+    var cookieBannerDimension = {"dimension100" : cookieBannerShown ? cookieBannerShown.toString() : "false"};
+    $.extend(options, cookieBannerDimension);
+
     var trackingOptions = GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions(options);
     this.analytics.trackPageview(path, title, trackingOptions);
   };
@@ -80,6 +86,8 @@
     }
 
     var cookieOptions = getOptionsFromCookie();
+    var cookieBannerOption = {"dimension100": this.getCookie("seen_cookie_message")};
+
     $.extend(cookieOptions, options);
 
     this.setCookie('analytics_next_page_call', cookieOptions);

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -1058,6 +1058,50 @@ describe("GOVUK.StaticAnalytics", function() {
     });
   });
 
+  describe('when the seen_cookie_message cookie does not exist', function() {
+    var pageViewObject;
+
+    beforeEach(function() {
+      window.ga.calls.reset();
+      analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+      pageViewObject = getPageViewObject();
+    });
+
+    it("sets dimension100 to true", function() {
+      expect(pageViewObject.dimension100).toEqual('true');
+    });
+  });
+
+  describe('when the cookie banner is displayed on the page', function() {
+    var pageViewObject;
+
+    beforeEach(function() {
+      GOVUK.cookie('seen_cookie_message', 'false');
+      window.ga.calls.reset();
+      analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+      pageViewObject = getPageViewObject();
+    });
+
+    it("sets dimension100 to true when the cookie banner is shown", function() {
+      expect(pageViewObject.dimension100).toEqual('true');
+    });
+  });
+
+  describe('when the cookie banner is not displayed on the page', function() {
+    var pageViewObject;
+
+    beforeEach(function() {
+      GOVUK.cookie('seen_cookie_message', 'true');
+      window.ga.calls.reset();
+      analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+      pageViewObject = getPageViewObject();
+    });
+
+    it("sets dimension100 to false when the cookie banner has been dismissed", function() {
+      expect(pageViewObject.dimension100).toEqual('false');
+    });
+  });
+
   describe('when tracking pageviews and events', function() {
     it('tracks them in universal', function() {
 


### PR DESCRIPTION
We originally added a tracking solution within govuk_publishing_components which fired an event if the cookie banner was not shown on the page. However, this could build up and hit our Google Analytics limit.

Instead, we are adding an additional dimension to our existing pageview event, so we don't need an additional event. This is dimension100 which has been defined as "cookie banner shown". It is set to false if seen_cookie_message is true and set to true if seen_cookie_message is false (i.e: when the banner is shown).

## Example
<img width="383" alt="Screen Shot 2019-05-02 at 17 29 29" src="https://user-images.githubusercontent.com/29889908/57090917-deaf4700-6cff-11e9-85fa-ea73d962522a.png">