### PR TITLE
Handle cookie consent in global bar

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -12,15 +12,18 @@
     this.start = function($el) {
       var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen";
       var always_on = $el.data("global-bar-permanent");
+      var cookieConsent = GOVUK.getConsentCookie().settings;
 
-      // If the cookie is not set, let's set a basic one
-      if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["count"] === undefined) {
-        GOVUK.setCookie("global_bar_seen", JSON.stringify({count: 0, version: 0}), {days: 84});
+      if (cookieConsent) {
+        // If the cookie is not set, let's set a basic one
+        if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))["count"] === undefined) {
+          GOVUK.setCookie("global_bar_seen", JSON.stringify({count: 0, version: 0}), {days: 84});
+        }
+
+        var current_cookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)),
+        current_cookie_version = current_cookie["version"],
+        count = viewCount();
       }
-
-      var current_cookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)),
-      current_cookie_version = current_cookie["version"],
-      count = viewCount();
 
       $el.on('click', '.dismiss', hide);
       $el.on('click', '.js-call-to-action', handleCallToActionClick);
@@ -76,5 +79,4 @@
       }
     };
   };
-
 })(window.GOVUK.Modules);


### PR DESCRIPTION
Trello: https://trello.com/c/eSgqMYLV/438-fix-global-banner-following-cookie-change

## What
Wraps some of the global bar logic in a check for cookie consent.

**Note: this introduces a bit of tech debt in that it assumes in the code that the global_bar_seen cookie is categorised under "settings". Ideally, we'd have a method in the govuk_publishing_components gem that takes a cookie name and returns the category, but that doesn't exist yet and we're under time pressure to fix this bug. I'll make a note to address this soon.**

## Why
The global bar relies on having a `global_bar_seen` cookie set with version and view count. If cookies are not allowed, this cookie isn't present and you get a Javascript error which also prevents things like the "Hide message" button working.

This is something we missed when we deployed the new cookie consent mechanism, probably because the global bar wasn't live on the site at the time. The new cookie consent mechanism means that only essential cookies are set by default when a user first lands on GOV.UK, and therefore the `global_bar_seen` cookie (category: settings) is never available on a user's first visit.
