### PR TITLE
Allow overriding of list title on ecommerce tracking

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -3,6 +3,8 @@
   "use strict";
   window.GOVUK = window.GOVUK || {};
 
+  var DEFAULT_LIST_TITLE = 'Site search results';
+
   var Ecommerce = function (config) {
     this.init = function (element) {
       // Limiting to 100 characters to avoid noise from extra longs search queries
@@ -10,6 +12,7 @@
       var searchQuery   = GOVUK.analytics.stripPII(element.attr('data-search-query')).substring(0, 100).toLowerCase();
       var ecommerceRows = element.find('[data-ecommerce-row]');
       var startPosition = parseInt(element.data('ecommerce-start-index'), 10);
+      var listTitle     = element.data('list-title') || DEFAULT_LIST_TITLE;
 
       ecommerceRows.each(function(index, ecommerceRow) {
         var $ecommerceRow = $(ecommerceRow);
@@ -17,23 +20,23 @@
         var contentId = $ecommerceRow.attr('data-ecommerce-content-id'),
           path = $ecommerceRow.attr('data-ecommerce-path');
 
-        addImpression(contentId, path, index + startPosition, searchQuery);
-        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery);
+        addImpression(contentId, path, index + startPosition, searchQuery, listTitle);
+        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle);
       });
     }
 
-    function addImpression (contentId, path, position, searchQuery) {
+    function addImpression (contentId, path, position, searchQuery, listTitle) {
       // We only add the id to GA as additional product data is linked when it is uploaded.
       // This approach is taken to avoid the GA data packet exceeding the 8k limit
       ga('ec:addImpression', {
         id: contentId || path,
         position: position,
-        list: 'Site search results',
+        list: listTitle,
         dimension71: searchQuery
       });
     }
 
-    function trackProductOnClick (row, contentId, path, position, searchQuery) {
+    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle) {
       row.click(function(event) {
         ga('ec:addProduct', {
           id: contentId || path,
@@ -41,7 +44,7 @@
           dimension71: searchQuery
         });
 
-        ga('ec:setAction', 'click', {list: 'Site search results'});
+        ga('ec:setAction', 'click', {list: listTitle});
         GOVUK.analytics.trackEvent('UX', 'click',
           GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions({label: 'Results'})
         );

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -93,6 +93,29 @@ describe('Ecommerce reporter for results pages', function() {
     });
   });
 
+  it('will use the non-default list title if set', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1" data-list-title="Non-default title" data-search-query="search query">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+    element.find('[data-ecommerce-row]').click();
+
+    expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Non-default title'})
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      position: 1,
+      list: 'Non-default title',
+      dimension71: 'search query'
+    });
+  });
+
   it('will send data for multiple rows', function(){
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query">\


### PR DESCRIPTION
This lets us set a list title on a per-list basis.

It will allow us to use this tracking stuff on all lists, rather than site search.

This doesn't seem to be in use (https://github.com/search?q=org%3Aalphagov+%22GOVUK.Ecommerce%22&type=Code)
but it soon will be.

https://trello.com/c/YXkJcbBo/851