### PR TITLE
Use getCookieCategory rather than assuming category

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").chomp
 gem "actionpack-page_caching", "1.2.0"
 gem "asset_bom_removal-rails", "~> 1.0.0"
 gem "govuk_app_config", "~> 2.0.2"
-gem "govuk_publishing_components", "~> 21.21.3"
+gem "govuk_publishing_components", "~> 21.22.0"
 gem "nokogiri", "~> 1.10"
 gem "rack_strip_client_ip", "0.0.2"
 gem "rails", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.21.3)
+    govuk_publishing_components (21.22.0)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -335,7 +335,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_app_config (~> 2.0.2)
   govuk_frontend_toolkit (~> 9.0.0)
-  govuk_publishing_components (~> 21.21.3)
+  govuk_publishing_components (~> 21.22.0)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.5)

--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -12,7 +12,8 @@
     this.start = function($el) {
       var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen";
       var always_on = $el.data("global-bar-permanent");
-      var cookieConsent = GOVUK.getConsentCookie().settings;
+      var cookieCategory = GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE);
+      var cookieConsent = GOVUK.getConsentCookie()[cookieCategory]
 
       if (cookieConsent) {
         // If the cookie is not set, let's set a basic one


### PR DESCRIPTION
Trello: https://trello.com/c/3rncf9Pt/439-tech-debt-global-bar-logic-assumes-cookie-category

The global_bar_seen cookie is in the "settings" category. For a quick fix, we previously hardcoded this assumption into Static, which is bad if we decided to change the category in the govuk_publishing_components gem.

We now have a function in the gem where we can provide a cookie name and the category is returned. This commit replaces our hardcoded 'settings' category with that method.