### PR TITLE
Remove toolkit conditionals

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ ruby File.read(".ruby-version").chomp
 gem "actionpack-page_caching", "1.2.0"
 gem "asset_bom_removal-rails", "~> 1.0.0"
 gem "govuk_app_config", "~> 2.0.3"
-gem "govuk_publishing_components", "~> 21.24.0"
+gem "govuk_publishing_components", "~> 21.26.2"
 gem "nokogiri", "~> 1.10"
 gem "rack_strip_client_ip", "0.0.2"
 gem "rails", "~> 5.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,7 +102,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (21.24.0)
+    govuk_publishing_components (21.26.2)
       gds-api-adapters
       govuk_app_config
       kramdown
@@ -335,7 +335,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_app_config (~> 2.0.3)
   govuk_frontend_toolkit (~> 9.0.0)
-  govuk_publishing_components (~> 21.24.0)
+  govuk_publishing_components (~> 21.26.2)
   govuk_template (= 0.26.0)
   govuk_test
   image_optim (= 0.26.5)

--- a/app/assets/stylesheets/header-footer-only-print.scss
+++ b/app/assets/stylesheets/header-footer-only-print.scss
@@ -2,7 +2,7 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
-@import "govuk_publishing_components/all_components_print";
+@import "govuk_publishing_components/components/print/feedback";
 
 // STYLEGUIDE
 // Mixins to be shared across gov.uk sites. Anything set in these

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -1,12 +1,12 @@
+@import "govuk_publishing_components/govuk_frontend_support";
+
 // settings
 @import "settings/colours";
 @import "settings/measurements";
 @import "settings/spacing";
 
-
 /* govuk_frontend_toolkit includes */
 @import "colours";
-@import "conditionals";
 @import "css3";
 @import "device-pixels";
 @import "measurements";

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -1,4 +1,9 @@
+$govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/_cookie-banner";
+@import "govuk_publishing_components/components/_feedback";
 
 // settings
 @import "settings/colours";

--- a/app/assets/stylesheets/helpers/_core.scss
+++ b/app/assets/stylesheets/helpers/_core.scss
@@ -38,7 +38,7 @@ h4 {
  */
 
 header.page-header div {
-  @include media(tablet){
+  @include govuk-media-query($from: tablet) {
     margin-top: govuk-spacing(6);
     margin-bottom: govuk-spacing(6);
   }

--- a/app/assets/stylesheets/helpers/_footer.scss
+++ b/app/assets/stylesheets/helpers/_footer.scss
@@ -9,20 +9,20 @@
   }
 
   .footer-container {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding-top: govuk-spacing(9);
     }
   }
 
   .footer-categories {
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding-bottom: govuk-spacing(6);
     }
 
     h2 {
       padding: govuk-spacing(2) 0 0;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         margin: 0 0 govuk-spacing(3) 0;
         padding: 0 0 govuk-spacing(4);
         border-bottom: 1px solid $border-colour;
@@ -35,7 +35,7 @@
       border: 1px solid $govuk-border-colour;
       border-width: 1px 0 0 0;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         margin-bottom: 0;
       }
     }
@@ -46,7 +46,7 @@
       padding: 0;
       margin: 0;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         padding-bottom: govuk-spacing(9);
       }
 
@@ -54,7 +54,7 @@
         padding: govuk-spacing(2) 0 0;
         margin-bottom: govuk-spacing(1);
 
-        @include media(tablet) {
+        @include govuk-media-query($from: tablet) {
           padding: govuk-spacing(4) 0 0;
           margin-bottom: 0;
         }
@@ -89,7 +89,7 @@
     .copyright {
       text-align: center;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         text-align: right;
       }
 

--- a/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
+++ b/app/assets/stylesheets/helpers/_govuk-emergency-banner.scss
@@ -4,7 +4,7 @@
   margin-top: 2px;
   padding: govuk-spacing(3) 0;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     padding: govuk-spacing(6) 0;
   }
 
@@ -18,7 +18,7 @@
 
     .homepage & {
       @include bold-48;
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         margin-bottom: govuk-spacing(4);
       }
     }
@@ -30,7 +30,7 @@
     margin-top: 0;
     margin-bottom: govuk-spacing(4);
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       width: percentage(2/3);
     }
 

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -81,7 +81,7 @@
     width: 49%;
     float: right;
 
-    @include media(desktop) {
+    @include govuk-media-query($from: desktop) {
       width: 33.33%;
     }
 
@@ -283,7 +283,7 @@
       border-bottom: 0;
       width: 100%;
 
-      @include media(tablet) {
+      @include govuk-media-query($from: tablet) {
         width: auto;
       }
     }
@@ -483,13 +483,13 @@ $light-blue: #259EDA;
     @extend %site-width-container;
     position: relative;
 
-    @include media($max-width: 320px) {
+    @include govuk-media-query($until: mobile) {
       .dismiss {
         position: relative;
       }
     }
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       .dismiss {
         position: absolute;
         right: 0;
@@ -497,7 +497,7 @@ $light-blue: #259EDA;
       }
     }
 
-    @include media($min-width: 320px) {
+    @include govuk-media-query($from: mobile) {
       .dismiss {
         position: absolute;
         right: 0;
@@ -511,7 +511,7 @@ $light-blue: #259EDA;
     margin-top: 0;
     max-width: 70%;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       max-width: auto;
     }
 

--- a/app/assets/stylesheets/helpers/_mixins.scss
+++ b/app/assets/stylesheets/helpers/_mixins.scss
@@ -9,11 +9,11 @@
     width: 960px;
   }
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     margin: 0 30px;
   }
 
-  @include media($min-width: (960px + 30px * 2)) {
+  @include govuk-media-query($and: "(min-width: #{($govuk-page-width + $govuk-gutter * 2)})") {
     margin: 0 auto;
   }
 }

--- a/app/assets/stylesheets/helpers/_organisations.scss
+++ b/app/assets/stylesheets/helpers/_organisations.scss
@@ -14,7 +14,7 @@
   padding-top: 23px;
   padding-left: govuk-spacing(2);
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     font-size: 19px;
     line-height: (20 / 19);
     padding-top: govuk-spacing(6);
@@ -27,7 +27,7 @@
     top: 0;
     position: static;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       padding: govuk-spacing(1) 0 govuk-spacing(1) 45px;
       background-position: 8px 50%;
     }
@@ -159,7 +159,7 @@
 @mixin organisation-logo-image($crest) {
   background: image-url('crests/#{$crest}_13px.png') no-repeat 8px 0;
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     background-image: image-url('crests/#{$crest}_18px.png');
   }
 }

--- a/app/assets/stylesheets/helpers/_publisher.scss
+++ b/app/assets/stylesheets/helpers/_publisher.scss
@@ -16,7 +16,7 @@
     padding-bottom: 1em;
     overflow: hidden;
 
-    @include media(tablet) {
+    @include govuk-media-query($from: tablet) {
       margin: 0 0 2.5em;
     }
   }

--- a/app/assets/stylesheets/helpers/_selectable.scss
+++ b/app/assets/stylesheets/helpers/_selectable.scss
@@ -16,7 +16,7 @@ label.selectable {
 
   cursor: pointer; // Encourage clicking on block labels
 
-  @include media(tablet) {
+  @include govuk-media-query($from: tablet) {
     float: left;
     margin-top: govuk-spacing(1);
     margin-bottom: govuk-spacing(1);

--- a/app/assets/stylesheets/modules/_sticky-element-container.scss
+++ b/app/assets/stylesheets/modules/_sticky-element-container.scss
@@ -11,7 +11,7 @@
     @include transition (opacity, .3s, ease);
     opacity: 1;
 
-    @include media(mobile) {
+    @include govuk-media-query($until: tablet) {
       position: static;
     }
   }

--- a/app/assets/stylesheets/static-pages/error-pages.scss
+++ b/app/assets/stylesheets/static-pages/error-pages.scss
@@ -24,7 +24,7 @@
     }
   }
 
-  @include media(mobile) {
+  @include govuk-media-query($until: tablet) {
     .page-header div {
       padding-left: 1em;
     }

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,5 +1,9 @@
 // settings
 @import "settings/measurements";
+
+$govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/_cookie-banner";
 @import "govuk_publishing_components/components/_feedback";

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -1,5 +1,8 @@
 // settings
 @import "settings/measurements";
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/_cookie-banner";
+@import "govuk_publishing_components/components/_feedback";
 
 @import "header-footer-only";
 

--- a/app/assets/stylesheets/styleguide/_conditionals2.scss
+++ b/app/assets/stylesheets/styleguide/_conditionals2.scss
@@ -20,3 +20,21 @@ $is-ie: false !default;
     }
   }
 }
+
+// mixins from toolkit, only used now by static and whitehall
+
+@mixin ie-lte($version) {
+  @if $is-ie {
+    @if $ie-version <= $version {
+      @content;
+    }
+  }
+}
+
+@mixin ie($version) {
+  @if $is-ie {
+    @if $ie-version == $version {
+      @content;
+    }
+  }
+}


### PR DESCRIPTION
## What

Remove `govuk_frontend_toolkit` conditionals from static. This involves:

- an update to include a new version of the components gem that allows static to import `govuk-frontend` mixins and variables (but no actual CSS weight)
- copying the IE conditional from toolkit
- updating all the media queries to use govuk-frontend, not toolkit
- pulling in the sass file from the gem for the cookie banner and feedback components(see below)

## Why

Just another step along the road to removing toolkit from the gem.

## Cookie banner and feedback components

In this new world of using specific sass for only the components an app is using from the gem, we need to import the sass for the cookie banner and feedback components into static, because static renders them, not the apps. At the moment this all works because all apps include all the components sass, but as soon as we start switching apps this will stop working.

Trello card: https://trello.com/c/knuRo9cF/207-replace-conditionals-from-frontend-toolkit-in-static