### PR TITLE
Add cross domain linker update instructions

### DIFF
--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -164,6 +164,25 @@ Note that `domainToLinkTo` must be an array of strings.
 Once this is done hits to that page will be tracked in both your local and the
 named tracker, and sessions will persist to the other domain.
 
+### Adding more domains to GOV.UK's cross domain linker
+
+Once a service starts sending analytics data to the shared GA property and has configured their system to include `www.gov.uk` in their cross domain linking, we must also configure `www.gov.uk` to include their domain in our cross linker configuration.
+
+The change is straightforward, add the domain of the service to [`init.js.erb`](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L44).
+
+Here's an [example of an earlier PR](https://github.com/alphagov/static/pull/1845) to do this.
+
+Only the domain should be added, GA will ignore any path details e.g. `/government/service/`
+
+Note that GA matches subdomains of any domains added this way. So `passport.service.gov.uk` also includes `www.passport.service.gov.uk`.
+
+On that basis the simplest course of action would appear to be to simply add `gov.uk` or even `service.gov.uk` and then it'll just match everything we want it to. **We must not do this** for very good reasons:
+
+- any link from `www.gov.uk` to a matching domain would have a URL parameter automatically added to it e.g. `https://something.service.gov.uk/?_ga=23.32423234.213.1.2213`. This could interfere with that site's own analytics.
+- the client ID might be reset.
+
+Once the changes to the linker configuration have been deployed a PA will need to check that everything is working correctly. Since static PRs can take upwards of half an hour to pass CI tests, it's worth having a revert PR ready early on just in case.
+
 ## Plugins
 
 Plugins are namespaced to `GOVUK.analyticsPlugins`. They should be pulled in by your project and initialised after `GOVUK.analytics` (see [Create an analytics tracker, above](#create-an-analytics-tracker)).

--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -168,7 +168,7 @@ named tracker, and sessions will persist to the other domain.
 
 Once a service starts sending analytics data to the shared GA property and has configured their system to include `www.gov.uk` in their cross domain linking, we must also configure `www.gov.uk` to include their domain in our cross linker configuration.
 
-The change is straightforward, add the domain of the service to [`init.js.erb`](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L44).
+Add the domain of the service to [`init.js.erb`](https://github.com/alphagov/static/blob/master/app/assets/javascripts/analytics/init.js.erb#L44).
 
 Here's an [example of an earlier PR](https://github.com/alphagov/static/pull/1845) to do this.
 

--- a/doc/analytics.md
+++ b/doc/analytics.md
@@ -181,7 +181,7 @@ On that basis the simplest course of action would appear to be to simply add `go
 - any link from `www.gov.uk` to a matching domain would have a URL parameter automatically added to it e.g. `https://something.service.gov.uk/?_ga=23.32423234.213.1.2213`. This could interfere with that site's own analytics.
 - the client ID might be reset.
 
-Once the changes to the linker configuration have been deployed a PA will need to check that everything is working correctly. Since static PRs can take upwards of half an hour to pass CI tests, it's worth having a revert PR ready early on just in case.
+Once the changes to the linker configuration have been deployed a performance analyst will need to check that everything is working correctly. Since static PRs can take upwards of half an hour to pass CI tests, it's worth having a revert PR ready early on just in case.
 
 ## Plugins
 


### PR DESCRIPTION
Adding some specific instructions on how to update the cross domain linker for gov.uk. This is documentation for ongoing work and may be subject to modification/removal once the work is completed.

Trello card: https://trello.com/c/GMQxr8kd/106-document-ga-code-on-govuk
