### PR TITLE
Separate out strip pii code

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -1,4 +1,5 @@
 //= require govuk_publishing_components/lib/cookie-functions
+//= require analytics/pii
 //= require analytics_toolkit/google-analytics-universal-tracker
 //= require analytics_toolkit/govuk-tracker
 //= require analytics_toolkit/analytics

--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -34,6 +34,8 @@
       universalId: universalId,
       cookieDomain: cookieDomain,
       allowLinker: true,
+      stripDatePII: true,
+      stripPostcodePII: true,
       // This is served by Fastly in production, and returns an empty 200 response
       govukTrackerUrl: '<%= asset_path "/static/a" %>'
     });

--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -1,0 +1,64 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
+  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
+  var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+
+  var pii = function () {
+    this.stripDatePII = false
+    this.stripPostcodePII = false
+  }
+
+  pii.prototype.stripPII = function (value) {
+    if (typeof value === 'string') {
+      return this.stripPIIFromString(value)
+    } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
+      return this.stripPIIFromArray(value)
+    } else if (typeof value === 'object') {
+      return this.stripPIIFromObject(value)
+    } else {
+      return value
+    }
+  }
+
+  pii.prototype.stripPIIFromString = function (string) {
+    var stripped = string.replace(EMAIL_PATTERN, '[email]')
+    if (this.stripDatePII === true) {
+      stripped = stripped.replace(DATE_PATTERN, '[date]')
+    }
+    if (this.stripPostcodePII === true) {
+      stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')
+    }
+    return stripped
+  }
+
+  pii.prototype.stripPIIFromObject = function (object) {
+    if (object) {
+      if (object instanceof GOVUK.Analytics.PIISafe || Object.keys(object).length === 1) {
+        return object.value
+      } else {
+        for (var property in object) {
+          var value = object[property]
+
+          object[property] = this.stripPII(value)
+        }
+        return object
+      }
+    }
+  }
+
+  pii.prototype.stripPIIFromArray = function (array) {
+    for (var i = 0, l = array.length; i < l; i++) {
+      var elem = array[i]
+
+      array[i] = this.stripPII(elem)
+    }
+    return array
+  }
+
+  GOVUK.pii = pii
+
+  global.GOVUK = GOVUK
+})(window)

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -125,7 +125,7 @@
   };
 
   StaticAnalytics.prototype.stripPII = function (value) {
-    return this.analytics.stripPII(value)
+    return this.analytics.pii.stripPII(value)
   }
 
   function getOptionsFromCookie() {

--- a/app/assets/javascripts/analytics_toolkit/analytics.js
+++ b/app/assets/javascripts/analytics_toolkit/analytics.js
@@ -2,24 +2,20 @@
   'use strict'
 
   var GOVUK = global.GOVUK || {}
-  var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
-  var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
-
   // For usage and initialisation see:
   // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/docs/analytics.md#create-an-analytics-tracker
 
   var Analytics = function (config) {
-    this.stripDatePII = false
+    this.pii = new GOVUK.pii()
+
     if (typeof config.stripDatePII !== 'undefined') {
-      this.stripDatePII = (config.stripDatePII === true)
+      this.pii.stripDatePII = (config.stripDatePII === true)
       // remove the option so we don't pass it to other trackers - it's not
       // their concern
       delete config.stripDatePII
     }
-    this.stripPostcodePII = false
     if (typeof config.stripPostcodePII !== 'undefined') {
-      this.stripPostcodePII = (config.stripPostcodePII === true)
+      this.pii.stripPostcodePII = (config.stripPostcodePII === true)
       // remove the option so we don't pass it to other trackers - it's not
       // their concern
       delete config.stripPostcodePII
@@ -41,53 +37,6 @@
     this.value = value
   }
   Analytics.PIISafe = PIISafe
-
-  Analytics.prototype.stripPII = function (value) {
-    if (typeof value === 'string') {
-      return this.stripPIIFromString(value)
-    } else if (Object.prototype.toString.call(value) === '[object Array]' || Object.prototype.toString.call(value) === '[object Arguments]') {
-      return this.stripPIIFromArray(value)
-    } else if (typeof value === 'object') {
-      return this.stripPIIFromObject(value)
-    } else {
-      return value
-    }
-  }
-
-  Analytics.prototype.stripPIIFromString = function (string) {
-    var stripped = string.replace(EMAIL_PATTERN, '[email]')
-    if (this.stripDatePII === true) {
-      stripped = stripped.replace(DATE_PATTERN, '[date]')
-    }
-    if (this.stripPostcodePII === true) {
-      stripped = stripped.replace(POSTCODE_PATTERN, '[postcode]')
-    }
-    return stripped
-  }
-
-  Analytics.prototype.stripPIIFromObject = function (object) {
-    if (object) {
-      if (object instanceof Analytics.PIISafe || Object.keys(object).length === 1) {
-        return object.value
-      } else {
-        for (var property in object) {
-          var value = object[property]
-
-          object[property] = this.stripPII(value)
-        }
-        return object
-      }
-    }
-  }
-
-  Analytics.prototype.stripPIIFromArray = function (array) {
-    for (var i = 0, l = array.length; i < l; i++) {
-      var elem = array[i]
-
-      array[i] = this.stripPII(elem)
-    }
-    return array
-  }
 
   Analytics.prototype.sendToTrackers = function (method, args) {
     for (var i = 0, l = this.trackers.length; i < l; i++) {
@@ -111,13 +60,13 @@
     // we ignore the possibility of there being campaign variables in the
     // anchor because we wouldn't know how to detect and parse them if they
     // were present
-    return this.stripPIIFromString(location.href.substring(location.origin.length).split('#')[0])
+    return this.pii.stripPIIFromString(location.href.substring(location.origin.length).split('#')[0])
   }
 
   Analytics.prototype.trackPageview = function (path, title, options) {
     arguments[0] = arguments[0] || this.defaultPathForTrackPageview(window.location)
     if (arguments.length === 0) { arguments.length = 1 }
-    this.sendToTrackers('trackPageview', this.stripPII(arguments))
+    this.sendToTrackers('trackPageview', this.pii.stripPII(arguments))
   }
 
   /*
@@ -127,11 +76,11 @@
     options.nonInteraction – Prevent event from impacting bounce rate
   */
   Analytics.prototype.trackEvent = function (category, action, options) {
-    this.sendToTrackers('trackEvent', this.stripPII(arguments))
+    this.sendToTrackers('trackEvent', this.pii.stripPII(arguments))
   }
 
   Analytics.prototype.trackShare = function (network, options) {
-    this.sendToTrackers('trackSocial', this.stripPII([network, 'share', global.location.pathname, options]))
+    this.sendToTrackers('trackSocial', this.pii.stripPII([network, 'share', global.location.pathname, options]))
   }
 
   /*
@@ -139,7 +88,7 @@
     Universal Analytics profile
    */
   Analytics.prototype.setDimension = function (index, value) {
-    this.sendToTrackers('setDimension', this.stripPII(arguments))
+    this.sendToTrackers('setDimension', this.pii.stripPII(arguments))
   }
 
   /*

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -206,7 +206,7 @@ describe('Ecommerce reporter for results pages', function() {
   });
 
   it('removes postcodes from the search query if configured to do so', function() {
-    GOVUK.analytics.analytics.stripPostcodePII = true;
+    GOVUK.analytics.analytics.pii.stripPostcodePII = true;
 
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query with a SW1A 1AA in it">\
@@ -227,11 +227,11 @@ describe('Ecommerce reporter for results pages', function() {
       dimension71: 'search query with a [postcode] in it'
     });
 
-    GOVUK.analytics.analytics.stripPostcodePII = false;
+    GOVUK.analytics.analytics.pii.stripPostcodePII = false;
   });
 
   it('leaves postcodes in the search query if not configured to remove them', function() {
-    GOVUK.analytics.analytics.stripPostcodePII = false;
+    GOVUK.analytics.analytics.pii.stripPostcodePII = false;
 
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query with a SW1A 1AA in it">\

--- a/spec/javascripts/analytics/pii.spec.js
+++ b/spec/javascripts/analytics/pii.spec.js
@@ -1,0 +1,95 @@
+describe("GOVUK.PII", function() {
+  var pii
+
+  describe('by default', function() {
+    beforeEach(function() {
+      pii = new GOVUK.pii()
+    })
+
+    it("strips email addresses, but not postcodes and dates from strings", function() {
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+    })
+
+    it("strips email addresses but not dates and postcodes from objects", function() {
+      var obj = {
+        'email': 'this is an@email.com address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      var strippedObj = {
+        'email': 'this is [email] address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it("strips email addresses but not dates and postcodes from arrays", function() {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+
+  describe('when configured to remove all PII', function() {
+    beforeEach(function() {
+      pii = new GOVUK.pii()
+      pii.stripDatePII = true
+      pii.stripPostcodePII = true
+    })
+
+    it("strips email addresses, postcodes and dates from strings", function() {
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a [date] date")
+    })
+
+    it("strips all PII from objects", function() {
+      var obj = {
+        'email': 'this is an@email.com address',
+        'postcode': 'this is a sw1a 1aa postcode',
+        'date': 'this is a 2019-01-21 date'
+      }
+
+      var strippedObj = {
+        'email': 'this is [email] address',
+        'postcode': 'this is a [postcode] postcode',
+        'date': 'this is a [date] date'
+      }
+
+      obj = pii.stripPII(obj)
+      expect(obj).toEqual(strippedObj)
+    })
+
+    it("strips all PII from arrays", function() {
+      var arr = [
+        'this is an@email.com address',
+        'this is a sw1a 1aa postcode',
+        'this is a 2019-01-21 date'
+      ]
+
+      var strippedArr = [
+        'this is [email] address',
+        'this is a [postcode] postcode',
+        'this is a [date] date'
+      ]
+
+      arr = pii.stripPII(arr)
+      expect(arr).toEqual(strippedArr)
+    })
+  })
+});

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -49,7 +49,7 @@ describe("GOVUK.StaticAnalytics", function() {
 
     describe('stripping date PII', function () {
       it('is off by default', function() {
-        expect(analytics.analytics.stripDatePII).toEqual(false);
+        expect(analytics.analytics.pii.stripDatePII).toEqual(false);
       });
 
       it('can be configured directly', function() {
@@ -58,7 +58,7 @@ describe("GOVUK.StaticAnalytics", function() {
           cookieDomain: '.www.gov.uk',
           stripDatePII: true
         });
-        expect(analytics.analytics.stripDatePII).toEqual(true);
+        expect(analytics.analytics.pii.stripDatePII).toEqual(true);
       });
 
       describe('when there is a a govuk:static-analytics:strip-dates meta tag present', function() {
@@ -74,7 +74,7 @@ describe("GOVUK.StaticAnalytics", function() {
             universalId: 'universal-id',
             cookieDomain: '.www.gov.uk'
           });
-          expect(analytics.analytics.stripDatePII).toEqual(true);
+          expect(analytics.analytics.pii.stripDatePII).toEqual(true);
         });
 
         it('can be configured directly to overrule the meta tag', function() {
@@ -83,14 +83,14 @@ describe("GOVUK.StaticAnalytics", function() {
             cookieDomain: '.www.gov.uk',
             stripDatePII: false
           });
-          expect(analytics.analytics.stripDatePII).toEqual(false);
+          expect(analytics.analytics.pii.stripDatePII).toEqual(false);
         });
       });
     });
 
     describe('stripping postcode PII', function () {
       it('is off by default', function() {
-        expect(analytics.analytics.stripPostcodePII).toEqual(false);
+        expect(analytics.analytics.pii.stripPostcodePII).toEqual(false);
       });
 
       it('can be configured directly', function() {
@@ -99,7 +99,7 @@ describe("GOVUK.StaticAnalytics", function() {
           cookieDomain: '.www.gov.uk',
           stripPostcodePII: true
         });
-        expect(analytics.analytics.stripPostcodePII).toEqual(true);
+        expect(analytics.analytics.pii.stripPostcodePII).toEqual(true);
       });
 
       describe('when there is a a govuk:static-analytics:strip-postcodes meta tag present', function() {
@@ -115,7 +115,7 @@ describe("GOVUK.StaticAnalytics", function() {
             universalId: 'universal-id',
             cookieDomain: '.www.gov.uk'
           });
-          expect(analytics.analytics.stripPostcodePII).toEqual(true);
+          expect(analytics.analytics.pii.stripPostcodePII).toEqual(true);
         });
 
         it('can be configured directly to overrule the meta tag', function() {
@@ -124,7 +124,7 @@ describe("GOVUK.StaticAnalytics", function() {
             cookieDomain: '.www.gov.uk',
             stripPostcodePII: false
           });
-          expect(analytics.analytics.stripPostcodePII).toEqual(false);
+          expect(analytics.analytics.pii.stripPostcodePII).toEqual(false);
         });
       });
     });
@@ -1076,8 +1076,8 @@ describe("GOVUK.StaticAnalytics", function() {
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
 
       expect(Object.keys(analytics).length).toBe(1)
-      expect(analytics.analytics.stripDatePII).toBe(false)
-      expect(analytics.analytics.stripPostcodePII).toBe(false)
+      expect(analytics.analytics.pii.stripDatePII).toBe(false)
+      expect(analytics.analytics.pii.stripPostcodePII).toBe(false)
     });
   });
 

--- a/spec/javascripts/analytics_toolkit/analytics.spec.js
+++ b/spec/javascripts/analytics_toolkit/analytics.spec.js
@@ -34,7 +34,7 @@ describe('GOVUK.Analytics', function () {
     })
 
     it('is configured not to strip date data from GA calls', function () {
-      expect(analytics.stripDatePII).toEqual(false)
+      expect(analytics.pii.stripDatePII).toEqual(false)
     })
 
     it('can be told to strip date data from GA calls', function () {
@@ -45,11 +45,11 @@ describe('GOVUK.Analytics', function () {
         stripDatePII: true
       })
 
-      expect(analytics.stripDatePII).toEqual(true)
+      expect(analytics.pii.stripDatePII).toEqual(true)
     })
 
     it('is configured not to strip postcode data from GA calls', function () {
-      expect(analytics.stripPostcodePII).toEqual(false)
+      expect(analytics.pii.stripPostcodePII).toEqual(false)
     })
 
     it('can be told to strip postcode data from GA calls', function () {
@@ -60,7 +60,7 @@ describe('GOVUK.Analytics', function () {
         stripPostcodePII: true
       })
 
-      expect(analytics.stripPostcodePII).toEqual(true)
+      expect(analytics.pii.stripPostcodePII).toEqual(true)
     })
   })
 


### PR DESCRIPTION
Move the code that strips PII from `analytics.js` into a separate file and update the analytics code to call it. This is preparatory work ahead of some future changes. The result of this PR is that everything should work as it did before, but the code is slightly restructured.

## Background

The stripPII code at first glance looks fairly straightforward - a few functions that accept any variable and strip pii from that variable. However there is a complexity in the form of the `PIISafe` attribute of the code in `analytics.js`. I believe this is used when passing objects to the pii safe code - seems there are circumstances where we don't want to strip pii from objects and this mechanism is used to prevent that.

Not sure what the circumstances around this are, but my current theory is that some custom dimensions contain non pii aspects that would be incorrectly removed by the pii code, e.g. something that looks like a postcode but in fact isn't a postcode and therefore shouldn't be removed.