### PR TITLE
Remove govuk_toolkit shims

### DIFF
--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -1,21 +1,16 @@
 /* Global footer */
 
 #footer {
-  // Replaces the 1px #a1acb2 border from govuk_template
-  border-top: 10px solid $govuk-brand-colour;
+  background-color: govuk-colour("light-grey");
+  border-top: 10px solid $govuk-brand-colour; // Replaces the 1px #a1acb2 border from govuk_template
 
   .govuk-link:focus {
     color: $govuk-focus-text-colour;
   }
 
-  &,
-  .footer-wrapper {
-    background-color: govuk-colour("light-grey");
-  }
-
   .footer-container {
     @include media(tablet) {
-      padding-top: 60px;
+      padding-top: govuk-spacing(9);
     }
   }
 

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -78,7 +78,6 @@
   }
 
   .header-wrapper .header-global .site-search {
-    @extend %contain-floats;
     width: 49%;
     float: right;
 
@@ -147,7 +146,6 @@
 
   form#search {
     .content {
-      @extend %contain-floats;
       position: relative;
       background: govuk-colour("white");
     }

--- a/app/assets/stylesheets/helpers/_multi-step.scss
+++ b/app/assets/stylesheets/helpers/_multi-step.scss
@@ -145,51 +145,6 @@ li.done:hover .undo a {
   margin-top: 0.5em;
 }
 
-.current-question {
-  padding: 1.5em 0 1em 0;
-
-  h2 {
-    border: none;
-    @include bold-19;
-    margin-top: 0;
-    margin-bottom: 1em;
-    position: relative;
-
-    .question-number {
-      padding-right: 0.25em;
-      font-weight: 400;
-    }
-  }
-
-  ul {
-    label {
-      margin-left: 0.25em;
-    }
-
-    select {
-      margin-right: 0.25em;
-    }
-
-    /* this is the multiple choice selector */
-    &.options {
-      @extend %contain-floats;
-      list-style: none;
-      padding: 0; /* this aligns optional questions with gutter */
-
-      li {
-        line-height: 1.5em;
-        margin: 0.5em 0;
-      }
-    }
-
-    &.optional-date {
-      li {
-        fieldset { display: inline; }
-      }
-    }
-  }
-}
-
 .next-question {
   margin: 1.5em 0 0.5em 0;
 }

--- a/app/assets/stylesheets/helpers/_text.scss
+++ b/app/assets/stylesheets/helpers/_text.scss
@@ -378,7 +378,12 @@ article {
     background: none;
     border-left: 10px solid $border-colour;
     margin-bottom: 1em;
-    @extend %contain-floats;
+
+    &:after {
+      clear: both;
+      content: "";
+      display: block;
+    }
   }
 
   .help-notice p,

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -4,9 +4,7 @@
 @import "header-footer-only";
 
 /* govuk_frontend_toolkit includes */
-@import "shims";
 @import "design-patterns/buttons";
-
 
 /* styles */
 @import "helpers/mixins";

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -14,8 +14,8 @@
   <a href="#search" class="search-toggle js-header-toggle">Search</a>
   <% # The /search page redirects to a finder if keywords are included. Be careful about
      # changing this, as the redirect adds some parameters to the search query. %>
-  <form id="search" class="site-search" action="/search" method="get" role="search">
-    <div class="content">
+  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search">
+    <div class="content govuk-clearfix">
       <label for="site-search-text">Search</label>
       <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
       <input class="submit" type="submit" value="Search" />


### PR DESCRIPTION
## What

Removing the shims that static loads in from toolkit.

There were two shims mixing coming in from toolkit. 

One was for `display: inline-block` which wasn't being used, so hasn't been moved across. 

The other was for elements that contain floated elements - a clearfix. Where possible, this has been replaced with the `govuk-clearfix` class on the element. In two places, the styles weren't affecting anything in the templates in static - so the class couldn't be added in static. In those places I've imported the shim specifically into those stylesheets rather than into the base stylesheet. 

## Why

A step along the road towards the complete removal of toolkit from static - and turning off of the compatibility mode.

## Visual differences 

None