### PR TITLE
Support page path as name in ecommerce tracking

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -28,32 +28,41 @@
       });
     }
 
-    function addImpression (contentId, path, position, searchQuery, listTitle, variant) {
-      // We only add the id to GA as additional product data is linked when it is uploaded.
-      // This approach is taken to avoid the GA data packet exceeding the 8k limit
+    function constructData(contentId, path, position, listTitle, searchQuery, variant) {
       var data = {
-        id: contentId || path,
         position: position,
         list: listTitle,
         dimension71: searchQuery
-      };
-      if(variant !== undefined) {
-        data.variant = variant;
       }
-      ga('ec:addImpression', data);
+
+      if (contentId !== undefined) {
+        data.id = contentId
+      }
+
+      if (path !== undefined) {
+        data.name = path
+      }
+
+      if (variant !== undefined) {
+        data.variant = variant
+      }
+
+      return data
+    }
+
+    function addImpression (contentId, path, position, searchQuery, listTitle, variant) {
+      if (contentId || path) {
+        var impressionData = constructData(contentId, path, position, listTitle, searchQuery, variant)
+        ga('ec:addImpression', impressionData);
+      }
     }
 
     function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, variant, trackClickLabel) {
-      row.click(function(event) {
-        var data = {
-          id: contentId || path,
-          position: position,
-          dimension71: searchQuery
-        };
-        if(variant !== undefined) {
-          data.variant = variant;
+      row.click(function() {
+        if (contentId || path) {
+          var clickData = constructData(contentId, path, position, listTitle, searchQuery, variant)
+          ga('ec:addProduct', clickData);
         }
-        ga('ec:addProduct', data);
 
         ga('ec:setAction', 'click', {list: listTitle});
         GOVUK.analytics.trackEvent('UX', 'click',

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -10,6 +10,20 @@ describe('Ecommerce reporter for results pages', function() {
     spyOn(window, 'ga')
   });
 
+  it('requires content id or path', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
+        <div \
+          data-ecommerce-row\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).not.toHaveBeenCalled()
+  })
+
   it('tracks ecommerce rows', function() {
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query">\
@@ -25,6 +39,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query'
@@ -46,6 +61,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query',
@@ -77,40 +93,21 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'First list',
       dimension71: 'search query'
     });
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-2222',
+      name: "/path/to/blah",
       position: 1,
       list: 'Second list',
       dimension71: 'blah'
     });
   })
 
-  it('falls back to the path if the content id is not set', function() {
-    element = $('\
-      <div data-ecommerce-start-index="1" data-search-query="search query">\
-        <div \
-          data-ecommerce-row\
-          data-ecommerce-path="/path/to/page"\
-          data-ecommerce-content-id=""\
-        </div>\
-      </div>\
-    ');
-
-    ecommerce.init(element);
-
-    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
-      id: '/path/to/page',
-      position: 1,
-      list: 'Site search results',
-      dimension71: 'search query'
-    });
-  });
-
-  it('falls back to the path if the content id is not present', function() {
+  it('does not send id if content id is not present', function() {
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query">\
         <div \
@@ -123,7 +120,7 @@ describe('Ecommerce reporter for results pages', function() {
     ecommerce.init(element);
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
-      id: '/path/to/page',
+      name: '/path/to/page',
       position: 1,
       list: 'Site search results',
       dimension71: 'search query'
@@ -145,6 +142,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 21,
       list: 'Site search results',
       dimension71: 'search query'
@@ -168,6 +166,7 @@ describe('Ecommerce reporter for results pages', function() {
     expect(ga).toHaveBeenCalledWith('ec:setAction', 'click', {list: 'Non-default title'})
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Non-default title',
       dimension71: 'search query'
@@ -194,12 +193,14 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query'
     });
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'BBBB-2222',
+      name: "/a/different/page",
       position: 2,
       list: 'Site search results',
       dimension71: 'search query'
@@ -221,6 +222,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query with an [email] in it'
@@ -244,6 +246,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query with a [postcode] in it'
@@ -269,6 +272,7 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addImpression', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
       position: 1,
       list: 'Site search results',
       dimension71: 'search query with a sw1a 1aa in it'
@@ -291,6 +295,8 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addProduct', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
+      list: "Site search results",
       position: 1,
       dimension71: 'search query'
     });
@@ -336,6 +342,8 @@ describe('Ecommerce reporter for results pages', function() {
 
     expect(ga).toHaveBeenCalledWith('ec:addProduct', {
       id: 'AAAA-1111',
+      name: "/path/to/page",
+      list: "Site search results",
       position: 1,
       dimension71: 'search query',
       variant: 'variant-x'


### PR DESCRIPTION
Trello: https://trello.com/c/2iCWKnNV/274-adjust-existing-ecommerce-tracking-logic-to-handle-passing-page-path-as-name

## What
Adds a `name` parameter which can send a page path to GA, instead of `id`.

The current ecommerce tracking logic supports passing in a page content-id or page path as the `id` param. This was originally implemented to stop the payload sent to GA from being too large. However, it makes the GA dashboard take a lot longer to create because they need to do separate lookups against each content id. It would be simpler to just be able to send the page path directly.

## Why
To make reporting quicker to load for performance analysts
So we can support ecommerce tracking on the Brexit checker results page

**Note: this is a backwards compatible change. Once this is deployed, existing ecommerce tracking set up with content-id and path will send both `id` and `name` (see below). We will update the frontend apps once this has gone live so they only send `name`, as `id` is no longer needed.**

## Before and After
### Search
`ga("ec:addImpression", {id: "fa748fae-3de4-4266-ae85-0797ada3f40c", position: 1, list: "Search", dimension71: "tax", variant: "Relevance"})`

`ga("ec:addImpression", {position: 1, list: "Search", dimension71: "tax", id: "fa748fae-3de4-4266-ae85-0797ada3f40c", name: "/vehicle-tax", variant: "Relevance"})`

<hr>

`ga("ec:addProduct", {id: "fa748fae-3de4-4266-ae85-0797ada3f40c", position: 1, dimension71: "tax", variant: "Relevance"})`

`ga("ec:addProduct", {position: 1, list: "Search", dimension71: "tax", id: "fa748fae-3de4-4266-ae85-0797ada3f40c", name: "/vehicle-tax", variant: "Relevance"})`

<hr>

### Landing Page
`ga("ec:addImpression", {id: "58d093a1-787d-4f36-a568-86da23a7b884", position: 1, list: "Brexit landing page: Browse Brexit guidance", dimension71: ""})`

`ga("ec:addImpression", {position: 1, list: "Brexit landing page: Browse Brexit guidance", dimension71: "", id: "58d093a1-787d-4f36-a568-86da23a7b884", name: "/get-ready-brexit-check"})`

<hr>

`ga("ec:addProduct", {id: "58d093a1-787d-4f36-a568-86da23a7b884", position: 1, dimension71: ""})`

`ga("ec:addProduct", {position: 1, list: "Brexit landing page: Browse Brexit guidance", dimension71: "", id: "58d093a1-787d-4f36-a568-86da23a7b884", name: "/get-ready-brexit-check"})`
