### PR TITLE
Ability to track click events with a custom event label

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -4,6 +4,7 @@
   window.GOVUK = window.GOVUK || {};
 
   var DEFAULT_LIST_TITLE = 'Site search results';
+  var DEFAULT_TRACK_CLICK_LABEL = 'Results';
 
   var Ecommerce = function (config) {
     this.init = function (element) {
@@ -14,6 +15,7 @@
       var startPosition = parseInt(element.data('ecommerce-start-index'), 10);
       var listTitle     = element.data('list-title') || DEFAULT_LIST_TITLE;
       var variant       = element.data('ecommerce-variant');
+      var trackClickLabel = element.data('track-click-label') || DEFAULT_TRACK_CLICK_LABEL;
 
       ecommerceRows.each(function(index, ecommerceRow) {
         var $ecommerceRow = $(ecommerceRow);
@@ -22,7 +24,7 @@
           path = $ecommerceRow.attr('data-ecommerce-path');
 
         addImpression(contentId, path, index + startPosition, searchQuery, listTitle, variant);
-        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant);
+        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant, trackClickLabel);
       });
     }
 
@@ -41,7 +43,7 @@
       ga('ec:addImpression', data);
     }
 
-    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, variant) {
+    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, variant, trackClickLabel) {
       row.click(function(event) {
         var data = {
           id: contentId || path,
@@ -55,7 +57,7 @@
 
         ga('ec:setAction', 'click', {list: listTitle});
         GOVUK.analytics.trackEvent('UX', 'click',
-          GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions({label: 'Results'})
+          GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions({label: trackClickLabel})
         );
       });
     }

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -366,6 +366,77 @@ describe('Ecommerce reporter for results pages', function() {
     })
   });
 
+  it('tracks clicks with different event labels', function() {
+    element = $('\
+      <div> \
+        <div data-analytics-ecommerce data-list-title="First list" data-ecommerce-start-index="1" data-search-query="search query">\
+          <div \
+            data-ecommerce-row=1\
+            data-ecommerce-path="/path/to/page"\
+            data-ecommerce-content-id="AAAA-1111">\
+          </div>\
+        </div>\
+        <div data-analytics-ecommerce data-list-title="Second list" data-track-click-label="Custom click label" data-ecommerce-start-index="1" data-search-query="blah">\
+          <div \
+            data-ecommerce-row=1\
+            data-ecommerce-path="/path/to/blah"\
+            data-ecommerce-content-id="AAAA-2222">\
+          </div>\
+        </div>\
+      </div>\
+    ');
+
+    GOVUK.Ecommerce.start(element.find('[data-analytics-ecommerce]'));
+    element.find('[data-ecommerce-row]').click();
+
+    expect(ga).toHaveBeenCalledWith('send', {
+      hitType: 'event',
+      eventCategory: 'UX',
+      eventAction: 'click',
+      eventLabel: 'Results',
+      dimension15: '200',
+      dimension16: 'unknown',
+      dimension11: '1',
+      dimension3: 'other',
+      dimension4: '00000000-0000-0000-0000-000000000000',
+      dimension12: 'not withdrawn',
+      dimension23: 'unknown',
+      dimension26: '0',
+      dimension27: '0',
+      dimension32: 'none',
+      dimension39: 'false',
+      dimension56: 'other',
+      dimension57: 'other',
+      dimension58: 'other',
+      dimension59: 'other',
+      dimension30: 'none',
+      dimension95: '12345.67890'
+    })
+    expect(ga).toHaveBeenCalledWith('send', {
+      hitType: 'event',
+      eventCategory: 'UX',
+      eventAction: 'click',
+      eventLabel: 'Custom click label',
+      dimension15: '200',
+      dimension16: 'unknown',
+      dimension11: '1',
+      dimension3: 'other',
+      dimension4: '00000000-0000-0000-0000-000000000000',
+      dimension12: 'not withdrawn',
+      dimension23: 'unknown',
+      dimension26: '0',
+      dimension27: '0',
+      dimension32: 'none',
+      dimension39: 'false',
+      dimension56: 'other',
+      dimension57: 'other',
+      dimension58: 'other',
+      dimension59: 'other',
+      dimension30: 'none',
+      dimension95: '12345.67890'
+    })
+  });
+
   it('will only require the ec library once', function() {
     GOVUK.Ecommerce.ecLoaded = false;
     GOVUK.Ecommerce.start($('<div data-search-query="search query"></div>'));


### PR DESCRIPTION
At the moment all instances of tracking click events in GA are sent with an eventLabel of 'Results' as shown below.
<img width="272" alt="Screen Shot 2019-10-15 at 09 26 47" src="https://user-images.githubusercontent.com/3758555/66814116-f71dc180-ef2d-11e9-8cd6-e9d3a1050143.png">
and this is hardcoded in [ecommerce.js](https://github.com/alphagov/static/blob/6a0d8a619e56063c81c193458bff92618f163306/app/assets/javascripts/analytics/ecommerce.js#L49)

This is sufficient when you're only tracking one set of link clicks with ecommerce.

Ability to track items on separate lists [was added ](https://github.com/alphagov/static/pull/1810) but the clicks always have the hardcoded `eventLabel` as shown above.

For upcoming [spelling suggestion work](https://github.com/alphagov/finder-frontend/pull/1643) we have a requirement to track those links with a different label.

This PR to provide the option to specify the event label sent to GA when clicking a link in a specific list.

This can be done by adding an additional  `data-track-click-label` attribute to the element where we initialise list tracking.

Example of how this would work: 
<img width="439" alt="Screen Shot 2019-10-15 at 09 47 04" src="https://user-images.githubusercontent.com/3758555/66815780-c723ed80-ef30-11e9-9abb-b09a022d7f4d.png">

While we could reuse the `listTitle` string for the click event label, there's probably a reason why standard search results link tracking has them separate, as shown below, where the list title is 'Search`
<img width="212" alt="Screen Shot 2019-10-15 at 09 50 29" src="https://user-images.githubusercontent.com/3758555/66816038-4addda00-ef31-11e9-9cf6-d9b2580f8948.png">

