### PR TITLE
Replace govuk-lint and fix offenses in the Gemfile

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml

--- a/Gemfile
+++ b/Gemfile
@@ -2,33 +2,33 @@ source "https://rubygems.org"
 
 ruby File.read(".ruby-version").chomp
 
-gem "rails", "~> 5.2"
-gem "rack_strip_client_ip", "0.0.2"
 gem "actionpack-page_caching", "1.1.1"
-gem "uglifier", ">= 1.3.0"
-gem "sass-rails", "5.0.7"
 gem "asset_bom_removal-rails", "~> 1.0.0"
-gem "nokogiri", "~> 1.10"
-gem "redis", "~> 4.1.3"
-gem "govuk_publishing_components", "~> 21.10.0"
 gem "govuk_app_config", "~> 2.0.1"
+gem "govuk_publishing_components", "~> 21.10.0"
+gem "nokogiri", "~> 1.10"
+gem "rack_strip_client_ip", "0.0.2"
+gem "rails", "~> 5.2"
+gem "redis", "~> 4.1.3"
+gem "sass-rails", "5.0.7"
+gem "uglifier", ">= 1.3.0"
 
 group :development do
-  gem "image_optim", "0.26.5"
   gem "better_errors"
   gem "binding_of_caller"
+  gem "image_optim", "0.26.5"
 end
 
 group :test do
   gem "govuk-content-schema-test-helpers", "~> 1.6"
   gem "govuk_test"
-  gem "mocha", "~> 1.9.0", require: false
-  gem "shoulda"
-  gem "webmock"
-  gem "test-unit"
+  gem "jasmine-core", [">= 2.99", "< 3"]
   gem "minitest"
   gem "minitest-capybara", "~> 0.9.0"
-  gem "jasmine-core", [">= 2.99", "< 3"]
+  gem "mocha", "~> 1.9.0", require: false
+  gem "shoulda"
+  gem "test-unit"
+  gem "webmock"
 end
 
 group :development, :test do
@@ -37,7 +37,7 @@ group :development, :test do
   gem "rubocop-govuk"
 end
 
-gem "plek", "3.0.0"
+gem "gds-api-adapters", "~> 61.0"
 gem "govuk_frontend_toolkit", "~> 9.0.0"
 gem "govuk_template", "0.26.0"
-gem "gds-api-adapters", "~> 61.0"
+gem "plek", "3.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,43 +1,43 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
-ruby File.read('.ruby-version').chomp
+ruby File.read(".ruby-version").chomp
 
-gem 'rails', '~> 5.2'
-gem 'rack_strip_client_ip', '0.0.2'
-gem 'actionpack-page_caching', '1.1.1'
-gem 'uglifier', ">= 1.3.0"
-gem 'sass-rails', "5.0.7"
-gem 'asset_bom_removal-rails', '~> 1.0.0'
-gem 'nokogiri', "~> 1.10"
-gem 'redis', "~> 4.1.3"
-gem 'govuk_publishing_components', '~> 21.10.0'
-gem 'govuk_app_config', '~> 2.0.1'
+gem "rails", "~> 5.2"
+gem "rack_strip_client_ip", "0.0.2"
+gem "actionpack-page_caching", "1.1.1"
+gem "uglifier", ">= 1.3.0"
+gem "sass-rails", "5.0.7"
+gem "asset_bom_removal-rails", "~> 1.0.0"
+gem "nokogiri", "~> 1.10"
+gem "redis", "~> 4.1.3"
+gem "govuk_publishing_components", "~> 21.10.0"
+gem "govuk_app_config", "~> 2.0.1"
 
 group :development do
-  gem 'image_optim', '0.26.5'
-  gem 'better_errors'
-  gem 'binding_of_caller'
+  gem "image_optim", "0.26.5"
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :test do
-  gem 'govuk-content-schema-test-helpers', '~> 1.6'
-  gem 'govuk_test'
-  gem 'mocha', '~> 1.9.0', require: false
-  gem 'shoulda'
-  gem 'webmock'
-  gem 'test-unit'
-  gem 'minitest'
-  gem 'minitest-capybara', '~> 0.9.0'
-  gem 'jasmine-core', ['>= 2.99', '< 3']
+  gem "govuk-content-schema-test-helpers", "~> 1.6"
+  gem "govuk_test"
+  gem "mocha", "~> 1.9.0", require: false
+  gem "shoulda"
+  gem "webmock"
+  gem "test-unit"
+  gem "minitest"
+  gem "minitest-capybara", "~> 0.9.0"
+  gem "jasmine-core", [">= 2.99", "< 3"]
 end
 
 group :development, :test do
-  gem 'jasmine-rails', '~> 0.15.0'
-  gem 'pry'
-  gem 'rubocop-govuk'
+  gem "jasmine-rails", "~> 0.15.0"
+  gem "pry"
+  gem "rubocop-govuk"
 end
 
-gem 'plek', '3.0.0'
-gem 'govuk_frontend_toolkit', '~> 9.0.0'
-gem 'govuk_template', '0.26.0'
-gem 'gds-api-adapters', '~> 61.0'
+gem "plek", "3.0.0"
+gem "govuk_frontend_toolkit", "~> 9.0.0"
+gem "govuk_template", "0.26.0"
+gem "gds-api-adapters", "~> 61.0"

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,8 @@ end
 
 group :development, :test do
   gem 'jasmine-rails', '~> 0.15.0'
-  gem 'govuk-lint', '~> 4.3'
   gem 'pry'
+  gem 'rubocop-govuk'
 end
 
 gem 'plek', '3.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,11 +94,6 @@ GEM
       activesupport (>= 4.2.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk-lint (4.3.0)
-      rubocop (~> 0.76)
-      rubocop-rails (~> 2)
-      rubocop-rspec (~> 1.28)
-      scss_lint
     govuk_app_config (2.0.1)
       logstasher (>= 1.2.2, < 1.4.0)
       sentry-raven (>= 2.7.1, < 2.12.0)
@@ -250,6 +245,10 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (1.0.0)
+      rubocop (~> 0.76)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-rails (2.3.2)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -277,8 +276,6 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    scss_lint (0.59.0)
-      sass (~> 3.5, >= 3.5.5)
     selenium-webdriver (3.142.6)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
@@ -338,7 +335,6 @@ DEPENDENCIES
   binding_of_caller
   gds-api-adapters (~> 61.0)
   govuk-content-schema-test-helpers (~> 1.6)
-  govuk-lint (~> 4.3)
   govuk_app_config (~> 2.0.1)
   govuk_frontend_toolkit (~> 9.0.0)
   govuk_publishing_components (~> 21.10.0)
@@ -356,6 +352,7 @@ DEPENDENCIES
   rack_strip_client_ip (= 0.0.2)
   rails (~> 5.2)
   redis (~> 4.1.3)
+  rubocop-govuk
   sass-rails (= 5.0.7)
   shoulda
   test-unit


### PR DESCRIPTION
- See commits for more detail.

https://trello.com/c/CdBFg6yw/1521-replace-govuk-lint-with-rubocop-govuk