### PR TITLE
Remove duplicate domain linking

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -165,11 +165,9 @@
              'auto',
              {'name': name})
     // Load the plugin.
-    sendToGa('require', 'linker')
     sendToGa(name + '.require', 'linker')
 
     // Define which domains to autoLink.
-    sendToGa('linker:autoLink', domain)
     sendToGa(name + '.linker:autoLink', domain)
 
     sendToGa(name + '.set', 'anonymizeIp', true)

--- a/spec/javascripts/analytics_toolkit/analytics.spec.js
+++ b/spec/javascripts/analytics_toolkit/analytics.spec.js
@@ -272,9 +272,7 @@ describe('GOVUK.Analytics', function () {
 
       var allArgs = window.ga.calls.allArgs()
       expect(allArgs).toContain(['create', '1234', 'auto', {'name': 'test'}])
-      expect(allArgs).toContain(['require', 'linker'])
       expect(allArgs).toContain(['test.require', 'linker'])
-      expect(allArgs).toContain(['linker:autoLink', ['www.example.com']])
       expect(allArgs).toContain(['test.linker:autoLink', ['www.example.com']])
       expect(allArgs).toContain(['test.set', 'anonymizeIp', true])
       expect(allArgs).toContain(['test.set', 'displayFeaturesTask', null])
@@ -286,9 +284,7 @@ describe('GOVUK.Analytics', function () {
 
       var allArgs = window.ga.calls.allArgs()
       expect(allArgs).toContain(['create', '5678', 'auto', {'name': 'test2'}])
-      expect(allArgs).toContain(['require', 'linker'])
       expect(allArgs).toContain(['test2.require', 'linker'])
-      expect(allArgs).toContain(['linker:autoLink', ['www.example.com', 'www.something.com']])
       expect(allArgs).toContain(['test2.linker:autoLink', ['www.example.com', 'www.something.com']])
       expect(allArgs).toContain(['test2.set', 'anonymizeIp', true])
       expect(allArgs).toContain(['test2.set', 'displayFeaturesTask', null])
@@ -300,9 +296,7 @@ describe('GOVUK.Analytics', function () {
 
       var allArgs = window.ga.calls.allArgs()
       expect(allArgs).toContain(['create', '5678', 'auto', {'name': 'test3'}])
-      expect(allArgs).toContain(['require', 'linker'])
       expect(allArgs).toContain(['test3.require', 'linker'])
-      expect(allArgs).toContain(['linker:autoLink', ['www.example.com', 'www.something.com', 'www.else.com']])
       expect(allArgs).toContain(['test3.linker:autoLink', ['www.example.com', 'www.something.com', 'www.else.com']])
       expect(allArgs).toContain(['test3.set', 'anonymizeIp', true])
       expect(allArgs).toContain(['test3.set', 'displayFeaturesTask', null])

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -227,12 +227,10 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.argsFor(callIndex)).toEqual(['create', 'UA-123456', 'auto', Object({ name: 'testTracker' })])
     })
     it('requires and configures the linker plugin', function () {
-      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['require', 'linker'])
-      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['testTracker.require', 'linker'])
+      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['testTracker.require', 'linker'])
     })
     it('configures the domain', function () {
-      expect(window.ga.calls.argsFor(callIndex + 3)).toEqual(['linker:autoLink', ['some.service.gov.uk']])
-      expect(window.ga.calls.argsFor(callIndex + 4)).toEqual(['testTracker.linker:autoLink', ['some.service.gov.uk']])
+      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['testTracker.linker:autoLink', ['some.service.gov.uk']])
     })
     it('sends a pageview', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['testTracker.send', 'pageview'])
@@ -258,12 +256,10 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.argsFor(callIndex)).toEqual(['create', 'UA-789', 'auto', Object({ name: 'multiple' })])
     })
     it('requires and configures the linker plugin', function () {
-      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['require', 'linker'])
-      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['multiple.require', 'linker'])
+      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['multiple.require', 'linker'])
     })
     it('configures the domains', function () {
-      expect(window.ga.calls.argsFor(callIndex + 3)).toEqual(['linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk']])
-      expect(window.ga.calls.argsFor(callIndex + 4)).toEqual(['multiple.linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk']])
+      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['multiple.linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk']])
     })
     it('sends a pageview', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['multiple.send', 'pageview'])
@@ -281,12 +277,10 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       expect(window.ga.calls.argsFor(callIndex)).toEqual(['create', 'UA-987', 'auto', Object({ name: 'multiple' })])
     })
     it('requires and configures the linker plugin', function () {
-      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['require', 'linker'])
-      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['multiple.require', 'linker'])
+      expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['multiple.require', 'linker'])
     })
     it('configures the domains', function () {
-      expect(window.ga.calls.argsFor(callIndex + 3)).toEqual(['linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk', 'third.service.gov.uk', 'fourth.service.gov.uk']])
-      expect(window.ga.calls.argsFor(callIndex + 4)).toEqual(['multiple.linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk', 'third.service.gov.uk', 'fourth.service.gov.uk']])
+      expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['multiple.linker:autoLink', ['some.service.gov.uk', 'another.service.gov.uk', 'third.service.gov.uk', 'fourth.service.gov.uk']])
     })
     it('sends a pageview', function () {
       expect(window.ga.calls.mostRecent().args).toEqual(['multiple.send', 'pageview'])


### PR DESCRIPTION
- cross domain linking is initialised on both the standard tracker (our GA property) and also in addLinkedTrackerDomain, which is now called on a different GA property for the cross domain linking
- presumably the original code was written assuming there'd only be one GA property, hence the slightly odd duplication
- removing as unnecessary
- some other cross domain linking was in place before we activated addLinkedTrackerDomain in this way (e.g. /change-driving-test) but it appears this page inits its own cross domain linker, which is separate from all of this stuff

Trello card: https://trello.com/c/wC0wQGqA/162-remove-duplicate-cross-domain-linking-initialisation