### PR TITLE
Reverting change in search box action

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -13,11 +13,12 @@
 <% content_for :inside_header do %>
   <a href="#search" class="search-toggle js-header-toggle">Search</a>
 
-  <form id="search" class="site-search" action="/search/all" method="get" role="search">
+  # The /search page redirects to a finder if keywords are included. Be careful about
+  # changing this, as the redirect adds some parameters to the search query.
+  <form id="search" class="site-search" action="/search" method="get" role="search">
     <div class="content">
       <label for="site-search-text">Search</label>
-      <input type="search" name="keywords" id="site-search-text" title="Search" class="js-search-focus">
-      <input type="hidden" name="order" value="relevance" />
+      <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
       <input class="submit" type="submit" value="Search" />
     </div>
   </form>


### PR DESCRIPTION
We want to retain the behaviour where empty searches go to the search page
at `/search`.  By changing the action to go to `/search/all` we stopped this.

The `/search` page redirects searches with keywords to go to `/search/all`
and adds the `order=relevance` param.  We added the hidden input here to
replicate that behaviour, but if we're reverting then we no longer need it.

We also broke scoped searches from service manual sub-pages as per https://govuk.zendesk.com/agent/tickets/3693761

I've added a comment to remind future me to not assume that it's trivial.