### PR TITLE
Stop setting GA if consent is null

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -15,3 +15,5 @@
 //= require analytics/ecommerce
 //= require analytics/init
 //= require analytics/scroll-tracker
+
+window.GOVUK.analyticsInit()

--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -1,4 +1,4 @@
-(function() {
+var analyticsInit = function() {
   "use strict";
 
   var consentCookie = window.GOVUK.getConsentCookie();
@@ -162,4 +162,6 @@
   } else {
     GOVUK.analytics = dummyAnalytics
   }
-})();
+}
+
+window.GOVUK.analyticsInit = analyticsInit

--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -16,7 +16,7 @@
   // This will be reversed below, if the consent cookie says usage cookies are allowed
   window['ga-disable-UA-26179049-1'] = true;
 
-  if (!consentCookie || consentCookie["usage"]) {
+  if (consentCookie && consentCookie["usage"]) {
     window['ga-disable-UA-26179049-1'] = false;
 
     // Load Google Analytics libraries

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -5,9 +5,19 @@ describe('Ecommerce reporter for results pages', function() {
       element;
 
   beforeEach(function() {
+    window.GOVUK.setConsentCookie({
+      'essential': true,
+      'settings': false,
+      'usage': true,
+      'campaigns': false
+    })
+
+    window.GOVUK.analyticsInit()
+
     ecommerce = new GOVUK.Ecommerce();
     GOVUK.analytics.gaClientId = '12345.67890'
     spyOn(window, 'ga')
+
   });
 
   it('requires content id or path', function() {


### PR DESCRIPTION
## What
Don't load in GA script if consent cookie is null

## Why
We previously assumed that if the consent cookie was null, we could load in the GA script. We can't do this now we've changed to opt-in.

**Note: tested on integration. GA cookies are no longer being set on page load, unless consent has been given.**