### PR TITLE
Resolve mocha deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,7 @@ require File.expand_path("../config/environment", __dir__)
 require "minitest/autorun"
 require "test/unit"
 require "rails/test_help"
-require "mocha/mini_test"
+require "mocha/minitest"
 
 class ActiveSupport::TestCase
   def create_test_file(filename:, content:)


### PR DESCRIPTION
Resolves:
> Mocha deprecation warning at /home/build/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/activesupport-5.2.3/lib/active_support/dependencies.rb:291:in
> `require': `require 'mocha/mini_test'` has been deprecated. Please use
> `require 'mocha/minitest' instead.