### PR TITLE
Override govuk-template footer colours

### DIFF
--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -7,10 +7,13 @@
   a:focus {
     outline: 3px solid transparent;
     color: #0b0c0c;
-    background-color: #fd0;
-    -webkit-box-shadow: 0 -2px #fd0,
+    // Instead of using #fd0 as per GOV.UK Frontend 3, until we are using
+    // govuk_publishing_components we'll stick to the legacy colours for now
+    // to keep things consistent.
+    background-color: #ffbf47;
+    -webkit-box-shadow: 0 -2px #ffbf47,
     0 4px #0b0c0c;
-    box-shadow: 0 -2px #fd0,
+    box-shadow: 0 -2px #ffbf47,
     0 4px #0b0c0c;
     text-decoration: none;
   }

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -4,6 +4,17 @@
   // Replaces the 1px #a1acb2 border from govuk_template
   border-top: 10px solid $mainstream-brand;
 
+  a:focus {
+    outline: 3px solid transparent;
+    color: #0b0c0c;
+    background-color: #fd0;
+    -webkit-box-shadow: 0 -2px #fd0,
+    0 4px #0b0c0c;
+    box-shadow: 0 -2px #fd0,
+    0 4px #0b0c0c;
+    text-decoration: none;
+  }
+
   .footer-categories {
     @extend %contain-floats;
     @extend %grid-row;
@@ -11,6 +22,7 @@
     @include media(tablet) {
       padding-bottom: $gutter;
     }
+
 
     .footer-explore,
     .footer-inside-government {


### PR DESCRIPTION
The focus state colours are not consistent across even the homepage,
which is a jarring experience. Explicitly setting the colours for
now until we can get the footer component in to Static.

## Before

![www gov uk_reapply-driving-licence-medical-condition](https://user-images.githubusercontent.com/424772/65966213-b2872600-e457-11e9-94a3-1e47fde8f0a2.png)

## After

![Screenshot at Oct 01 2-34-46 pm](https://user-images.githubusercontent.com/424772/65966897-a2237b00-e458-11e9-8f28-c1f87cfa09eb.png)
