### PR TITLE
Handle global_bar_seen cookie not being set

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -9,9 +9,16 @@
 
   Modules.GlobalBar = function() {
     this.start = function($el) {
-      var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen",
-          current_cookie_version = JSON.parse(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["version"],
-          count = viewCount();
+      var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen";
+
+      // If the cookie is not set, let's set a basic one
+      if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)["count"] === undefined) {
+        GOVUK.setCookie("global_bar_seen", JSON.stringify({"count":0,"version":0}), {days: 84});
+      }
+
+      var current_cookie = JSON.parse(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)),
+      current_cookie_version = current_cookie["version"],
+      count = viewCount();
 
       $el.on('click', '.dismiss', hide);
       $el.on('click', '.js-call-to-action', handleCallToActionClick);


### PR DESCRIPTION
To fix Smokey test failures like this: https://deploy.publishing.service.gov.uk/job/smokey/11502/consoleFull

Some of our Smokey tests don't seem to include the global bar, and so the JS included in the global bar view is not executed, including setting a cookie if it doesn't yet exist.

This commit replicates that logic in the global-bar.js file too, so if the cookie is not set, it will set a basic one. The next time the user navigates, that cookie will be updated with the correct version etc.