### PR TITLE
Ecommerce

### DIFF
--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -31,6 +31,9 @@
 
       $(window).trigger('gaClientSet');
 
+      // Start up ecommerce tracking
+      GOVUK.Ecommerce.start();
+
       // Track initial pageview
       this.trackPageview(null, null, trackingOptions);
 
@@ -52,8 +55,6 @@
   };
 
   StaticAnalytics.prototype.trackPageview = function (path, title, options) {
-    GOVUK.Ecommerce.start();
-
     // Add the cookie banner status as a custom dimension
     var cookieBannerShown = !this.getCookie("seen_cookie_message");
     var cookieBannerDimension = {"dimension100" : cookieBannerShown ? cookieBannerShown.toString() : "false"};


### PR DESCRIPTION
Paired with @hannako 
Trello: https://trello.com/c/YXkJcbBo/851

We want to send all GA tracking calls via `sendBeacon` if possible. This is to prevent requests from failing when the page 'unloads'. This will be downgraded to normal transport methods if sendBeacon is not supported. 

- https://developers.google.com/analytics/devguides/collection/analyticsjs/sending-hits#specifying_different_transport_mechanisms
- https://developer.mozilla.org/en-US/docs/Web/API/Navigator/sendBeacon
