### PR TITLE
Remove new_cookie_banner flag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.7"
 gem 'asset_bom_removal-rails', '~> 1.0.0'
 gem 'nokogiri', "~> 1.10"
 gem 'redis', "~> 4.1.2"
-gem 'govuk_publishing_components', '~> 17.7'
+gem 'govuk_publishing_components', '~> 17.8.0'
 gem 'govuk_app_config', '~> 1.19.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,7 +109,7 @@ GEM
     govuk_frontend_toolkit (8.2.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (17.7.0)
+    govuk_publishing_components (17.8.0)
       gds-api-adapters
       govuk_app_config
       govuk_frontend_toolkit
@@ -241,7 +241,7 @@ GEM
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rouge (3.4.1)
+    rouge (3.5.1)
     rubocop (0.68.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -339,7 +339,7 @@ DEPENDENCIES
   govuk-lint (~> 3.11)
   govuk_app_config (~> 1.19.0)
   govuk_frontend_toolkit (~> 8.2.0)
-  govuk_publishing_components (~> 17.7)
+  govuk_publishing_components (~> 17.8.0)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.4)

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -47,7 +47,7 @@
       </div>
     </div>
 
-    <%= render "govuk_publishing_components/components/cookie_banner", new_cookie_banner: true %>
+    <%= render "govuk_publishing_components/components/cookie_banner" %>
 
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">


### PR DESCRIPTION
## What
Removes `new_cookie_banner` flag on the cookie banner component.

## Why
Following [the change to remove old cookie banner code](https://github.com/alphagov/govuk_publishing_components/pull/959) this flag is no longer required to render the new cookie banner.

**Note: this needs to be deployed only after all frontend apps have been deployed. This is so the new CSS and JS is in place before the `.gem-c-cookie-banner--new` is removed from the HTML via this change.**