### PR TITLE
Update global banner content to match campaign

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -388,15 +388,20 @@
   .global-bar-message {
     margin-bottom: 0;
     margin-top: 0;
+    max-width: 70%;
 
     @include media(tablet) {
-      max-width: 66.67%;
+      max-width: auto;
     }
 
     .global-bar-title {
       display: block;
       font-weight: 700;
       margin-right: 10px;
+    }
+
+    .global-bar-link {
+      @include bold-19;
     }
   }
 }

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,8 +1,8 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
-  title = "The United Kingdom is leaving the European Union on 31 October 2019."
+  title = false
   link_href = "/brexit"
-  link_text = "Get ready for Brexit"
+  link_text = "Get ready for Brexit on 31 October 2019"
 -%>
 <% if show_global_bar %>
   <% content_for :head do %>
@@ -14,13 +14,18 @@
   <div id="global-bar" class="global-bar dont-print" data-module="global-bar">
     <div class="global-bar-message-container">
     <p class="global-bar-message">
-      <span class="global-bar-title"><%= title %></span>
-      <%= link_to(
-        link_text,
-        link_href,
-        rel: "external noreferrer",
-        class: "js-call-to-action"
-      ) %>
+      <% if title %>
+        <span class="global-bar-title"><%= title %></span>
+      <% end %>
+
+      <% if link_href && link_text %>
+        <%= link_to(
+          link_text,
+          link_href,
+          rel: "external noreferrer",
+          class: "global-bar-link js-call-to-action"
+        ) %>
+      <% end %>
     </p>
     <a href="#hide-message"
        class="dismiss"


### PR DESCRIPTION
Updates the global banner content to match the campaign. This includes:

- Making the banner more flexible so it can be displayed without the title or without the link if necessary
- Updates the link text
- A slight tweak to stop the link text and hide button overlapping on mobile

<img width="1008" alt="Screen Shot 2019-10-08 at 10 08 56" src="https://user-images.githubusercontent.com/29889908/66383021-26738200-e9b4-11e9-8182-354a3bd70e2a.png">
