### PR TITLE
Trying to solve a problem with cross-domain linking

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -40,9 +40,9 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'designsystem', 'design-system.service.gov.uk');
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'passportservice', 'passport.service.gov.uk');
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'applysettledstatus', 'apply-for-eu-settled-status.homeoffice.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'design-system.service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'passport.service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'apply-for-eu-settled-status.homeoffice.gov.uk');
   } else {
     GOVUK.analytics = dummyAnalytics
   }


### PR DESCRIPTION
- with unique names, cross linked domains work but hits to our GA account are tripled
- maybe setting the same name for the three will fix this