### PR TITLE
Centre global bar title vertically

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -520,6 +520,10 @@ $light-blue: #259EDA;
       font-weight: 700;
       margin-right: govuk-spacing(2);
       margin-bottom: govuk-spacing(1);
+
+      &:only-child {
+        margin: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
Vertically align the title in the global bar 'component'.

Update: There are a few variations for the global bar. Updated so that it copes with all.

## Preview

### Desktop (title only) before
<img width="1439" alt="Screenshot 2020-03-04 at 08 59 20" src="https://user-images.githubusercontent.com/788096/75862652-2c508080-5df7-11ea-83db-551e95e4113a.png">


## Desktop (title only) after
<img width="1438" alt="Screenshot 2020-03-04 at 08 59 41" src="https://user-images.githubusercontent.com/788096/75862661-307c9e00-5df7-11ea-8efb-aa920514fdad.png">

## Desktop (title and content) before and after
<img width="1438" alt="Screenshot 2020-03-04 at 09 23 08" src="https://user-images.githubusercontent.com/788096/75864706-56f00880-5dfa-11ea-9dc4-6427cab16bbd.png">


## Mobile
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

![www gov uk_(iPhone 6_7_8)](https://user-images.githubusercontent.com/788096/75863250-12fc0400-5df8-11ea-8f24-ff4f0cc4c1b0.png)


</td><td valign="top">

![www gov uk_(iPhone 6_7_8) (1)](https://user-images.githubusercontent.com/788096/75863262-17c0b800-5df8-11ea-9495-535802b2fe09.png)


</td></tr>
</table>