### PR TITLE
Update footer link to Accessibility

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -3,7 +3,7 @@
   <li><a href="/help">Help</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
-  <li><a href="/help/accessibility">Accessibility</a></li>
+  <li><a href="/help/accessibility-statement">Accessibility statement</a></li>
   <li><a href="/help/terms-conditions">Terms and conditions</a></li>
   <li><a href="/cymraeg" lang="cy" hreflang="cy">Rhestr o Wasanaethau Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a></li>


### PR DESCRIPTION
The Accessibility Statement needs to be available from all pages on
the site. Will also replace the old page with a redirect in other
work.