### PR TITLE
Fix 403 page title

### DIFF
--- a/app/views/root/403.html.erb
+++ b/app/views/root/403.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Page not found - 403",
+    title: "Forbidden - 403",
     heading: "You are not permitted to see this page",
     intro: '<p>This page is restricted to certain users only.</p>',
     status_code: 403


### PR DESCRIPTION
Trello: https://trello.com/c/sUjBwDG0/166-clean-up-factcheck

This is not a page not found scenario, I'm assuming the title here was done by mistake.