### PR TITLE
Track ecommerce variant if set

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -13,6 +13,7 @@
       var ecommerceRows = element.find('[data-ecommerce-row]');
       var startPosition = parseInt(element.data('ecommerce-start-index'), 10);
       var listTitle     = element.data('list-title') || DEFAULT_LIST_TITLE;
+      var variant       = element.data('ecommerce-variant');
 
       ecommerceRows.each(function(index, ecommerceRow) {
         var $ecommerceRow = $(ecommerceRow);
@@ -20,29 +21,37 @@
         var contentId = $ecommerceRow.attr('data-ecommerce-content-id'),
           path = $ecommerceRow.attr('data-ecommerce-path');
 
-        addImpression(contentId, path, index + startPosition, searchQuery, listTitle);
-        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle);
+        addImpression(contentId, path, index + startPosition, searchQuery, listTitle, variant);
+        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant);
       });
     }
 
-    function addImpression (contentId, path, position, searchQuery, listTitle) {
+    function addImpression (contentId, path, position, searchQuery, listTitle, variant) {
       // We only add the id to GA as additional product data is linked when it is uploaded.
       // This approach is taken to avoid the GA data packet exceeding the 8k limit
-      ga('ec:addImpression', {
+      var data = {
         id: contentId || path,
         position: position,
         list: listTitle,
         dimension71: searchQuery
-      });
+      };
+      if(variant !== undefined) {
+        data.variant = variant;
+      }
+      ga('ec:addImpression', data);
     }
 
-    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle) {
+    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, variant) {
       row.click(function(event) {
-        ga('ec:addProduct', {
+        var data = {
           id: contentId || path,
           position: position,
           dimension71: searchQuery
-        });
+        };
+        if(variant !== undefined) {
+          data.variant = variant;
+        }
+        ga('ec:addProduct', data);
 
         ga('ec:setAction', 'click', {list: listTitle});
         GOVUK.analytics.trackEvent('UX', 'click',

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -31,6 +31,28 @@ describe('Ecommerce reporter for results pages', function() {
     });
   });
 
+  it('tracks impressions with product variants', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1" data-search-query="search query" data-ecommerce-variant="variant-x">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111">\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      position: 1,
+      list: 'Site search results',
+      dimension71: 'search query',
+      variant: 'variant-x'
+    });
+  });
+
   it('tracks multiple lists individually', function() {
     element = $('\
       <div> \
@@ -271,6 +293,52 @@ describe('Ecommerce reporter for results pages', function() {
       id: 'AAAA-1111',
       position: 1,
       dimension71: 'search query'
+    });
+    expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Site search results'})
+    expect(ga).toHaveBeenCalledWith('send', {
+      hitType: 'event',
+      eventCategory: 'UX',
+      eventAction: 'click',
+      eventLabel: 'Results',
+      dimension15: '200',
+      dimension16: 'unknown',
+      dimension11: '1',
+      dimension3: 'other',
+      dimension4: '00000000-0000-0000-0000-000000000000',
+      dimension12: 'not withdrawn',
+      dimension23: 'unknown',
+      dimension26: '0',
+      dimension27: '0',
+      dimension32: 'none',
+      dimension39: 'false',
+      dimension56: 'other',
+      dimension57: 'other',
+      dimension58: 'other',
+      dimension59: 'other',
+      dimension30: 'none',
+      dimension95: '12345.67890'
+    })
+  });
+
+  it('tracks clicks with product variants', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1" data-search-query="search query" data-ecommerce-variant="variant-x">\
+        <a \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-content-id="AAAA-1111"\
+        </a>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+    element.find('[data-ecommerce-row]').click();
+
+    expect(ga).toHaveBeenCalledWith('ec:addProduct', {
+      id: 'AAAA-1111',
+      position: 1,
+      dimension71: 'search query',
+      variant: 'variant-x'
     });
     expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Site search results'})
     expect(ga).toHaveBeenCalledWith('send', {


### PR DESCRIPTION
We use ecommerce tracking to know what people click on in search, and
where in the results list that is: when sorting by relevancy, we want
higher up results to match what the users expect.  But relevancy isn't
the only way to sort search results, in which case we wouldn't
necessarily want or expect clicks to be clustered at the top.

So we can see how sort order affects clicks, and to avoid lumping
different use-cases together, we're going to use the selected sort
option as a product variant.

---

[Trello card](https://trello.com/c/CCMNeJl4/972-modify-ecommerce-tracking-to-track-sort-order)