### PR TITLE
Enable global Brexit banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,9 +1,8 @@
 <%
-  show_global_bar ||= false # Toggles the appearance of the global bar
-  title = "The title"
-  information = "Some information about something"
-  link_href = "https://www.gov.uk/"
-  link_text = %Q(More information<span class="visually-hidden"> about this</span>).html_safe
+  show_global_bar ||= true # Toggles the appearance of the global bar
+  title = "The United Kingdom is leaving the European Union on 31 October 2019."
+  link_href = "https://www.gov.uk/brexit"
+  link_text = "Get ready for Brexit"
 -%>
 <% if show_global_bar %>
   <% content_for :head do %>
@@ -16,7 +15,6 @@
     <div class="global-bar-message-container">
     <p class="global-bar-message">
       <span class="global-bar-title"><%= title %></span>
-      <%= information %>
       <%= link_to(
         link_text,
         link_href,


### PR DESCRIPTION
Updates the content for the global non-emergency banner and enables the display of this banner on GOV.UK.

Desktop:
<img width="1410" alt="Screen Shot 2019-08-29 at 17 56 49" src="https://user-images.githubusercontent.com/6329861/63960610-d3d6aa00-ca86-11e9-826c-5e7ad5997ff5.png">

Tablet:
<img width="684" alt="Screen Shot 2019-08-29 at 17 57 03" src="https://user-images.githubusercontent.com/6329861/63960623-d802c780-ca86-11e9-9db1-3f8547fb8142.png">

Mobile:
<img width="478" alt="Screen Shot 2019-08-29 at 17 57 17" src="https://user-images.githubusercontent.com/6329861/63960628-dd601200-ca86-11e9-9933-a43477f85843.png">

Trello card: https://trello.com/c/j2jX1N62