### PR TITLE
Remove displayFeaturesTask from GA code

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -18,11 +18,6 @@
       sendToGa('set', 'anonymizeIp', true)
     }
 
-    function disableAdTracking () {
-      // https://support.google.com/analytics/answer/2444872?hl=en
-      sendToGa('set', 'displayFeaturesTask', null)
-    }
-
     function disableAdFeatures () {
       // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#allowAdFeatures
       sendToGa('set', 'allowAdFeatures', false)
@@ -43,7 +38,6 @@
 
     configureProfile()
     anonymizeIp()
-    disableAdTracking()
     disableAdFeatures()
     stripTitlePII()
     stripLocationPII()
@@ -171,7 +165,6 @@
     sendToGa(name + '.linker:autoLink', domain)
 
     sendToGa(name + '.set', 'anonymizeIp', true)
-    sendToGa(name + '.set', 'displayFeaturesTask', null)
     sendToGa(name + '.set', 'allowAdFeatures', false)
     sendToGa(name + '.set', 'title', pii.stripPII(document.title))
     sendToGa(name + '.set', 'location', pii.stripPII(window.location.href))

--- a/spec/javascripts/analytics_toolkit/analytics.spec.js
+++ b/spec/javascripts/analytics_toolkit/analytics.spec.js
@@ -30,7 +30,7 @@ describe('GOVUK.Analytics', function () {
     it('configures a universal tracker', function () {
       expect(universalSetupArguments[0]).toEqual(['create', 'universal-id', {cookieDomain: '.www.gov.uk', siteSpeedSampleRate: 100}])
       expect(universalSetupArguments[1]).toEqual(['set', 'anonymizeIp', true])
-      expect(universalSetupArguments[2]).toEqual(['set', 'displayFeaturesTask', null])
+      expect(universalSetupArguments[2]).toEqual(['set', 'allowAdFeatures', false])
     })
   })
 
@@ -275,7 +275,7 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['test.require', 'linker'])
       expect(allArgs).toContain(['test.linker:autoLink', ['www.example.com']])
       expect(allArgs).toContain(['test.set', 'anonymizeIp', true])
-      expect(allArgs).toContain(['test.set', 'displayFeaturesTask', null])
+      expect(allArgs).toContain(['test.set', 'allowAdFeatures', false])
       expect(allArgs).toContain(['test.send', 'pageview'])
     })
 
@@ -287,7 +287,7 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['test2.require', 'linker'])
       expect(allArgs).toContain(['test2.linker:autoLink', ['www.example.com', 'www.something.com']])
       expect(allArgs).toContain(['test2.set', 'anonymizeIp', true])
-      expect(allArgs).toContain(['test2.set', 'displayFeaturesTask', null])
+      expect(allArgs).toContain(['test2.set', 'allowAdFeatures', false])
       expect(allArgs).toContain(['test2.send', 'pageview'])
     })
 
@@ -299,7 +299,7 @@ describe('GOVUK.Analytics', function () {
       expect(allArgs).toContain(['test3.require', 'linker'])
       expect(allArgs).toContain(['test3.linker:autoLink', ['www.example.com', 'www.something.com', 'www.else.com']])
       expect(allArgs).toContain(['test3.set', 'anonymizeIp', true])
-      expect(allArgs).toContain(['test3.set', 'displayFeaturesTask', null])
+      expect(allArgs).toContain(['test3.set', 'allowAdFeatures', false])
       expect(allArgs).toContain(['test3.send', 'pageview'])
     })
   })

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -50,7 +50,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     })
 
     it('disables Ad features', function () {
-      expect(setupArguments[3]).toEqual(['set', 'allowAdFeatures', false])
+      expect(setupArguments[2]).toEqual(['set', 'allowAdFeatures', false])
     })
   })
 
@@ -240,7 +240,7 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
     })
     it('removes pii from the pageview', function () {
       expect(window.ga.calls.allArgs()).toContain(['set', 'title' , 'With [email] [date] and [postcode] in it'])
-      expect(window.ga.calls.argsFor(5)[2]).toContain('?address=[email]&postcode=[postcode]&date=[date]')
+      expect(window.ga.calls.argsFor(4)[2]).toContain('?address=[email]&postcode=[postcode]&date=[date]')
     })
     it('can omit sending a pageview', function () {
       universal.addLinkedTrackerDomain('UA-123456', 'testTracker', 'some.service.gov.uk', false)


### PR DESCRIPTION
- seems to be unnecessary for our purposes: `allowAdFeatures:false` is already being set
- according to https://developers.google.com/analytics/devguides/collection/analyticsjs/tasks displayFeaturesTask `Sends an additional hit if display features is enabled and a previous hit has not been sent within the timeout period set by the advertising features cookie (_gat).` and we're not using display features

Trello card: https://trello.com/c/41rsUlcT/157-implement-allowadfeaturesfalse-on-cross-domain-tracking-and-update-guidance
