### PR TITLE
Make Brexit banner link relative

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,7 +1,7 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
   title = "The United Kingdom is leaving the European Union on 31 October 2019."
-  link_href = "https://www.gov.uk/brexit"
+  link_href = "/brexit"
   link_text = "Get ready for Brexit"
 -%>
 <% if show_global_bar %>


### PR DESCRIPTION
The link was hardcoded to the live URL in all environments.  It should be relative.