### PR TITLE
Update cross domain tracking

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -40,7 +40,7 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'www.gov.uk', 'gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'www.gov.uk');
     GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'designsystem', 'design-system.service.gov.uk');
   } else {
     GOVUK.analytics = dummyAnalytics


### PR DESCRIPTION
- currently sending the ga parameter to every link that includes .gov.uk, need to be more specific