### PR TITLE
Set the global banner border to custom blue

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -472,7 +472,7 @@ $light-blue: #259EDA;
 
 .global-bar {
   background-color: #E5EAF1;
-  border-top: 8px solid $govuk-brand-colour;
+  border-top: 8px solid $light-blue;
   display: none;
   padding: govuk-spacing(3) 0;
 


### PR DESCRIPTION
## What
Set the global banner border to custom light blue

## Why
This got replaced when we moved to using colours from GOVUK Frontend. However, this is actually a one off and it should use the custom blue rather than govuk brand colour.

## Before
<img width="1041" alt="Screenshot 2020-02-05 at 13 03 45" src="https://user-images.githubusercontent.com/29889908/73844211-0942a900-4818-11ea-920b-e6ed037fd5e5.png">

## After
<img width="1030" alt="Screenshot 2020-02-05 at 13 03 53" src="https://user-images.githubusercontent.com/29889908/73844221-0d6ec680-4818-11ea-869a-6ae04f7f82c2.png">
