### PR TITLE
Guard against GA not being defined

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -54,6 +54,7 @@
 
   Ecommerce.ecLoaded = false;
   Ecommerce.start = function (element) {
+    if (!window.ga) { return }
     element = element || $('[data-analytics-ecommerce]');
     if(element.length > 0) {
       if(!Ecommerce.ecLoaded) {


### PR DESCRIPTION
Ecommerce tracking requires GA, but GA is undefined if a cookie policy setting is chosen. This guards against that.