### PR TITLE
Change EU Exit to Brexit in footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -42,15 +42,15 @@
   <% unless local_assigns[:hide_footer_links] %>
     <div class="footer-categories" data-module="track-click">
       <div class="footer-explore">
-        <h2>Prepare for EU Exit</h2>
+        <h2>Prepare for Brexit</h2>
 
         <ul>
-          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Prepare your business or organisation for the UK leaving the EU" href="/business-uk-leaving-eu">Prepare your business or organisation for the UK leaving the EU</a></li>
-          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Prepare for EU Exit if you live in the UK" href="/prepare-eu-exit">Prepare for EU Exit if you live in the UK</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Prepare your business or organisation for the UK leaving the EU" href="/business-uk-leaving-eu">Prepare your business or organisation for Brexit</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Prepare for EU Exit if you live in the UK" href="/prepare-eu-exit">Prepare for Brexit if you live in the UK</a></li>
         </ul>
         <ul>
-          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Living in Europe after the UK leaves the EU" href="/uk-nationals-living-eu">Living in Europe after the UK leaves the EU</a></li>
-          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Continue to live in the UK after it leaves the EU" href="/staying-uk-eu-citizen">Continue to live in the UK after it leaves the EU</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Living in Europe after the UK leaves the EU" href="/uk-nationals-living-eu">Living in Europe after Brexit</a></li>
+          <li><a data-track-category="footerClicked" data-track-action="brexitLinks" data-track-label="Continue to live in the UK after it leaves the EU" href="/staying-uk-eu-citizen">Continue to live in the UK after Brexit</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Change in name from EU Exit to Brexit, requested from Content team.

Trello card: https://trello.com/c/2iQ09yYJ