### PR TITLE
Update footer partial to not use frontend_toolkit

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -1,3 +1,8 @@
+$govuk-compatibility-govuktemplate: true;
+@import "govuk/settings/all";
+@import "govuk/tools/all";
+@import "govuk/helpers/all";
+
 /* govuk_frontend_toolkit includes */
 @import "colours";
 @import "conditionals";

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -2,7 +2,8 @@
 
 #footer {
   // Replaces the 1px #a1acb2 border from govuk_template
-  border-top: 10px solid $mainstream-brand;
+  // this is now the lighter blue shade
+  border-top: 10px solid $govuk-brand-colour;
 
   a:focus {
     outline: 3px solid transparent;
@@ -19,17 +20,17 @@
   }
 
   .footer-categories {
-    @extend %contain-floats;
-    @extend %grid-row;
+    @include govuk-clearfix;
+    margin: 0 -($govuk-gutter-half);
 
-    @include media(tablet) {
-      padding-bottom: $gutter;
+    @include govuk-media-query($from: tablet) {
+      padding-bottom: $govuk-gutter;
     }
 
 
     .footer-explore,
     .footer-inside-government {
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         float: left;
         width: 66.66%;
         padding-bottom: 60px;
@@ -39,9 +40,9 @@
         margin: 0 15px;
         padding: 10px 0 0;
 
-        @include media(tablet) {
+        @include govuk-media-query($from: tablet) {
           padding: 0 0 20px;
-          border-bottom: 1px solid $border-colour;
+          border-bottom: 1px solid $govuk-border-colour;
         }
       }
     }
@@ -49,21 +50,21 @@
     hr {
       clear: both;
       margin: 0 15px 30px;
-      border: 1px solid $border-colour;
+      border: 1px solid $govuk-border-colour;
       border-width: 1px 0 0 0;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         margin-bottom: 0;
       }
     }
 
     ul {
-      @include core-16;
+      @include govuk-font(16);
       list-style: none;
       padding: 0;
       margin: 0;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         float: left;
         margin: 15px 0 0 0;
         width: 50%;
@@ -77,7 +78,7 @@
         padding: 10px 0 0;
         margin: 0 15px 5px;
 
-        @include media(tablet) {
+        @include govuk-media-query($from: tablet) {
           padding: 20px 0 0;
           margin: 0 15px;
         }
@@ -85,7 +86,7 @@
     }
 
     .footer-inside-government {
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         float: left;
         width: 33.33%;
 


### PR DESCRIPTION
Part of https://trello.com/c/fxfRx7dQ/95-remove-govukfrontendtoolkit-from-static
This PR
- imports govuk_publishing_component Sass files into header_footer
- replaces toolkit variables and mixins with publishing components
