### PR TITLE
Fix spacing regression in footer

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,11 +1,12 @@
+// settings
+@import "settings/measurements";
+
 @import "header-footer-only";
 
 /* govuk_frontend_toolkit includes */
 @import "shims";
 @import "design-patterns/buttons";
 
-// settings
-@import "settings/measurements";
 
 /* styles */
 @import "helpers/buttons";


### PR DESCRIPTION
## What 
The spacing functions were being imported after the footer and header stylesheet - this meant that the spacing functions weren't being processed, which broke the spacings. This changes the order of imports to fix that.

## Why

The footer looked broken.

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/73743221-f9f32b00-4745-11ea-8a99-d1a868f2ffa3.png)


After:

![image](https://user-images.githubusercontent.com/1732331/73743250-05deed00-4746-11ea-96bc-4b9e4de99df6.png)

Live:

![image](https://user-images.githubusercontent.com/1732331/73743358-42124d80-4746-11ea-8e14-95b958f27fe8.png)

