### PR TITLE
Move measurement into static from toolkit

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -4,7 +4,6 @@
 @import "css3";
 @import "device-pixels";
 @import "grid_layout";
-@import "measurements";
 @import "typography";
 @import "design-patterns/buttons";
 

--- a/app/assets/stylesheets/helpers/_core-print.scss
+++ b/app/assets/stylesheets/helpers/_core-print.scss
@@ -62,7 +62,7 @@ article {
 
   .info-notice p,
   .help-notice p {
-    margin-left: $gutter;
+    margin-left: govuk-spacing(6);
     position: relative;
 
     &:before {

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -56,8 +56,8 @@ h4 {
 
 header.page-header div {
   @include media(tablet){
-    margin-top: 30px;
-    margin-bottom: 30px;
+    margin-top: govuk-spacing(6);
+    margin-bottom: govuk-spacing(6);
   }
 
   h1 {
@@ -83,7 +83,7 @@ header.page-header div {
 /* Licence Application */
 
 .relevant-authority {
-  margin: 0 0 20px 84px;
+  margin: 0 0 govuk-spacing(4) 84px;
 
   h2 {
     margin: 0;
@@ -96,7 +96,7 @@ header.page-header div {
   }
   li { list-style: none;
     label {
-      padding-left: 5px;
+      padding-left: govuk-spacing(1);
     }
   }
 }
@@ -178,7 +178,7 @@ header.page-header div {
   right: 0.75em;
 
   @include media-down(mobile) {
-    bottom: 20px;
+    bottom: govuk-spacing(4);
     right: 16px;
   }
 }

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -32,15 +32,15 @@
       @include media(tablet) {
         float: left;
         width: 66.66%;
-        padding-bottom: 60px;
+        padding-bottom: govuk-spacing(9);
       }
 
       h2 {
-        margin: 0 15px;
-        padding: 10px 0 0;
+        margin: 0 govuk-spacing(3);
+        padding: govuk-spacing(2) 0 0;
 
         @include media(tablet) {
-          padding: 0 0 20px;
+          padding: 0 0 govuk-spacing(4);
           border-bottom: 1px solid $border-colour;
         }
       }
@@ -48,7 +48,7 @@
 
     hr {
       clear: both;
-      margin: 0 15px 30px;
+      margin: 0 govuk-spacing(3) govuk-spacing(6);
       border: 1px solid $border-colour;
       border-width: 1px 0 0 0;
 
@@ -65,21 +65,21 @@
 
       @include media(tablet) {
         float: left;
-        margin: 15px 0 0 0;
+        margin: govuk-spacing(3) 0 0 0;
         width: 50%;
       }
 
 
       li {
         display: block;
-        margin-bottom: 5px;
+        margin-bottom: govuk-spacing(1);
 
-        padding: 10px 0 0;
-        margin: 0 15px 5px;
+        padding: govuk-spacing(2) 0 0;
+        margin: 0 govuk-spacing(3) govuk-spacing(1);
 
         @include media(tablet) {
-          padding: 20px 0 0;
-          margin: 0 15px;
+          padding: govuk-spacing(4) 0 0;
+          margin: 0 govuk-spacing(3);
         }
       }
     }

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -23,7 +23,7 @@
     @extend %grid-row;
 
     @include media(tablet) {
-      padding-bottom: $gutter;
+      padding-bottom: govuk-spacing(6);
     }
 
 

--- a/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
+++ b/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
@@ -2,10 +2,10 @@
   background-color: $panel-colour;
   color: $white;
   margin-top: 2px;
-  padding: $gutter-half 0;
+  padding: govuk-spacing(3) 0;
 
   @include media(tablet) {
-    padding: $gutter 0;
+    padding: govuk-spacing(6) 0;
   }
 
   div {
@@ -19,7 +19,7 @@
     .homepage & {
       @include bold-48;
       @include media(tablet) {
-        margin-bottom: $gutter-two-thirds;
+        margin-bottom: govuk-spacing(4);
       }
     }
   }
@@ -28,7 +28,7 @@
     @include core-19;
     color: $white;
     margin-top: 0;
-    margin-bottom: $gutter-two-thirds;
+    margin-bottom: govuk-spacing(4);
 
     @include media(tablet) {
       width: percentage(2/3);
@@ -39,7 +39,7 @@
     }
 
     .homepage & {
-      margin: $gutter-two-thirds 0;
+      margin: govuk-spacing(4) 0;
     }
   }
 

--- a/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
+++ b/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
@@ -60,8 +60,8 @@
   }
 
   .homepage & {
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: govuk-spacing(1);
+    margin-bottom: govuk-spacing(1);
   }
 
   &.notable-death {

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -14,7 +14,7 @@
     }
 
     .content {
-      margin: 0 15px;
+      margin: 0 govuk-spacing(3);
     }
   }
   &.with-proposition {
@@ -32,7 +32,7 @@
       height: 30px;
       width: 36px;
       padding: 0;
-      margin: -32px 15px;
+      margin: -32px govuk-spacing(3);
       overflow: hidden;
       text-indent: -5000px;
       background-color: $govuk-blue;
@@ -68,7 +68,7 @@
       text-indent: 15px;
       overflow: hidden;
       display: block;
-      margin-right: 10px;
+      margin-right: govuk-spacing(2);
 
       .js-enabled & {
         float: none;
@@ -330,7 +330,7 @@ $light-blue: #259EDA;
 .global-bar {
   background-color: #E5EAF1;
   display: none;
-  padding: 15px 0;
+  padding: govuk-spacing(3) 0;
   border-top: 8px solid $light-blue;
 
   .show-global-bar & {
@@ -377,8 +377,8 @@ $light-blue: #259EDA;
     .global-bar-title {
       display: block;
       font-weight: 700;
-      margin-right: 10px;
-      margin-bottom: 5px;
+      margin-right: govuk-spacing(2);
+      margin-bottom: govuk-spacing(1);
     }
   }
 }

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -258,8 +258,8 @@
 
   .survey-wrapper {
     @extend %site-width-container;
-    padding-top: $gutter-half;
-    padding-bottom: $gutter-two-thirds;
+    padding-top: govuk-spacing(3);
+    padding-bottom: govuk-spacing(4);
     clear: both;
   }
 

--- a/app/assets/stylesheets/helpers/_organisations.scss
+++ b/app/assets/stylesheets/helpers/_organisations.scss
@@ -12,12 +12,12 @@
   height: auto;
   width: auto;
   padding-top: 23px;
-  padding-left: 10px;
+  padding-left: govuk-spacing(2);
 
   @include media(tablet) {
     font-size: 19px;
     line-height: (20 / 19);
-    padding-top: 30px;
+    padding-top: govuk-spacing(6);
     background-image: image-url("coa-default-24.gif");
   }
 
@@ -28,7 +28,7 @@
     position: static;
 
     @include media(tablet) {
-      padding: 5px 0 5px 45px;
+      padding: govuk-spacing(1) 0 govuk-spacing(1) 45px;
       background-position: 8px 50%;
     }
   }

--- a/app/assets/stylesheets/helpers/_print-base.scss
+++ b/app/assets/stylesheets/helpers/_print-base.scss
@@ -72,24 +72,24 @@ li {
 }
 
 figure {
-  margin: $gutter-half 0;
+  margin: govuk-spacing(3) 0;
 }
 
 table {
   border-collapse: collapse;
   width: 100%;
-  margin: $gutter-half 0;
+  margin: govuk-spacing(3) 0;
 
   th,
   td {
     border: 1pt solid $border-colour;
-    padding: $gutter-one-third;
+    padding: govuk-spacing(2);
     text-align: left;
   }
 
   caption {
     @include core-19;
-    margin: $gutter-half 0;
+    margin: govuk-spacing(3) 0;
   }
 }
 

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -10,9 +10,9 @@ label.selectable {
 
   background: $panel-colour;
   border: 1px solid $panel-colour;
-  padding: (18px $gutter $gutter-half $gutter*1.5);
-  margin-top: 10px;
-  margin-bottom: 10px;
+  padding: (govuk-spacing(4) govuk-spacing(6) govuk-spacing(3) govuk-spacing(5));
+  margin-top: govuk-spacing(2);
+  margin-bottom: govuk-spacing(2);
 
   cursor: pointer; // Encourage clicking on block labels
 
@@ -30,14 +30,14 @@ label.selectable {
   input {
     position: absolute;
     top: 18px;
-    left: $gutter-half;
+    left: govuk-spacing(3);
     cursor: pointer;
   }
 
   // Use inline, to sit block labels next to each other
   .inline & {
     clear: none;
-    margin-right: $gutter-half;
+    margin-right: govuk-spacing(3);
   }
 
   // Only if JavaScript is enabled

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -18,8 +18,8 @@ label.selectable {
 
   @include media(tablet) {
     float: left;
-    margin-top: 5px;
-    margin-bottom: 5px;
+    margin-top: govuk-spacing(1);
+    margin-bottom: govuk-spacing(1);
   }
 
   &:hover {

--- a/app/assets/stylesheets/settings/_measurements.scss
+++ b/app/assets/stylesheets/settings/_measurements.scss
@@ -1,0 +1,57 @@
+//// Source: https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/settings/_spacing.scss
+////
+/// @group settings/spacing
+////
+
+/// Single point spacing variables. Access using `govuk-spacing()`
+/// (see `helpers/spacing`).
+///
+/// @type Map
+/// @access private
+
+$govuk-spacing-points: (
+  0: 0,
+  1: 5px,
+  2: 10px,
+  3: 15px,
+  4: 20px,
+  5: 25px,
+  6: 30px,
+  7: 40px,
+  8: 50px,
+  9: 60px
+) !default;
+
+//// Source: https://github.com/alphagov/govuk-frontend/blob/master/src/govuk/helpers/_spacing.scss
+////
+/// @group helpers
+////
+
+/// Single point spacing
+///
+/// Returns measurement corresponding to the spacing point requested.
+///
+/// @param {Number} $spacing-point - Point on the spacing scale (set in `settings/_spacing.sccs`)
+///
+/// @returns {String} Spacing Measurement eg. 10px
+///
+/// @example scss
+///   .element {
+///     padding: govuk-spacing(5);
+///     top: govuk-spacing(2) !important; // if `!important` is required
+///   }
+/// @access public
+
+@function govuk-spacing($spacing-point) {
+  $actual-input-type: type-of($spacing-point);
+  @if $actual-input-type != "number" {
+    @error "Expected a number (integer), but got a "
+    + "#{$actual-input-type}.";
+  }
+
+  @if not map-has-key($govuk-spacing-points, $spacing-point) {
+    @error "Unknown spacing variable `#{$spacing-point}`. Make sure you are using a point from the spacing scale in `_settings/spacing.scss`.";
+  }
+
+  @return map-get($govuk-spacing-points, $spacing-point);
+}

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -4,6 +4,9 @@
 @import "shims";
 @import "design-patterns/buttons";
 
+// settings
+@import "settings/measurements";
+
 /* styles */
 @import "helpers/buttons";
 @import "helpers/core";


### PR DESCRIPTION
## What

Moved the spacing function (`govuk-spacing(𝖷)`) into static so it can be used without importing all of the publishing components gem.

Replaced the all of the `$gutter` variables and hardcoded variables that could be directly replaced with a spacing function without impacting the layout. So `30px` and `$gutter` were replaced with `govuk-spacing(6)`, but any magic numbers like`48px` were left alone.

## Why

The Sass functions and variables are useful. But if we import publishing components we'll inflate the amount of CSS in static dramatically - so we need to add just the functions and variables on their own. This is a quick way of doing it until the publishing components gem allows only importing specific parts on their own.

## Visual changes

None