### PR TITLE
Fix layout for government-frontend

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -9,7 +9,7 @@
 
 /* local styleguide includes */
 @import "styleguide/conditionals2";
-@import "helpers/mixins";
+@import "helpers/wrapper";
 
 // basic styles for HTML5 and other elements
 @import "helpers/draft";

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -7,10 +7,6 @@ body {
   }
 }
 
-#wrapper {
-  @extend %site-width-container;
-}
-
 p {
   @include core-19;
 }

--- a/app/assets/stylesheets/helpers/_wrapper.scss
+++ b/app/assets/stylesheets/helpers/_wrapper.scss
@@ -1,0 +1,5 @@
+@import "helpers/mixins";
+
+#wrapper {
+  @extend %site-width-container;
+}


### PR DESCRIPTION
- the #wrapper styling was recently restructured, but government-frontend had a problem with it
- looks like all apps pull in static's static.css, but gf pulls in core-layout, which is a bit different and thanks to the recent changes no longer included the #wrapper styling
- this all needs to be fixed and replaced properly at some point in every app, by using govuk-site-container (or whatever it is) in place of styling an ID and nesting everything underneath that 

This PR is a little bit unclear, so here's some more detail.

The two files we're concerned with are `static.scss` and `core-layout.scss`. They both import `header-footer-only` so I've modified that to pull in the new file, `wrapper`, which itself pulls in the mixin for `site-width-container` and creates the `#wrapper` styling using it. This means both government-frontend and the rest of the apps should get the `#wrapper` styling now.