### PR TITLE
Shift global banner hide button to right on mobile

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -369,6 +369,14 @@
         top: 0;
       }
     }
+
+    @include media(mobile) {
+      .dismiss {
+        position: absolute;
+        right: 0;
+        bottom: 1px;
+      }
+    }
   }
 
   .global-bar-message {


### PR DESCRIPTION
Move the global (Brexit) banner's 'Hide message' link to the right side of the banner in mobile only.

Before:
<img width="480" alt="Screen Shot 2019-08-29 at 18 02 21" src="https://user-images.githubusercontent.com/6329861/63967502-7b5ad900-ca95-11e9-8895-0c6865bfa193.png">

After:
<img width="487" alt="Screen Shot 2019-08-29 at 19 37 04" src="https://user-images.githubusercontent.com/6329861/63967467-6716dc00-ca95-11e9-878e-5148fa1a7469.png">