### PR TITLE
Redact PII from page titles

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -174,6 +174,7 @@
 
     sendToGa(name + '.set', 'anonymizeIp', true)
     sendToGa(name + '.set', 'displayFeaturesTask', null)
+    sendToGa(name + '.set', 'title', pii.stripPII(document.title))
     sendToGa(name + '.set', 'location', pii.stripPII(window.location.href))
 
     if (typeof sendPageView === 'undefined' || sendPageView === true) {

--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -28,6 +28,10 @@
       sendToGa('set', 'allowAdFeatures', false)
     }
 
+    function stripTitlePII () {
+      sendToGa('set', 'title', pii.stripPII(document.title))
+    }
+
     function stripLocationPII () {
       sendToGa('set', 'location', pii.stripPII(window.location.href))
     }
@@ -41,6 +45,7 @@
     anonymizeIp()
     disableAdTracking()
     disableAdFeatures()
+    stripTitlePII()
     stripLocationPII()
   }
 

--- a/spec/javascripts/analytics_toolkit/analytics.spec.js
+++ b/spec/javascripts/analytics_toolkit/analytics.spec.js
@@ -102,6 +102,11 @@ describe('GOVUK.Analytics', function () {
       analytics.trackPageview('/foo', 'A page')
       expect(window.ga.calls.mostRecent().args[2].title).toEqual('A page')
     })
+
+    it('removes pii from the title', function (){
+      analytics.trackPageview('/foo', 'With email@email.com in it')
+      expect(window.ga.calls.mostRecent().args[2].title).toEqual('With [email] in it')
+    })
   })
 
   describe('when tracking pageviews, events and custom dimensions', function () {

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -237,6 +237,10 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     it('sends a pageview', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['testTracker.send', 'pageview'])
     })
+    it('removes pii from the pageview', function () {
+      expect(window.ga.calls.allArgs()).toContain(['set', 'title' , 'With [email] [date] and [postcode] in it'])
+      expect(window.ga.calls.argsFor(5)[2]).toContain('?address=[email]&postcode=[postcode]&date=[date]')
+    })
     it('can omit sending a pageview', function () {
       universal.addLinkedTrackerDomain('UA-123456', 'testTracker', 'some.service.gov.uk', false)
       expect(window.ga.calls.mostRecent().args).not.toEqual(['testTracker.send', 'pageview'])

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -199,6 +199,21 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.mostRecent().args[2]).toContain('postcode=[postcode]')
       expect(window.ga.calls.mostRecent().args[2]).toContain('date=[date]')
     })
+
+    it('removes any pii from the title', function () {
+      document.title = "With email@email.com 2012-01-01 and wc2b 6nh in it"
+      // need to reinit all the GA setup because the page title has changed
+      addGoogleAnalyticsSpy()
+      pageWantsDatesStripped()
+      pageWantsPostcodesStripped()
+
+      universal = new GOVUK.GoogleAnalyticsUniversalTracker('id', {
+        cookieDomain: 'cookie-domain.com',
+        siteSpeedSampleRate: 100
+      })
+
+      expect(window.ga.calls.allArgs()).toContain([ 'set', 'title', 'With [email] [date] and [postcode] in it' ])
+    })
   })
 
   describe('adding a linked tracker', function () {


### PR DESCRIPTION
Sanitises title data for pageviews, specifically aimed at the search page.

Trello card: https://trello.com/c/ZGGRxLrk/153-redact-pii-from-page-titles