### PR TITLE
Add versioning mechanism to global banner

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -10,6 +10,7 @@
   Modules.GlobalBar = function() {
     this.start = function($el) {
       var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen",
+          current_cookie_version = JSON.parse(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["version"],
           count = viewCount();
 
       $el.on('click', '.dismiss', hide);
@@ -29,7 +30,8 @@
 
       function hide(evt) {
         $el.hide();
-        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, 999, {days: 84});
+        var cookie_value = JSON.stringify({"count": 999, "version": current_cookie_version});
+        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookie_value, {days: 84});
         track('Manually dismissed');
         $('html').removeClass('show-global-bar');
         evt.preventDefault();
@@ -37,7 +39,8 @@
 
       function incrementViewCount(count) {
         count = count + 1;
-        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, count, {days: 84});
+        var cookie_value = JSON.stringify({"count": count, "version": current_cookie_version});
+        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookie_value, {days: 84});
 
         if (count == 2) {
           track('Automatically dismissed');
@@ -46,7 +49,7 @@
 
       function viewCount() {
         var viewCountCookie = GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE),
-            viewCount = parseInt(viewCountCookie, 10);
+            viewCount = parseInt(JSON.parse(viewCountCookie)["count"],10);
 
         if (isNaN(viewCount)) {
           viewCount = 0;

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -7,7 +7,13 @@
 <% if show_global_bar %>
   <% content_for :head do %>
     <!--[if gt IE 7]><!-->
-    <script>!function(t){"use strict";function e(){return!/^\/register-to-vote|^\/done|^\/brexit|^\/get-ready-brexit-check/.test(window.location.pathname)}function n(){var e=t.cookie.match("(?:^|[ ;])global_bar_seen=([0-9]+)");return e?parseInt(e.pop(),10)<3:!0}var o=t.documentElement;e()&&n()&&(o.className=o.className.concat(" show-global-bar"))}(document);</script>
+    <script>
+      // Bump this if you are releasing a major change to the banner
+      // This will reset the view count so all users will see the banner, even if previously seen
+      COOKIE_VERSION = 1;
+
+      !function(e,o=COOKIE_VERSION){function n(){var e=new Date(Date.now()+72576e5).toUTCString();document.cookie='global_bar_seen={"count":0,"version":'+o+"}; expires="+e+";"}var t,a,r,c=e.documentElement;!/^\/register-to-vote|^\/done|^\/brexit|^\/get-ready-brexit-check/.test(window.location.pathname)&&(a=document.cookie.match("(?:^|[ ;])(?:global_bar_seen=)(.+?)(?:(?=;|$))"),r=!1,null===a?(n(),r=!0):(t=a[1],void 0===JSON.parse(t).version||JSON.parse(a[1]).version!==o?(n(),r=!0):(a=JSON.parse(a[1]),r=parseInt(a.count,10)<3)),r)&&(c.className=c.className.concat(" show-global-bar"))}(document);
+    </script>
     <!--<![endif]-->
   <% end %>
   <!--[if gt IE 7]><!-->


### PR DESCRIPTION
## What
Changes the `global_bar_seen` cookie value to include the banner version, therefore adding a versioning mechanism to the banner.

## Why
The global banner currently disappears after it has been viewed 3 times or if a user manually dismisses it. This banner could be used in the future for other events, and we therefore may want to "reset" the banner so users who have previously seen it or manually dismissed it will be able to view it again.

Note: this PR does change some of the behaviour, but doesn't address the minified JS in the view. This isn't ideal, but we don't have the time/capacity to tidy it up now.

**This is currently on integration, if you want to test**