### PR TITLE
Add register to vote banner

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -351,7 +351,7 @@
   background-color: #E5EAF1;
   display: none;
   padding: 15px 0;
-  border-top: 8px solid #E61E32;
+  border-top: 8px solid $govuk-blue;
 
   .show-global-bar & {
     display: block;

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,16 +1,20 @@
 <%
-  show_global_bar ||= false # Toggles the appearance of the global bar
-  title = "A Brexit deal has been agreed but needs to be ratified"
-  link_href = "/brexit"
-  link_text = "Find out what this means for you"
+  require 'date'
+
+  show_global_bar ||= true # Toggles the appearance of the global bar
+  title = "Register to vote"
+  link_href = "/register-to-vote"
+  link_text = "Register by 26 November to vote in the General Election on 12 December."
+  close_date = DateTime.new(2019,11,26,23,59,00) # DateTime after which the bar will automatically disappear, or false to unset
 -%>
-<% if show_global_bar %>
+
+<% if show_global_bar && (!close_date || DateTime.now() < close_date) %>
   <% content_for :head do %>
     <!--[if gt IE 7]><!-->
     <script>
       // Bump this if you are releasing a major change to the banner
       // This will reset the view count so all users will see the banner, even if previously seen
-      COOKIE_VERSION = 2;
+      COOKIE_VERSION = 3;
 
       !function(e,o=COOKIE_VERSION){function n(){var e=new Date(Date.now()+72576e5).toUTCString();document.cookie='global_bar_seen={"count":0,"version":'+o+"}; expires="+e+";"}var t,a,r,c=e.documentElement;!/^\/register-to-vote|^\/done|^\/brexit|^\/get-ready-brexit-check/.test(window.location.pathname)&&(a=document.cookie.match("(?:^|[ ;])(?:global_bar_seen=)(.+?)(?:(?=;|$))"),r=!1,null===a?(n(),r=!0):(t=a[1],void 0===JSON.parse(t).version||JSON.parse(a[1]).version!==o?(n(),r=!0):(a=JSON.parse(a[1]),r=parseInt(a.count,10)<3)),r)&&(c.className=c.className.concat(" show-global-bar"))}(document);
     </script>


### PR DESCRIPTION
Trello: https://trello.com/c/Lu2x8C4G/236-add-register-to-vote-banner

## What

- Updates global banner content to point to Register to Vote page
- Adds logic to support an automatic turn off date and time
- Sets automatic turn off datetime to 11:59pm on 26th November 2019

<img width="1440" alt="Screen Shot 2019-11-11 at 11 37 39" src="https://user-images.githubusercontent.com/29889908/68587788-d76faf80-047f-11ea-9fe9-895b6c44e070.png">
