### PR TITLE
Remove unnecessary govuk-link class

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -42,7 +42,7 @@
             class: "govuk-link js-call-to-action"
           ) %>
         <% else %>
-          <span class="govuk-link"><%= link_text %></span>
+          <span><%= link_text %></span>
         <% end %>
       <% end %>
     </p>


### PR DESCRIPTION
Removes the unnecessary `govuk-link` class - this will otherwise add hover and focus states to non-link text.