### PR TITLE
Tweak dismiss button

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -362,6 +362,12 @@
     @extend %site-width-container;
     position: relative;
 
+    @include media($max-width: 320px) {
+      .dismiss {
+        position: relative;
+      }
+    }
+
     @include media(tablet) {
       .dismiss {
         position: absolute;
@@ -370,7 +376,7 @@
       }
     }
 
-    @include media(mobile) {
+    @include media($min-width: 320px) {
       .dismiss {
         position: absolute;
         right: 0;

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -374,7 +374,7 @@
       .dismiss {
         position: absolute;
         right: 0;
-        bottom: 1px;
+        bottom: 0;
       }
     }
   }


### PR DESCRIPTION
## Before
The dismiss button was 1px from the bottom (rather than 0), and it would overlap below 320px width.
<img width="260" alt="Screen Shot 2019-09-05 at 16 29 31" src="https://user-images.githubusercontent.com/29889908/64356212-6385d680-cffa-11e9-87bd-0878a425ce60.png"> <img width="230" alt="Screen Shot 2019-09-05 at 16 29 38" src="https://user-images.githubusercontent.com/29889908/64356213-6385d680-cffa-11e9-8279-82d9459d74c3.png">

## After
Both links are aligned to the bottom:
<img width="312" alt="Screen Shot 2019-09-05 at 16 46 06" src="https://user-images.githubusercontent.com/29889908/64357523-b1034300-cffc-11e9-8156-e475c176444d.png">

No overlapping of links on smaller screen widths:
<img width="242" alt="Screen Shot 2019-09-05 at 16 45 59" src="https://user-images.githubusercontent.com/29889908/64357522-b1034300-cffc-11e9-9768-889f7b1f9517.png"> 
