### PR TITLE
Fix global bar multiple cookies

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -1,4 +1,5 @@
 //= require libs/GlobalBarHelper.js
+//= require govuk_publishing_components/lib/cookie-functions
 
 'use strict'
 window.GOVUK = window.GOVUK || {}
@@ -34,12 +35,9 @@ var globalBarInit = {
   },
 
   setBannerCookie: function() {
-    var eighty_four_days = 84*24*60*60*1000
-    var expiryDate = new Date(Date.now() + eighty_four_days).toUTCString()
-    var value = JSON.stringify({count: 0, version: globalBarInit.getBannerVersion()})
-    var cookieString = "global_bar_seen=" + value + "; expires=" + expiryDate + ";"
+      var value = JSON.stringify({count: 0, version: globalBarInit.getBannerVersion()})
 
-    document.cookie=cookieString
+      window.GOVUK.setCookie("global_bar_seen", value, {days: 84});
   },
 
   makeBannerVisible: function() {

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -35,9 +35,14 @@ var globalBarInit = {
   },
 
   setBannerCookie: function() {
+    var cookieCategory = window.GOVUK.getCookieCategory("global_bar_seen")
+    var cookieConsent = GOVUK.getConsentCookie()
+
+    if (cookieConsent && cookieConsent[cookieCategory]) {
       var value = JSON.stringify({count: 0, version: globalBarInit.getBannerVersion()})
 
       window.GOVUK.setCookie("global_bar_seen", value, {days: 84});
+    }
   },
 
   makeBannerVisible: function() {

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -7,6 +7,7 @@ window.GOVUK = window.GOVUK || {}
 // Bump this if you are releasing a major change to the banner
 // This will reset the view count so all users will see the banner, even if previously seen
 var BANNER_VERSION = 3;
+var GLOBAL_BAR_SEEN_COOKIE = "global_bar_seen"
 
 var globalBarInit = {
   getBannerVersion: function() {
@@ -14,12 +15,12 @@ var globalBarInit = {
   },
 
   getLatestCookie: function() {
-    var currentCookie = document.cookie.match("(?:^|[ ;])(?:global_bar_seen=)(.+?)(?:(?=;|$))")
+    var currentCookie = window.GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)
 
     if (currentCookie == null) {
       return currentCookie
     } else {
-      return currentCookie[1]
+      return currentCookie
     }
   },
 
@@ -35,13 +36,13 @@ var globalBarInit = {
   },
 
   setBannerCookie: function() {
-    var cookieCategory = window.GOVUK.getCookieCategory("global_bar_seen")
+    var cookieCategory = window.GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE)
     var cookieConsent = GOVUK.getConsentCookie()
 
     if (cookieConsent && cookieConsent[cookieCategory]) {
       var value = JSON.stringify({count: 0, version: globalBarInit.getBannerVersion()})
 
-      window.GOVUK.setCookie("global_bar_seen", value, {days: 84});
+      window.GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, value, {days: 84});
     }
   },
 


### PR DESCRIPTION
Trello: https://trello.com/c/hA65u9qV/460-global-banner-setting-two-cookies-on-some-pages

## What
Use cookie helper functions in the global bar init logic, to match the rest of the global bar logic.

## Why
The global banner was setting two cookies on some pages, one with a path of '/' and one with the path of the page. This had the side effect of the banner not being able to be dismissed (it also didn't disappear after 3 page views). This looked like it was happening because some of the global bar functions set the cookie manually without specifying a path, whereas other functions use the cookie helper function which always set the path to '/'.

**Example page to check:**
[www.gov.uk/government/organisations/companies-house](www.gov.uk/government/organisations/companies-house)
