### PR TITLE
Testing the addLinkedTrackerDomain code

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -27,6 +27,7 @@
     var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
 
     var universalId = '<%= Rails.application.config.ga_universal_id %>';
+    var secondaryId = '<%= Rails.application.config.ga_secondary_id %>';
 
     // Configure profiles, setup custom vars, track initial pageview
     var analytics = new GOVUK.StaticAnalytics({
@@ -39,6 +40,8 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'www.gov.uk', 'gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'designsystem', 'design-system.service.gov.uk');
   } else {
     GOVUK.analytics = dummyAnalytics
   }

--- a/config/application.rb
+++ b/config/application.rb
@@ -54,5 +54,6 @@ module Static
 
     # Google Analytics ID
     config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-UNSET")
+    config.ga_secondary_id = ENV.fetch("GA_SECONDARY_ID", "UA-UNSET")
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,4 +69,5 @@ Rails.application.configure do
   config.eager_load = true
 
   config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-26179049-1")
+  config.ga_secondary_id = ENV.fetch("GA_SECONDARY_ID", "UA-145652997-1")
 end


### PR DESCRIPTION
Turn on `addLinkedTrackerDomain`, which allows tracking events to be sent to a secondary GA property. This property requires a unique name (the first property does not, if both do not have a name specified the second one is not fired as GA assumes it is a duplicate).

The third parameter is a domain or list of domains for (we believe) cross domain tracking, which (we also believe) has been enabled by this code change. Further work may be required.

See documentation: https://github.com/alphagov/static/blob/master/doc/analytics.md#tracking-across-domains