### PR TITLE
Allow pageview function to be passed a tracker name

### DIFF
--- a/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
+++ b/app/assets/javascripts/analytics_toolkit/google-analytics-universal-tracker.js
@@ -55,6 +55,7 @@
   // https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
   GoogleAnalyticsUniversalTracker.prototype.trackPageview = function (path, title, options) {
     var pageviewObject
+    var trackerName = ''
 
     if (typeof path === 'string') {
       pageviewObject = { page: path }
@@ -69,12 +70,19 @@
     // https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#transport
     if (typeof options === 'object') {
       pageviewObject = $.extend(pageviewObject || {}, options)
+
+      // trackerName is optional
+      if (typeof options.trackerName === 'string') {
+        trackerName = options.trackerName + '.'
+        delete options.trackerName
+      }
     }
 
+
     if (!$.isEmptyObject(pageviewObject)) {
-      sendToGa('send', 'pageview', pageviewObject)
+      sendToGa(trackerName + 'send', 'pageview', pageviewObject)
     } else {
-      sendToGa('send', 'pageview')
+      sendToGa(trackerName + 'send', 'pageview')
     }
   }
 

--- a/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
+++ b/spec/javascripts/analytics_toolkit/google-analytics-universal-tracker.spec.js
@@ -92,6 +92,11 @@ describe('GOVUK.GoogleAnalyticsUniversalTracker', function () {
       universal.trackPageview('/t', 'T', {transport: 'beacon'})
       expect(window.ga.calls.mostRecent().args).toEqual(['send', 'pageview', {page: '/t', title: 'T', transport: 'beacon'}])
     })
+
+    it('can send a pageview to a named tracker', function () {
+      universal.trackPageview('/path', 'title', { 'trackerName' : 'another_tracker' })
+      expect(window.ga.calls.mostRecent().args).toEqual(['another_tracker.send', 'pageview', { 'page': '/path', 'title': 'title', 'trackerName': 'another_tracker'}])
+    })
   })
 
   describe('when events are tracked', function () {


### PR DESCRIPTION
## What

- extends trackPageView function to accept a trackerName parameter in the options object, allowing pageviews to be sent to a tracker other than our default GA property
- this functionality was already in the trackEvent function following it, basically copying it from there
- defaults to no tracker name, so will not effect existing calls

## Why

We want to get all pageviews into the shared GA property, which will include those sent when pages are updated dynamically, for example in search, when users choose different search filters and the page and URL are updated without a page reload. This will allow us to call the trackPageView function and pass it the name of the tracker to use.

Trello card: https://trello.com/c/FYntaHmw/92-send-virtual-pageviews-for-ajax-page-updates-on-search-finders-and-mainstream-browse
