### PR TITLE
Run Javascript tests on default bundle exec rake

### DIFF
--- a/lib/tasks/jasmine.rake
+++ b/lib/tasks/jasmine.rake
@@ -1,0 +1,1 @@
+Rake::Task[:default].enhance ["spec:javascript"]


### PR DESCRIPTION
## What
Expands the default task (`bundle exec rake`) to include `spec:javascript`.

## Why
At the moment, Javascript tests aren't run when you run `bundle exec rake` - they are only run when running `bundle exec rake spec:javascript`. This means failing tests can go unnoticed until you push to Github and the build fails on CI.

**Note: the Jenkins build remains unchanged, as it already runs `test` and `spec:javascript` separately**