### PR TITLE
Remove www.gov.uk from cross domain tracking

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -40,7 +40,6 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'www.gov.uk');
     GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'designsystem', 'design-system.service.gov.uk');
   } else {
     GOVUK.analytics = dummyAnalytics


### PR DESCRIPTION
- unnecessary to have our own site in there, seems to be causing duplication of page views