### PR TITLE
Remove recently added test workaround

### DIFF
--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -36,7 +36,7 @@
 
   pii.prototype.stripPIIFromObject = function (object) {
     if (object) {
-      if (object instanceof GOVUK.Analytics.PIISafe || Object.keys(object).length === 1) {
+      if (object instanceof GOVUK.Analytics.PIISafe) {
         return object.value
       } else {
         for (var property in object) {


### PR DESCRIPTION
- this reverts a change made during migration of the analytics code from govuk_frontend_toolkit to static, without which an ecommerce spec test was failing
- details here: https://github.com/alphagov/static/pull/1795/commits/1c29c3977c732d912798091f2ada2bdbfc31cb45
- noted in a recent review that the change was not ideal, so removing it
- all the tests still pass, confusing as the change was originally introduced in order to make a test pass