### PR TITLE
Set up data tracking for navigation on secondary content

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -59,6 +59,7 @@
       'content-has-history': {dimension: 39, defaultValue: 'false'},
       'publishing-application': {dimension: 89},
       'stepnavs': {dimension: 96},
+      'secondary-stepnav-shown': {dimension: 32},
       'relevant-result-shown': {dimension: 83}
     };
 


### PR DESCRIPTION
## What

**Note: this card is for setting up data tracking, it is not about doing the analysis**

We want to be able to track usage of the step by step side bar and the breadcrumb on secondary content.

Is the data tracking in place? What are the metrics we are trying to measure?

Would we be able to answer these questions:

- Does adding step by step navigation make a difference to user journeys (eg next page paths, exits) for *users who land directly* (eg from Google) on a secondary content page with step by step navigation? And compared to users who come from GOV.UK pages?
- Does the step by step navigation being closed make a difference to user journeys compared to the step by step being opened at a certain step, for secondary content?

## Why
We want to add a new feature to 'step by step publisher' that makes it possible to add step by step navigation to secondary content. (Secondary content = content that is about the service but is not useful enough to include in the step by step).

https://trello.com/c/LU6AAcOk/14-step-by-step-set-up-data-tracking-for-navigation-on-secondary-content