### PR TITLE
Add a direct link to the accessibility page in the footer

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -3,6 +3,7 @@
   <li><a href="/help">Help</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
+  <li><a href="/help/accessibility">Accessibility</a></li>
   <li><a href="/help/terms-conditions">Terms and conditions</a></li>
   <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>


### PR DESCRIPTION
## What
Add a direct link to the accessibility page from the GOV.UK footer _(the list Help | Cookies | Contact etc)_  (you currently have to navigate through the ‘Help’ section). 

It should be added between "Contact" and "Terms and conditions". 

## Why
This makes our accessibility link more prominent . Monitoring body advice is that the link should never be more than one click away from the user.

## Background

EU Accessibility Directive : _“A link to the accessibility statement should be prominently placed on the homepage of the website or made available on every web page, for example in a static header or footer.”_

This applies to new websites from September 2019. Strictly speaking, it doesn’t apply to existing websites until September 2020, but we’ve committed to making GOV.UK bit of an exemplar - so would be good to do it ahead of the September 2019 deadline.