### PR TITLE
Add a dummy GOVUK.analytics when no cookie consent

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -3,6 +3,15 @@
 
   var consentCookie = window.GOVUK.getConsentCookie();
 
+  var dummyAnalytics = {
+    addLinkedTrackerDomain: function(){},
+    setDimension: function(){},
+    setOptionsForNextPageView: function(){},
+    trackEvent: function(){},
+    trackPageview: function(){},
+    trackShare: function(){},
+  };
+
   // Disable analytics by default
   // This will be reversed below, if the consent cookie says usage cookies are allowed
   window['ga-disable-UA-26179049-1'] = true;
@@ -30,5 +39,7 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
+  } else {
+    GOVUK.analytics = dummyAnalytics
   }
 })();


### PR DESCRIPTION
Previously we were not setting GOVUK.analytics
when the user had denied tracking cookie consent.

This is causing other apps to break as they call methods on this
directly, it always existed before.

This commit sets it to a dummy object (kinda like null object pattern)
with empty functions.

I'm not at all familiar with the how the FE stuff fits together, if there's
a more elegant way to do this, let me know.

I've tried it on integration and it does fix the problem.

Trello: https://trello.com/c/t2LSpLSc/1139-cookie-policy-setting-breaks-js-functions-across-govuk-frontend