### PR TITLE
Remove bold link style on sitewide banner

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sass-rails', "5.0.7"
 gem 'asset_bom_removal-rails', '~> 1.0.0'
 gem 'nokogiri', "~> 1.10"
 gem 'redis', "~> 4.1.3"
-gem 'govuk_publishing_components', '~> 21.5.1'
+gem 'govuk_publishing_components', '~> 21.5.0'
 gem 'govuk_app_config', '~> 2.0.1'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.5.1)
+    govuk_publishing_components (21.5.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -341,7 +341,7 @@ DEPENDENCIES
   govuk-lint (~> 4.0)
   govuk_app_config (~> 2.0.1)
   govuk_frontend_toolkit (~> 9.0.0)
-  govuk_publishing_components (~> 21.5.1)
+  govuk_publishing_components (~> 21.5.0)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.5)

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -399,9 +399,5 @@
       font-weight: 700;
       margin-right: 10px;
     }
-
-    .global-bar-link {
-      @include bold-19;
-    }
   }
 }

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -29,7 +29,7 @@
           link_text,
           link_href,
           rel: "external noreferrer",
-          class: "govuk-link global-bar-link js-call-to-action"
+          class: "govuk-link js-call-to-action"
         ) %>
       <% end %>
     </p>


### PR DESCRIPTION
No longer needed now that it contains more than just a link.
This means we no longer need the `global-bar-link` class, so
that class has been removed too.