### PR TITLE
Move global-bar-init in body_end

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -12,7 +12,7 @@
 -%>
 
 <% if show_global_bar %>
-  <% content_for :head do %>
+  <% content_for :body_end do %>
     <%= javascript_include_tag 'global-bar-init', integrity: false %>
     <script>
       if (GOVUK.globalBarInit) {


### PR DESCRIPTION
Because the init runs right away (without awaiting the page to load) it's not able to query the markup elements (as they aren't loaded yet). [See this issue in integration](https://www.integration.publishing.service.gov.uk/government/topical-events/coronavirus-covid-19-uk-government-response).

Follow up on #2060.