### PR TITLE
Add Research and Statistics to site footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -90,7 +90,7 @@
           <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Services" href="/search/services">Services</a></li>
           <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Guidance and regulation" href="/search/guidance-and-regulation">Guidance and regulation</a></li>
           <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="News and communications" href="/search/news-and-communications">News and communications</a></li>
-          <!--li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Research and statistics</" href="/search/statistics">Research and statistics</a></li-->
+          <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Research and statistics" href="/search/research-and-statistics">Research and statistics</a></li>
           <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Policy papers and consultations" href="/search/policy-papers-and-consultations">Policy papers and consultations</a></li>
           <li><a data-track-category="footerClicked" data-track-action="footerLinks" data-track-label="Transparency and freedom of information releases" href="/search/transparency-and-freedom-of-information-releases">Transparency and freedom of information releases</a></li>
         </ul>


### PR DESCRIPTION
It looks like this was already added, but commented out.

Trello: https://trello.com/c/5IMeeSQH/907-add-the-research-statistics-finder-in-the-footer