### PR TITLE
Set default search order to relevance

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -17,6 +17,7 @@
     <div class="content">
       <label for="site-search-text">Search</label>
       <input type="search" name="keywords" id="site-search-text" title="Search" class="js-search-focus">
+      <input type="hidden" name="order" value="relevance" />
       <input class="submit" type="submit" value="Search" />
     </div>
   </form>


### PR DESCRIPTION
We should revisit this in finder-frontend for keyword searches, but I don't want to roll back to using the redirect.  Patching the input form will fix the issue from here, but we'll need to fix the source before we solve the other redirected search boxes.