### PR TITLE
Remove close date logic from banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,15 +1,12 @@
 <%
-  require 'date'
-
   show_global_bar ||= false # Toggles the appearance of the global bar
   title = "Register to vote"
   title_href = "/register-to-vote"
   link_text = "Register by 26 November to vote in the General Election on 12 December."
   link_href = false
-  close_date = false # DateTime after which the bar will automatically disappear, or false to unset
 -%>
 
-<% if show_global_bar && (!close_date || DateTime.now() < close_date) %>
+<% if show_global_bar %>
   <% content_for :head do %>
     <!--[if gt IE 7]><!-->
     <script>


### PR DESCRIPTION
We previously added logic in https://github.com/alphagov/static/pull/1934 to automatically take down the banner at a specified close date.
However, this didn't work as expected due to templates being cached when they are requested by Slimmer. Bypassing this caching would be more challenging and as there isn't an immediate use case for this work (we can manually remove the banner instead) we're going to remove this logic for now.

If this feature is requested in the future, we now know that this is more difficult to implement than we first thought and can scope accordingly.