### PR TITLE
Hide the global banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_global_bar ||= true # Toggles the appearance of the global bar
+  show_global_bar ||= false # Toggles the appearance of the global bar
   title = "The UK has left the EU"
   title_href = false
   link_text = "Find out what this means for you"


### PR DESCRIPTION
## What
Hide the global banner

## Why
The fact we've left the EU is known, and transition information is well signposted around GOV.UK.
