### PR TITLE
Add missing JSON.parse

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -12,7 +12,7 @@
       var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen";
 
       // If the cookie is not set, let's set a basic one
-      if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)["count"] === undefined) {
+      if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || JSON.parse(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["count"] === undefined) {
         GOVUK.setCookie("global_bar_seen", JSON.stringify({"count":0,"version":0}), {days: 84});
       }
 


### PR DESCRIPTION
I missed a `JSON.parse` in the previous fix, so the conditional was always evaluating to true and the count/version were always being set to the default.

Tested on integration and this seems to fix the issue.