### PR TITLE
Add missing env var for Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,6 @@ RUN bundle install
 
 ADD . $APP_HOME
 
-RUN RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
 
 CMD foreman run web


### PR DESCRIPTION
The build is failing since a change in Puppet that requires
this variable as part of asset compilation for production.