### PR TITLE
Handle GA cookies when usage cookies are denied

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -1,24 +1,34 @@
 (function() {
   "use strict";
 
-  // Load Google Analytics libraries
-  GOVUK.StaticAnalytics.load();
+  var consentCookie = window.GOVUK.getConsentCookie();
 
-  // Use document.domain in dev, preview and staging so that tracking works
-  // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
-  var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+  // Disable analytics by default
+  // This will be reversed below, if the consent cookie says usage cookies are allowed
+  window['ga-disable-UA-26179049-1'] = true;
 
-  var universalId = '<%= Rails.application.config.ga_universal_id %>';
+  if (!consentCookie || consentCookie["usage"]) {
+    window['ga-disable-UA-26179049-1'] = false;
 
-  // Configure profiles, setup custom vars, track initial pageview
-  var analytics = new GOVUK.StaticAnalytics({
-    universalId: universalId,
-    cookieDomain: cookieDomain,
-    allowLinker: true,
-    // This is served by Fastly in production, and returns an empty 200 response
-    govukTrackerUrl: '<%= asset_path "/static/a" %>'
-  });
+    // Load Google Analytics libraries
+    GOVUK.StaticAnalytics.load();
 
-  // Make interface public for virtual pageviews and events
-  GOVUK.analytics = analytics;
+    // Use document.domain in dev, preview and staging so that tracking works
+    // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+    var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+
+    var universalId = '<%= Rails.application.config.ga_universal_id %>';
+
+    // Configure profiles, setup custom vars, track initial pageview
+    var analytics = new GOVUK.StaticAnalytics({
+      universalId: universalId,
+      cookieDomain: cookieDomain,
+      allowLinker: true,
+      // This is served by Fastly in production, and returns an empty 200 response
+      govukTrackerUrl: '<%= asset_path "/static/a" %>'
+    });
+
+    // Make interface public for virtual pageviews and events
+    GOVUK.analytics = analytics;
+  }
 })();

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -16,7 +16,11 @@
     // Create universal tracker
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
-    this.analytics = new GOVUK.Analytics(config);
+    var consentCookie = window.GOVUK.getConsentCookie();
+
+    if (!consentCookie || consentCookie['usage']) {
+      this.analytics = new GOVUK.Analytics(config);
+    }
 
     var trackingOptions = getOptionsFromCookie();
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -2,6 +2,7 @@ describe("GOVUK.StaticAnalytics", function() {
   var analytics;
 
   beforeEach(function() {
+    window.GOVUK.setConsentCookie({'usage': true});
     window.ga = function() {};
     spyOn(window, 'ga');
     spyOn(GOVUK.analyticsPlugins, 'printIntent');
@@ -1055,6 +1056,28 @@ describe("GOVUK.StaticAnalytics", function() {
 
     it("sets unknown as the value of the tls version custom dimension", function() {
       expect(pageViewObject.dimension16).toEqual('unknown');
+    });
+  });
+
+  describe("when the consent cookie has been set", function() {
+    beforeEach(function() {
+      window.ga.calls.reset();
+    });
+
+    it('does not set analytics cookies as normal when usage cookies are allowed', function() {
+      window.GOVUK.setConsentCookie({'usage': false});
+      analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+
+      expect(Object.keys(analytics).length).toBe(0)
+    });
+
+    it('does set analytics cookies as normal when usage cookies are allowed', function() {
+      window.GOVUK.setConsentCookie({'usage': true});
+      analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+
+      expect(Object.keys(analytics).length).toBe(1)
+      expect(analytics.analytics.stripDatePII).toBe(false)
+      expect(analytics.analytics.stripPostcodePII).toBe(false)
     });
   });
 

--- a/spec/javascripts/surveys-spec.js
+++ b/spec/javascripts/surveys-spec.js
@@ -573,23 +573,27 @@ describe('Surveys', function () {
   })
 
   describe('currentTlsVersion', function() {
+    afterEach(function() {
+      window.GOVUK.setCookie('TLSversion', null)
+    })
+
     it('returns an empty string when the cookie returns null', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue(null)
+      window.GOVUK.setCookie('TLSversion', null)
       expect(surveys.currentTlsVersion()).toBe('')
     })
 
     it('returns an empty string when the cookie returns "unknown"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("unknown")
+      window.GOVUK.setCookie('TLSversion', "unknown")
       expect(surveys.currentTlsVersion()).toBe('')
     })
 
     it('returns the correct version when the cookie returns a valid value"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("TLSv1.1")
+      window.GOVUK.setCookie('TLSversion', "TLSv1.1")
       expect(surveys.currentTlsVersion()).toBe(1.1)
     })
 
     it('returns an empty string when the TLS version is malformed"', function () {
-      spyOn(GOVUK, 'getCookie').and.returnValue("TLSvabcd11123")
+      window.GOVUK.setCookie('TLSversion', "TLSvabcd11123")
       expect(surveys.currentTlsVersion()).toBe('')
     })
   })


### PR DESCRIPTION
**The build is failing because it relies on some fixes from version 17 of govuk_publishing_components and some test fixes in static around TLS cookies, and this hasn't been updated yet.**

If a user doesn't give consent to usage cookies, we need to disable GA tracking. This involves:

- Setting a flag which turns off tracking
- Not automatically setting the value of the GA cookies. This allows us to set the value of the cookies to null on the `govuk_publishing_components` side and not have the cookies be automatically re-created each time we try to do this.