### PR TITLE
Update styling of global banner

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -348,9 +348,10 @@
 }
 
 .global-bar {
-  background-color: #BFE3E0;
+  background-color: #E5EAF1;
   display: none;
   padding: 15px 0;
+  border-top: 8px solid #E61E32;
 
   .show-global-bar & {
     display: block;


### PR DESCRIPTION
## What
Changes the background from teal to light blue
Adds a red border top

## Why
To match EU Exit campaign branding on the landing page and the new call to action which will be added to the homepage.

<img width="1440" alt="Screen Shot 2019-08-29 at 11 51 01" src="https://user-images.githubusercontent.com/29889908/63934501-6fe6be00-ca53-11e9-97cd-14250261e500.png">
<img width="277" alt="Screen Shot 2019-08-29 at 11 51 12" src="https://user-images.githubusercontent.com/29889908/63934502-6fe6be00-ca53-11e9-980b-7dd3818e8a0d.png">
