### PR TITLE
Remove IE6/7 specific styles from static

### DIFF
--- a/app/assets/stylesheets/core-layout-ie6.scss
+++ b/app/assets/stylesheets/core-layout-ie6.scss
@@ -1,5 +1,0 @@
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "core-layout";

--- a/app/assets/stylesheets/core-layout-ie7.scss
+++ b/app/assets/stylesheets/core-layout-ie7.scss
@@ -1,4 +1,0 @@
-$is-ie: true;
-$ie-version: 7;
-
-@import "core-layout";

--- a/app/assets/stylesheets/header-footer-only-ie6.scss
+++ b/app/assets/stylesheets/header-footer-only-ie6.scss
@@ -1,5 +1,0 @@
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "header-footer-only";

--- a/app/assets/stylesheets/header-footer-only-ie7.scss
+++ b/app/assets/stylesheets/header-footer-only-ie7.scss
@@ -1,4 +1,0 @@
-$is-ie: true;
-$ie-version: 7;
-
-@import "header-footer-only";

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -31,11 +31,6 @@
   @include bold-24($line-height: (16 / 24));
   padding: 0.45em 0.5em 0.45em 0.5em;
   display: inline-block;
-
-  /* IE6 adds its own side padding so requires no extra */
-  @include ie(6) {
-    padding: 0.45em 0.5em 0.62em 0.5em;
-  }
 }
 
 .transaction .get-started .button,
@@ -51,26 +46,9 @@
     background-position: 110% 50%;
   }
 
-  @include ie(7) {
-    padding: 0.45em 1.7em 0.62em 0.67em;
-  }
-
-  @include ie(6) {
-    background-image: image-url('icon-pointer-indexed.png');
-  }
-
   @include device-pixel-ratio() {
     background-image: image-url("icon-pointer-2x.png");
     background-size: 30px 19px;
-  }
-}
-
-/* IE6 adds its own side padding so requires no extra */
-@include ie(6) {
-  .transaction .get-started input.button,
-  .local_transaction .get-started input.button,
-  .licence .get-started input.button {
-    padding: 0.45em 0.5em 0.62em 0em;
   }
 }
 
@@ -100,10 +78,6 @@ input{
     min-width: 8em;
     margin: 0 0.5em;
     padding: 0.25em;
-
-    @include ie-lte(7) {
-      width:8em;
-    }
   }
 
   /* below fixes a bug where IE puts a nasty black border around these elements */

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -110,20 +110,8 @@ header.page-header div {
   @include core-16;
   color: $secondary-text-colour;
 
-  @include ie-lte(7) {
-    width: 60%;
-  }
-
-  @include ie(6) {
-    zoom: 1;
-  }
-
   p{
     text-align: left;
-
-    @include ie-lte(7) {
-      zoom: 1;
-    }
 
     a{
       color: $secondary-text-colour;

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -180,10 +180,6 @@
     @include core-19;
     margin: 0 auto;
     max-width: 960px;
-
-    @include ie-lte(6) {
-      width: 960px;
-    }
   }
 
   @include media-down(mobile) {
@@ -198,10 +194,6 @@
     position: relative;
     padding-right: 20px;
     max-width: 940px;
-
-    @include ie(6) {
-      width: 940px;
-    }
   }
 
   .dismiss {

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -96,9 +96,6 @@
       @include ie-lte(8) {
         min-height: 24px;
       }
-      @include ie-lte(6) {
-        height: 24px;
-      }
       @include appearance(none);
     }
 
@@ -115,9 +112,6 @@
         outline-offset: -3px;
       }
 
-      @include ie-lte(7){
-        padding-left: 0;
-      }
       .js-enabled & {
         width: 86%;
         @include calc(width, "100% - 35.1px"); /* 35.1 is for Safari, which renders this input too narrow */
@@ -134,9 +128,6 @@
 
       border: 1px solid $mainstream-brand;
       border-width: 0 0 0 1px;
-      @include ie-lte(7){
-        border-width: 1px;
-      }
       border-left-color: #222;
       @include border-radius(0);
 
@@ -152,11 +143,6 @@
       @include device-pixel-ratio() {
         background-size: 52.5px 35px;
         background-position: 100% 50%;
-      }
-
-      @include ie-lte(7) {
-        background-image: none;
-        width: auto;
       }
 
       &:hover {

--- a/app/assets/stylesheets/helpers/_multi-step.scss
+++ b/app/assets/stylesheets/helpers/_multi-step.scss
@@ -67,11 +67,11 @@
       @include core-16;
     }
 
-  &.done {
-    background: #D5ECEA;
-    border-bottom: solid 1px #b6d6d2;
-    overflow: hidden;
-    padding-right: 9.5em;
+    &.done {
+      background: #D5ECEA;
+      border-bottom: solid 1px #b6d6d2;
+      overflow: hidden;
+      padding-right: 9.5em;
 
       .answer {
         @include bold-16;
@@ -92,18 +92,11 @@
           }
         }
       }
-
-      @include ie-lte(8) {
-        list-style: none;
-        position: relative;
-        overflow: hidden;
-      }
     }
   }
 }
 
 .upcoming-questions ol {
-
   li {
     background-color: #f0e7d7;
     border-bottom: solid 1px #dac39c;
@@ -120,15 +113,6 @@ li.done .undo {
   right: (1.5em/0.9);
   margin: 0;
   @include core-14;
-
-  @include ie-lte(8) {
-    margin: 0;
-  }
-
-  @include ie-lte(6) {
-    position: absolute;
-    right: 1em;
-  }
 
   a {
     color: $text-colour;
@@ -157,16 +141,6 @@ li.done:hover .undo a {
   }
 }
 
-@include ie(6) {
-  .smart-answer-questions .current {
-    background-color: #fff;
-    margin-right: 15em;
-    padding: 0 2em 1em 5em;
-    position: relative;
-    zoom: 1;
-  }
-}
-
 .question-body + p input.button {
   margin-top: 0.5em;
 }
@@ -184,10 +158,6 @@ li.done:hover .undo a {
     .question-number {
       padding-right: 0.25em;
       font-weight: 400;
-    }
-
-    @include ie-lte(8) {
-      line-height: 1.2em;
     }
   }
 

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -206,10 +206,6 @@ aside .page-navigation {
       color: $link-colour;
       text-decoration: none;
 
-      @include ie-lte(7) {
-        height: 4.5em;
-      }
-
       &:hover,
       &:active {
         background-color: $canvas-colour;
@@ -281,30 +277,16 @@ aside .page-navigation {
   .last {
     min-height: 4.5em;
 
-    @include ie-lte(7) {
-      height: 4.5em;
-    }
-
     span {
       display: block;
       min-height: 4.5em;
       padding: 0.75em 5%;
       width: 90%;
-
-      @include ie-lte(7) {
-        height: 4.5em;
-      }
     }
 
     .pagination-label {
       display: block;
       margin-bottom: 0.5em;
-    }
-  }
-
-  @include ie(6) {
-    .first {
-      text-align: left;
     }
   }
 }

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -19,10 +19,6 @@
     @include media(tablet) {
       margin: 0 0 2.5em;
     }
-
-    @include ie(6) {
-      zoom: 1;
-    }
   }
 }
 

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -59,10 +59,6 @@ aside .page-navigation {
     overflow: hidden;
     width:50%;
 
-    @include ie-lte(7) {
-      width: 49%;
-    }
-
     @include media-down(mobile) {
       float: none;
       display: block;
@@ -79,12 +75,6 @@ aside .page-navigation {
 
     @include core-16;
 
-    @include ie-lte(7) {
-      list-style: none;
-      margin-left: 0;
-      display: list-item;
-    }
-
     @include media-down(mobile) {
       float: none;
       margin: 0 1em 0 2.25em;
@@ -93,11 +83,6 @@ aside .page-navigation {
     a {
       display: block;
       padding: 0.25em 1em 0.25em 0;
-
-      @include ie-lte(7) {
-        display: inline;
-        float: left;
-      }
 
       span {
         cursor: pointer;
@@ -112,18 +97,9 @@ aside .page-navigation {
     }
 
     span {
-      @include ie-lte(7) {
-        float: left;
-      }
-
       &.part-number {
         display: none;
         width: 1.75em;
-
-        @include ie-lte(7) {
-          display: inline;
-          padding: 0.25em 0;
-        }
       }
 
       &.part-label,

--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -25,7 +25,6 @@ article {
     span {
       @include core-16;
       display: block;
-      // display: none;
       margin-bottom: 0.4em;
     }
   }
@@ -246,10 +245,6 @@ article {
 
   .summary h2 {
     line-height: 1.35em;
-
-    @include ie(6) {
-      height: 2.75em;
-    }
   }
   .licence-finder &.outcome ul {
     padding: 1em 1em;
@@ -279,10 +274,6 @@ article {
       margin: 0 0.75em 0 0;
       min-height: 1.75em;
       padding-right: 3em;
-
-      @include ie-lte(7) {
-        height: 1.75em;
-      }
     }
 
     strong {
@@ -495,12 +486,6 @@ article {
       @include core-16;
       display: inline-block;
       margin-right: 1em;
-
-      @include ie-lte(7) {
-        display: inline;
-        padding-right: 1em;
-        margin-right: 0;
-      }
     }
   }
 

--- a/app/assets/stylesheets/static-ie6.scss
+++ b/app/assets/stylesheets/static-ie6.scss
@@ -1,7 +1,0 @@
-// BASE STYLESHEET FOR IE 6 COMPILER
-
-$is-ie: true;
-$ie-version: 6;
-$mobile-ie6: false;
-
-@import "static";

--- a/app/assets/stylesheets/static-ie7.scss
+++ b/app/assets/stylesheets/static-ie7.scss
@@ -1,6 +1,0 @@
-// BASE STYLESHEET FOR IE 7 COMPILER
-
-$is-ie: true;
-$ie-version: 7;
-
-@import "static";

--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -7,8 +7,6 @@
     <title><%= content_for?(:page_title) ? yield(:page_title) : "GOV.UK - The best place to find government services and information" %></title>
 
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag "govuk-template.css", integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
-    <!--[if IE 6]><%= stylesheet_link_tag "govuk-template-ie6.css" %><![endif]-->
-    <!--[if IE 7]><%= stylesheet_link_tag "govuk-template-ie7.css" %><![endif]-->
     <!--[if IE 8]><%= stylesheet_link_tag "govuk-template-ie8.css" %><![endif]-->
     <%= stylesheet_link_tag "govuk-template-print.css", media: "print", integrity: true, crossorigin: "anonymous" %>
 

--- a/app/views/root/_stylesheet.html.erb
+++ b/app/views/root/_stylesheet.html.erb
@@ -2,8 +2,6 @@
   css_file = local_assigns[:css_file] || 'static'
 %>
 <!--[if gt IE 8]><!--><%= stylesheet_link_tag css_file, integrity: true, crossorigin: "anonymous" %><!--<![endif]-->
-<!--[if IE 6]><%= stylesheet_link_tag "#{css_file}-ie6" %><script>var ieVersion = 6;</script><![endif]-->
-<!--[if IE 7]><%= stylesheet_link_tag "#{css_file}-ie7" %><script>var ieVersion = 7;</script><![endif]-->
 <!--[if IE 8]><%= stylesheet_link_tag "#{css_file}-ie8" %><script>var ieVersion = 8;</script><![endif]-->
 
 <%= stylesheet_link_tag "#{css_file}-print", media: "print", integrity: true, crossorigin: "anonymous" %>


### PR DESCRIPTION
## What / why

Removing the IE6 and IE7 specific stylesheets from static because we no longer support these browsers and this will speed up the compile time fractionally, which will be useful for future work.

Will address IE8 in a future PR - it feels like supporting that might be more controversial, so I'm trying to make this PR simple. I've left several 'less than or equal to IE8' statements in place.

## Changes

I don't know where these styles are used so the way I've done this is to reproduce the markup for the elements that will change temporarily (in frontend's homepage) and taken screenshots to show the changes. My aim is to document these changes and ensure that nothing causes a dramatically bad thing to happen - we don't have to support these browsers, but we can still be kind.

The search box at the start of some of the screenshots is only included for a left margin reference point.

---

### Removing IE6/7 specific styles for buttons and inputs

**IE6 before**

![ie6-before](https://user-images.githubusercontent.com/861310/72718743-6f6bd280-3b6e-11ea-9c78-a855cf4e6ecc.png)

**IE6 after**

![ie6-after](https://user-images.githubusercontent.com/861310/72718754-72ff5980-3b6e-11ea-9ee3-b1194e0fdde8.png)


**IE7 before**

![ie7-before](https://user-images.githubusercontent.com/861310/72718759-772b7700-3b6e-11ea-9c4c-d0df25195523.png)

**IE7 after**

![ie7-after](https://user-images.githubusercontent.com/861310/72718769-7a266780-3b6e-11ea-9384-2b57ad275c1e.png)

---

### Removing IE6/7 specific styles for `.meta-data`

Removing the IE specific styles for this seems to introduce a little extra spacing above the element, although a grep through the codebase finds no reference to this classname anywhere, so I'm not sure it's even in use.

**IE6 before**

![Screenshot 2020-01-20 at 16 20 23](https://user-images.githubusercontent.com/861310/72742209-2719d800-3ba1-11ea-88ad-673347789071.png)

**IE6 after**

![Screenshot 2020-01-20 at 16 21 16](https://user-images.githubusercontent.com/861310/72742230-30a34000-3ba1-11ea-9724-b798a113430c.png)

**IE7 before**

![Screenshot 2020-01-20 at 16 20 42](https://user-images.githubusercontent.com/861310/72742243-39941180-3ba1-11ea-90e1-dcfc45593f44.png)

**IE7 after**

![Screenshot 2020-01-20 at 16 21 36](https://user-images.githubusercontent.com/861310/72742255-3f89f280-3ba1-11ea-9d24-add9ee6bf837.png)

---

### Removing IE6/7 specific styles for the site header

Breaks the search button a little bit, but the intent of the control can still be determined from the 'Search' text in the input. Also at some point this will all be replaced by `govuk-frontend`.

**IE6 before**

![Screenshot 2020-01-20 at 16 28 52](https://user-images.githubusercontent.com/861310/72742919-9643fc00-3ba2-11ea-81b6-dbc56d3b3ca7.png)

**IE6 after**

![Screenshot 2020-01-20 at 16 36 39](https://user-images.githubusercontent.com/861310/72743199-1f5b3300-3ba3-11ea-8b85-958d41c787b9.png)

**IE7 before**

![Screenshot 2020-01-20 at 16 32 47](https://user-images.githubusercontent.com/861310/72742993-b2479d80-3ba2-11ea-975e-1c1aab35a7c7.png)

**IE7 after**

![Screenshot 2020-01-20 at 16 37 06](https://user-images.githubusercontent.com/861310/72743211-24b87d80-3ba3-11ea-8f73-40a1a136ab8a.png)

---

### Removing IE6/7 specific styles for the browser warning

This is obviously meant for these browsers so should look reasonable however I don't remember ever seeing this so is it possible it isn't working properly? (maybe something to look into separately). Have simulated the markup based on the JS - it's normally along the top of the page (I assume the broken 'x' layout is to do with it being simulated).

**IE6 before**

<img width="1414" alt="Screenshot 2020-01-20 at 17 23 15" src="https://user-images.githubusercontent.com/861310/72746427-fee2a700-3ba9-11ea-9ab9-50690ed842c9.png">

**IE6 after**

Loses the nice alignment with the rest of the page, but it's still usable.

<img width="1421" alt="Screenshot 2020-01-20 at 17 32 26" src="https://user-images.githubusercontent.com/861310/72746874-25551200-3bab-11ea-8086-fb4d640d1cd4.png">

**IE7 before**

<img width="1413" alt="Screenshot 2020-01-20 at 17 25 01" src="https://user-images.githubusercontent.com/861310/72746454-0dc95980-3baa-11ea-9c0b-7ee57049bcaf.png">

**IE7 after**

IE7 supports `max-width` anyway.

<img width="1415" alt="Screenshot 2020-01-20 at 17 33 51" src="https://user-images.githubusercontent.com/861310/72746876-25eda880-3bab-11ea-9486-686cec56dd27.png">

---

### Removing IE6/7 specific styles for simple smart answers

https://www.gov.uk/settle-in-the-uk/y/you-re-an-eu-citizen

Now that smart answers has been migrated to components we should do the same with simple smart answers, then this whole stylesheet could potentially be removed.

IE8 screenshots included because some of the media queries removed are `less than or equal to ie8`.

**IE6 before**

Pretty broken already - the radios overlap the labels.

<img width="644" alt="Screenshot 2020-01-21 at 12 52 46" src="https://user-images.githubusercontent.com/861310/72806402-073fee00-3c4d-11ea-8637-35c4e8f8e147.png">

**IE6 after**

Tiny change to the position of the 'change this answer' text.

<img width="617" alt="Screenshot 2020-01-21 at 12 53 05" src="https://user-images.githubusercontent.com/861310/72806415-0d35cf00-3c4d-11ea-8fb4-5db223e0cfe7.png">

**IE7 before**

<img width="616" alt="Screenshot 2020-01-21 at 12 55 42" src="https://user-images.githubusercontent.com/861310/72806615-71f12980-3c4d-11ea-8259-9505fb1d3822.png">

**IE7 after**

No obvious change.

<img width="616" alt="Screenshot 2020-01-21 at 12 56 16" src="https://user-images.githubusercontent.com/861310/72806633-787fa100-3c4d-11ea-963a-4d50111782c5.png">

**IE8 before**

<img width="671" alt="Screenshot 2020-01-21 at 12 57 32" src="https://user-images.githubusercontent.com/861310/72806752-bbda0f80-3c4d-11ea-9a8e-c8a15c296195.png">

**IE8 after**

No obvious change.

<img width="656" alt="Screenshot 2020-01-21 at 12 58 19" src="https://user-images.githubusercontent.com/861310/72806773-c72d3b00-3c4d-11ea-9ae8-ce8e506bd9a2.png">

---

### Removing IE6/7 specific styles for multi-page

Looking through our code the only application I can find where an element has an class/id of `#content.multi-page` is in frontend, in [getting a riding licence](https://www.gov.uk/riding-establishment-licence). But there's no aside on the page, and none I can find in a template, so I think this style is unused anyway.

---

### Removing IE6/7 specific styles for page-navigation

Can't find where this is used, as it only applies if `.page-navigation` is inside an `aside`. The only application that uses this class seems to be frontend, which contains no asides.

---

### Removing IE6/7 specific styles for pagination

Also can't find evidence of this being in use, a comment in the sass says 'guides pagination' but government-frontend doesn't use it, and can't see anything else either. Possibly this whole chunk of sass is redundant.

---

### Removing IE6/7 specific styles for content-block

Used in simple smart answers in frontend, plus a whole load of other places. These styles are slightly odd - setting a height on a h2 and a para, and I'm not sure the rest are in use. Leaving 'less than or equal to IE8' styles in place.

