### PR TITLE
Bump govuk_publishing_components to v17.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.7"
 gem 'asset_bom_removal-rails', '~> 1.0.0'
 gem 'nokogiri', "~> 1.10"
 gem 'redis', "~> 4.1.1"
-gem 'govuk_publishing_components', '~> 16.20'
+gem 'govuk_publishing_components', '~> 17.0'
 gem 'govuk_app_config', '~> 1.18.1'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,9 +83,9 @@ GEM
     exifr (1.3.6)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
-    ffi (1.10.0)
+    ffi (1.11.1)
     fspath (3.1.0)
-    gds-api-adapters (59.4.0)
+    gds-api-adapters (59.5.1)
       addressable
       link_header
       null_logger
@@ -109,7 +109,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (16.20.0)
+    govuk_publishing_components (17.0.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -241,7 +241,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.3.0)
+    rouge (3.4.1)
     rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -320,9 +320,9 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.0)
+    websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
-    websocket-extensions (0.1.3)
+    websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -339,7 +339,7 @@ DEPENDENCIES
   govuk-lint (~> 3.11)
   govuk_app_config (~> 1.18.1)
   govuk_frontend_toolkit (~> 8.2.0)
-  govuk_publishing_components (~> 16.20)
+  govuk_publishing_components (~> 17.0)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.3)


### PR DESCRIPTION
Version 17.0 of govuk_publishing_components includes the code for
the new cookies consent mechanism.