### PR TITLE
Add a custom meta tag for dimension 21

### DIFF
--- a/app/assets/javascripts/analytics/custom-dimensions.js
+++ b/app/assets/javascripts/analytics/custom-dimensions.js
@@ -50,6 +50,7 @@
       'withdrawn': {dimension: 12, defaultValue: 'not withdrawn'},
       'schema-name': {dimension: 17},
       'rendering-application': {dimension: 20},
+      'search-autocomplete-status': {dimension: 21},
       'navigation-legacy': {dimension: 30, defaultValue: 'none'},
       'navigation-page-type': {dimension: 32, defaultValue: 'none'},
       'taxon-slug': {dimension: 56, defaultValue: 'other'},

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -68,6 +68,16 @@ describe("GOVUK.StaticAnalytics", function() {
         expect(pageViewObject.dimension42).toEqual('name-of-test:name-of-ab-bucket');
         expect(pageViewObject.dimension48).toEqual('name-of-other-test:name-of-other-ab-bucket');
       });
+      it('sets the search autocomplete status as dimension 21', function() {
+        $('head').append('\
+          <meta name="govuk:search-autocomplete-status" content="used">\
+        ');
+
+        analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
+        pageViewObject = getPageViewObject();
+
+        expect(pageViewObject.dimension21).toEqual('used');
+      });
       it('sets the spelling suggestion as dimension 81', function() {
         $('head').append('\
           <meta name="govuk:spelling-suggestion" content="driving">\


### PR DESCRIPTION
We will be looking to track whether displayed search results were as a result of users selecting a suggestion from the title autocomplete or whether they just used the keyword search.

Dimension 21 was chosen in https://trello.com/c/FbRA8Wf1/1337-define-tracking-on-title-suggest-autocomplete and agreed with the Performance analyst community as per below

> Dimension 21 has been changed on Google analytics GOV.UK main profile.
> This was previously "search position" but was no longer being used.
> It has been renamed to "Search autocomplete status".
> The name can be changed at a later date.

[Trello ticket](https://trello.com/c/ddyRrx5k/1381-create-a-analytics-meta-tag-in-alphagov-static)