### PR TITLE
Remove crossorigin and SRI from our static assets (CSS/JS)

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -6,12 +6,12 @@
     <meta charset="utf-8" />
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
-    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+    <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: false %><!--<![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "govuk-template-ie8.css" %><![endif]-->
-    <%= stylesheet_link_tag "govuk-template-print.css", media: "print", integrity: true, crossorigin: "anonymous" %>
+    <%= stylesheet_link_tag "govuk-template-print.css", media: "print", integrity: false %>
 
-    <%= stylesheet_link_tag "fonts.css", media: "all", integrity: true, crossorigin: "anonymous" %>
-    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: true, crossorigin: "anonymous" %><![endif]-->
+    <%= stylesheet_link_tag "fonts.css", media: "all", integrity: false %>
+    <!--[if lt IE 9]><%= javascript_include_tag "ie.js", integrity: false %><![endif]-->
 
     <link rel="shortcut icon" href="<%= asset_path 'favicon.ico' %>" type="image/x-icon" />
     <%# the colour used for mask-icon is the standard palette $black from

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -13,7 +13,7 @@
 
 <% if show_global_bar %>
   <% content_for :head do %>
-    <%= javascript_include_tag 'global-bar-init', integrity: true, crossorigin: 'anonymous' %>
+    <%= javascript_include_tag 'global-bar-init', integrity: false %>
     <script>
       if (GOVUK.globalBarInit) {
         window.GOVUK.globalBarInit.init()

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,6 +1,6 @@
-<%= javascript_include_tag 'libs/jquery/jquery-1.12.4.js', integrity: true, crossorigin: 'anonymous' %>
-<%= javascript_include_tag local_assigns[:js_file] || 'application', integrity: true, crossorigin: 'anonymous' %>
+<%= javascript_include_tag 'libs/jquery/jquery-1.12.4.js', integrity: false %>
+<%= javascript_include_tag local_assigns[:js_file] || 'application', integrity: false %>
 <% if ENV["DRAFT_ENVIRONMENT"].present? %>
-  <%= javascript_include_tag 'modules/base-target', integrity: true, crossorigin: 'anonymous' %>
+  <%= javascript_include_tag 'modules/base-target', integrity: false %>
 <% end %>
-<%= javascript_include_tag 'surveys', integrity: true, crossorigin: 'anonymous' %>
+<%= javascript_include_tag 'surveys', integrity: false %>

--- a/app/views/root/_stylesheet.html.erb
+++ b/app/views/root/_stylesheet.html.erb
@@ -1,7 +1,7 @@
 <%
   css_file = local_assigns[:css_file] || 'static'
 %>
-<!--[if gt IE 8]><!--><%= stylesheet_link_tag css_file, integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
+<!--[if gt IE 8]><!--><%= stylesheet_link_tag css_file, integrity: false %><!--<![endif]-->
 <!--[if IE 8]><%= stylesheet_link_tag "#{css_file}-ie8" %><script>var ieVersion = 8;</script><![endif]-->
 
-<%= stylesheet_link_tag "#{css_file}-print", media: "print", integrity: true, crossorigin: "anonymous" %>
+<%= stylesheet_link_tag "#{css_file}-print", media: "print", integrity: false %>

--- a/app/views/root/print.html.erb
+++ b/app/views/root/print.html.erb
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta name="robots" content="noindex, nofollow">
 
-  <%= stylesheet_link_tag 'guides-print', media: 'all', integrity: true, crossorigin: 'anonymous' %>
+  <%= stylesheet_link_tag 'guides-print', media: 'all', integrity: false %>
   <script type="text/javascript">
     window.onload = function() { window.print(); }
   </script>


### PR DESCRIPTION
Change to remove SRI on the JavaScript / CSS and remove the `crossorigin` attribute.

This change is part of [RFC-115](https://github.com/alphagov/govuk-rfcs/pull/115).

Changes have been tested on integration, [seen here](https://github.com/alphagov/static/pull/1993#issuecomment-580287175)