### PR TITLE
Add a custom meta tag dimension for spelling suggestions

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -59,7 +59,8 @@
       'content-has-history': {dimension: 39, defaultValue: 'false'},
       'publishing-application': {dimension: 89},
       'stepnavs': {dimension: 96},
-      'relevant-result-shown': {dimension: 83}
+      'relevant-result-shown': {dimension: 83},
+      'spelling-suggestion': {dimension: 81}
     };
 
     var $metas = $('meta[name^="govuk:"]');

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -68,6 +68,16 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(pageViewObject.dimension42).toEqual('name-of-test:name-of-ab-bucket');
         expect(pageViewObject.dimension48).toEqual('name-of-other-test:name-of-other-ab-bucket');
       });
+      it('sets the spelling suggestion as dimension 81', function() {
+        $('head').append('\
+          <meta name="govuk:spelling-suggestion" content="driving">\
+        ');
+
+        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+        pageViewObject = getPageViewObject();
+
+        expect(pageViewObject.dimension81).toEqual('driving');
+      });
 
       it('ignores A/B meta tags with invalid dimensions', function () {
         $('head').append('\


### PR DESCRIPTION
Add custom meta tag to the dimensionsMap

We'd like to track spelling suggestions on page view. Previously, we set the value via javascript, but it was too late as the pageview object payload was already sent.

Adding this custom meta tag to the allowed map, will enable us
to track if suggestion are displayed on page view.

[Trello ticket](https://trello.com/c/7eVLdKvd/1110-fix-spelling-suggestion-tracking)