### PR TITLE
Set location prior to page view for linked tracker

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -169,6 +169,7 @@
 
     sendToGa(name + '.set', 'anonymizeIp', true)
     sendToGa(name + '.set', 'displayFeaturesTask', null)
+    sendToGa(name + '.set', 'location', pii.stripPII(window.location.href))
 
     if (typeof sendPageView === 'undefined' || sendPageView === true) {
       sendToGa(name + '.send', 'pageview')


### PR DESCRIPTION
Set the redacted ga location parameter prior to sending a page view from the linker tracker code.