### PR TITLE
Add base target blank when rendered in iframes

### DIFF
--- a/app/assets/javascripts/modules/base-target.js
+++ b/app/assets/javascripts/modules/base-target.js
@@ -1,0 +1,26 @@
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
+(function (Modules) {
+  function BaseTarget () { }
+
+  BaseTarget.prototype.start = function () {
+    if (this.pageIsInIframe()) {
+      this.setBaseTarget()
+    }
+  }
+
+  BaseTarget.prototype.setBaseTarget = function () {
+    var base = document.createElement('base')
+    base.target = '_blank'
+    document.getElementsByTagName('head')[0].appendChild(base)
+  }
+
+  BaseTarget.prototype.pageIsInIframe = function () {
+    return window.parent && window.location !== window.parent.location
+  }
+
+  Modules.BaseTarget = BaseTarget
+})(window.GOVUK.Modules)
+
+new window.GOVUK.Modules.BaseTarget().start()

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,5 +1,4 @@
 // = require govuk/modules
-// = require modules/base-target
 // = require modules/global-bar
 // = require modules/sticky-element-container
 // = require modules/toggle

--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,4 +1,5 @@
 // = require govuk/modules
+// = require modules/base-target
 // = require modules/global-bar
 // = require modules/sticky-element-container
 // = require modules/toggle

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,3 +1,6 @@
 <%= javascript_include_tag 'libs/jquery/jquery-1.12.4.js', integrity: true, crossorigin: 'anonymous' %>
 <%= javascript_include_tag local_assigns[:js_file] || 'application', integrity: true, crossorigin: 'anonymous' %>
+<% if ENV["DRAFT_ENVIRONMENT"].present? %>
+  <%= javascript_include_tag 'modules/base-target', integrity: true, crossorigin: 'anonymous' %>
+<% end %>
 <%= javascript_include_tag 'surveys', integrity: true, crossorigin: 'anonymous' %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,6 +1,7 @@
 Rails.application.config.assets.precompile += %w{
   favicon.ico
   libs/jquery/jquery-1.12.4.js
+  modules/base-target.js
   application.js
   header-footer-only.js
   error-page.js

--- a/spec/javascripts/modules/base-target.spec.js
+++ b/spec/javascripts/modules/base-target.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env jasmine, jquery */
+// = require modules/base-target
 
 describe('A base target module', function () {
   'use strict'

--- a/spec/javascripts/modules/base-target.spec.js
+++ b/spec/javascripts/modules/base-target.spec.js
@@ -1,0 +1,41 @@
+/* eslint-env jasmine, jquery */
+
+describe('A base target module', function () {
+  'use strict'
+
+  describe('when rendered inside an iframe', function () {
+    var windowParent = window.parent
+    var mockWindowParent = {} // window.parent would be different than window when used inside an iframe
+
+    beforeEach(function () {
+      window.parent = mockWindowParent
+      var baseTarget = new window.GOVUK.Modules.BaseTarget()
+      baseTarget.start()
+    })
+
+    afterEach(function () {
+      window.parent = windowParent
+      var head = document.getElementsByTagName('head')[0]
+      var base = document.getElementsByTagName('base')[0]
+      if (head && base) head.removeChild(base)
+    })
+
+    it('should append a <base target="_blank"> tag to <head>', function () {
+      var base = document.getElementsByTagName('base')[0]
+      expect(base.getAttribute('target')).toEqual('_blank')
+    })
+  })
+
+  describe('when not rendered inside an iframe', function () {
+    beforeEach(function () {
+      var baseTarget = new window.GOVUK.Modules.BaseTarget()
+      baseTarget.start()
+    })
+
+    it('should not append a <base target="_blank"> tag to <head>', function () {
+      var head = document.getElementsByTagName('head')[0]
+      var base = head.getElementsByTagName('base')[0]
+      expect(base).toBeFalsy()
+    })
+  })
+})


### PR DESCRIPTION
### What
Add a script to determine whether or not the current page sits within an <iframe>. If it does we change the base target to be blank so that all links will open in a new window (outside the iframe).

### Why
To allow people to check links (especially when they point to an non-secure (http) location) while previewing pages in Content Publisher.

[Trello card](https://trello.com/c/JMWWsYBT)