### PR TITLE
Hide global bar on the referred page

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,7 +26,8 @@ var globalBarInit = {
 
   blacklistedUrl: function() {
     var paths = [
-      "/done"
+      "/done",
+      "/transition-check"
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -29,6 +29,11 @@ var globalBarInit = {
       "/done"
     ]
 
+    var ctaLink = document.querySelector('.js-call-to-action')
+    if (ctaLink) {
+      paths.push(ctaLink.getAttribute('href'))
+    }
+
     return new RegExp(paths.join("|")).test(window.location.pathname)
   },
 

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,10 +26,7 @@ var globalBarInit = {
 
   blacklistedUrl: function() {
     var paths = [
-      "/register-to-vote",
-      "/done",
-      "/transition",
-      "/transition-check"
+      "/done"
     ]
 
     return new RegExp(paths.join("|")).test(window.location.pathname)


### PR DESCRIPTION
Replace hardcoded blacklisted paths with the path of the page the call to action link points to.

Follow up on #2057 and #2059.