### PR TITLE
Add Privacy Notice link to site-wide footer

### DIFF
--- a/app/views/root/_footer_support_links.html.erb
+++ b/app/views/root/_footer_support_links.html.erb
@@ -1,6 +1,7 @@
 <h2 class="visuallyhidden">Support links</h2>
 <ul>
   <li><a href="/help">Help</a></li>
+  <li><a href="/help/privacy-notice">Privacy</a></li>
   <li><a href="/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
   <li><a href="/help/accessibility-statement">Accessibility statement</a></li>


### PR DESCRIPTION
Added to site-wide footer to increase visibility

![Screen Shot 2019-10-03 at 11 18 29](https://user-images.githubusercontent.com/13475227/66118992-a1f9bb80-e5cf-11e9-9309-501133f1bbd7.png)

[Trello](https://trello.com/c/jK2Yj1Hr/1342-2-add-privacy-notice-link-to-sitewide-footer)