### PR TITLE
Revert "Bump govuk_publishing_components from 21.21.2 to 21.21.3"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").chomp
 gem "actionpack-page_caching", "1.2.0"
 gem "asset_bom_removal-rails", "~> 1.0.0"
 gem "govuk_app_config", "~> 2.0.2"
-gem "govuk_publishing_components", "~> 21.21.3"
+gem "govuk_publishing_components", "~> 21.21.2"
 gem "nokogiri", "~> 1.10"
 gem "rack_strip_client_ip", "0.0.2"
 gem "rails", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.21.3)
+    govuk_publishing_components (21.21.2)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -162,7 +162,7 @@ GEM
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
-    mimemagic (0.3.4)
+    mimemagic (0.3.3)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
     minitest (5.14.0)
@@ -190,7 +190,7 @@ GEM
     public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
-    rack (2.1.2)
+    rack (2.1.1)
     rack-cache (1.11.0)
       rack (>= 0.4)
     rack-test (1.1.0)
@@ -335,7 +335,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_app_config (~> 2.0.2)
   govuk_frontend_toolkit (~> 9.0.0)
-  govuk_publishing_components (~> 21.21.3)
+  govuk_publishing_components (~> 21.21.2)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.5)


### PR DESCRIPTION
CI fails in production (and only in production) when trying to release #2016, so we're going to revert it and test again – currently investigating the cause.