### PR TITLE
Change linker code calling approach

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -40,7 +40,7 @@
 
     // Make interface public for virtual pageviews and events
     GOVUK.analytics = analytics;
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'design-system.service.gov.uk');
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', 'design-system.service.gov.uk, passport.service.gov.uk, apply-for-eu-settled-status.homeoffice.gov.uk');
   } else {
     GOVUK.analytics = dummyAnalytics
   }

--- a/spec/javascripts/analytics_toolkit/analytics.spec.js
+++ b/spec/javascripts/analytics_toolkit/analytics.spec.js
@@ -399,5 +399,19 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['test.set', 'displayFeaturesTask', null])
       expect(allArgs).toContain(['test.send', 'pageview'])
     })
+
+    it('adds multiple linked domains to universal analytics', function () {
+      analytics.addLinkedTrackerDomain('1234', 'test', 'www.example.com, www.something.com')
+
+      var allArgs = window.ga.calls.allArgs()
+      expect(allArgs).toContain(['create', '1234', 'auto', {'name': 'test'}])
+      expect(allArgs).toContain(['require', 'linker'])
+      expect(allArgs).toContain(['test.require', 'linker'])
+      expect(allArgs).toContain(['linker:autoLink', ['www.example.com, www.something.com']])
+      expect(allArgs).toContain(['test.linker:autoLink', ['www.example.com, www.something.com']])
+      expect(allArgs).toContain(['test.set', 'anonymizeIp', true])
+      expect(allArgs).toContain(['test.set', 'displayFeaturesTask', null])
+      expect(allArgs).toContain(['test.send', 'pageview'])
+    })
   })
 })


### PR DESCRIPTION
Seems we might have been calling the linker code incorrectly. Rather than calling it once for each linked domain required, we should call it once but with all the domains. 

The previous method was causing duplicate GA events to be fired, one for each call to the linker code.

This PR also adds a test for calling the code this way.