### PR TITLE
Set the TLS cookie rather than stubbing getCookie

### DIFF
--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -573,23 +573,27 @@ describe('Surveys', function () {
   })
 
   describe('currentTlsVersion', function() {
+    afterEach(function() {
+      window.GOVUK.setCookie('TLSversion', null)
+    })
+
     it('returns an empty string when the cookie returns null', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue(null)
+      window.GOVUK.setCookie('TLSversion', null)
       expect(surveys.currentTlsVersion()).toBe('')
     })
 
     it('returns an empty string when the cookie returns "unknown"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("unknown")
+      window.GOVUK.setCookie('TLSversion', "unknown")
       expect(surveys.currentTlsVersion()).toBe('')
     })
 
     it('returns the correct version when the cookie returns a valid value"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("TLSv1.1")
+      window.GOVUK.setCookie('TLSversion', "TLSv1.1")
       expect(surveys.currentTlsVersion()).toBe(1.1)
     })
 
     it('returns an empty string when the TLS version is malformed"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("TLSvabcd11123")
+      window.GOVUK.setCookie('TLSversion', "TLSvabcd11123")
       expect(surveys.currentTlsVersion()).toBe('')
     })
   })


### PR DESCRIPTION
Stubbing `getCookie` will stub the return value for all calls to `getCookie`, which isn't what we want to do - we really only want to stub the value of TLS cookie.

**Note: these test failures are only present once the govuk_publishing_components has been versioned to include, so a passing build on CI now isn't representative of fixed tests until the Gemfile has also been updated. https://github.com/alphagov/govuk_publishing_components/pull/916**