### PR TITLE
Add ability to make global banner permanent

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -10,6 +10,7 @@
   Modules.GlobalBar = function() {
     this.start = function($el) {
       var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen";
+      var always_on = $el.data("global-bar-permanent");
 
       // If the cookie is not set, let's set a basic one
       if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || JSON.parse(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["count"] === undefined) {
@@ -25,7 +26,9 @@
 
 
       if ($el.is(':visible')) {
-        incrementViewCount(count);
+        if (!always_on) {
+          incrementViewCount(count);
+        }
         track('Viewed');
       }
 

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -4,6 +4,11 @@
   title_href = "/register-to-vote"
   link_text = "Register by 26 November to vote in the General Election on 12 December."
   link_href = false
+
+  # Toggles banner being permanently visible
+  # If true, banner is always_visible & does not disappear automatically after 3 pageviews
+  # Regardless of value, banner is always manually dismissable by users
+  always_visible = false
 -%>
 
 <% if show_global_bar %>
@@ -19,7 +24,7 @@
     <!--<![endif]-->
   <% end %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="global-bar dont-print" data-module="global-bar">
+  <div id="global-bar" class="global-bar dont-print" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %>>
     <div class="global-bar-message-container">
     <p class="global-bar-message">
       <% if title %>


### PR DESCRIPTION
The default behaviour of the banner is to show for 3 pageviews, and then automatically hide. It can also be manually dismissed by the user.

We want the ability to have the banner be permanent, i.e: it will always show, regardless of the number of pageviews. This won't affect the user's ability to manually dismiss the banner.

How it works: if `always_on` is set to `true`, the view count for the global bar cookie is never updated which means the banner won't automatically hide as the count will never reach 3. 