### PR TITLE
Fix error page template

### DIFF
--- a/app/assets/javascripts/error-page.js
+++ b/app/assets/javascripts/error-page.js
@@ -1,1 +1,2 @@
+//= require libs/jquery/jquery-1.12.4.js
 //= require govuk_publishing_components/all_components

--- a/app/assets/stylesheets/error-page.scss
+++ b/app/assets/stylesheets/error-page.scss
@@ -1,1 +1,2 @@
-@import 'govuk_publishing_components/all_components';
+$govuk-compatibility-govuktemplate: true;
+@import "govuk_publishing_components/all_components";


### PR DESCRIPTION
The `error-page` template, used for rendering 4xx and 5xx pages, is currently missing the jQuery import (as flagged in #1862) and doesn't have the compatibility with `govuk_template` flag turned on - this is needed for the cookie banner and feedback component used on the pages.

Fixes #1862.