### PR TITLE
Set allowAdFeatures on linker tracker to false

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -172,6 +172,7 @@
 
     sendToGa(name + '.set', 'anonymizeIp', true)
     sendToGa(name + '.set', 'displayFeaturesTask', null)
+    sendToGa(name + '.set', 'allowAdFeatures', false)
     sendToGa(name + '.set', 'title', pii.stripPII(document.title))
     sendToGa(name + '.set', 'location', pii.stripPII(window.location.href))
 

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -229,6 +229,9 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     it('requires and configures the linker plugin', function () {
       expect(window.ga.calls.argsFor(callIndex + 1)).toEqual(['testTracker.require', 'linker'])
     })
+    it('disables Ad features', function () {
+      expect(window.ga.calls.allArgs()).toContain(['set', 'allowAdFeatures', false])
+    })
     it('configures the domain', function () {
       expect(window.ga.calls.argsFor(callIndex + 2)).toEqual(['testTracker.linker:autoLink', ['some.service.gov.uk']])
     })


### PR DESCRIPTION
- was already set on our normal tracker, but not on the cross domain linking tracker

Trello card: https://trello.com/c/41rsUlcT/157-implement-allowadfeaturesfalse-on-cross-domain-tracking-and-update-guidance