### PR TITLE
Add linked domain

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -109,6 +109,7 @@
       'manage-water-abstraction-impoundment-licence.service.gov.uk',
       'match.redundancy-payments.service.gov.uk',
       'mot-testing.service.gov.uk',
+      'nominate-uk-honour.service.gov.uk',
       'notice.redundancy-payments.service.gov.uk',
       'passport.service.gov.uk',
       'paydvlafine.service.gov.uk',


### PR DESCRIPTION
Missed one from yesterday.

Adding some more service domains to the cross domain linking configuration, now that they've turned on cross domain tracking.

See https://github.com/alphagov/static/blob/master/doc/analytics.md#adding-more-domains-to-govuks-cross-domain-linker

