### PR TITLE
Update global banner path blacklist (Transition pages)

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -4,7 +4,7 @@
   window.GOVUK = window.GOVUK || {};
 
   var CONFIG = {
-    '/brexit': [
+    '/transition': [
       ['Percent', 20],
       ['Percent', 40],
       ['Percent', 60],

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -23,7 +23,12 @@ var globalBarInit = {
   },
 
   blacklistedUrl: function() {
-    var paths = ["/register-to-vote", "/done", "/brexit", "/get-ready-brexit-check"]
+    var paths = [
+      "/register-to-vote",
+      "/done",
+      "/transition",
+      "/transition-check"
+    ]
 
     return new RegExp(paths.join("|")).test(window.location.pathname)
   },


### PR DESCRIPTION
Trello: https://trello.com/c/DsPNCfTV/429-update-global-banner-logic-to-stop-it-appearing-on-transition

Stops transition banner showing on:
- /transition
- /transition-check (the newly re-slugged brexit checker)

Also update scroll tracking config to monitor the new /transition path.