### PR TITLE
Add tracking to see where the JS is being used

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ group :development, :test do
 end
 
 gem "gds-api-adapters", "~> 63.5"
-gem "govuk_frontend_toolkit", "~> 9.0.0"
+# gem "govuk_frontend_toolkit", "~> 9.0.0"
+gem "govuk_frontend_toolkit", github: "alphagov/govuk_frontend_toolkit_gem", submodules: true, branch: "add-tracking-see-where-js-is-being-used"
 gem "govuk_template", "0.26.0"
 gem "plek", "3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/govuk_frontend_toolkit_gem.git
+  revision: 7174cd5f0e6b934f9fa4843c352c4f1cb9106645
+  branch: add-tracking-see-where-js-is-being-used
+  submodules: true
+  specs:
+    govuk_frontend_toolkit (9.0.0)
+      railties (>= 3.1.0)
+      sass (>= 3.2.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -99,9 +109,6 @@ GEM
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
-    govuk_frontend_toolkit (9.0.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
     govuk_publishing_components (21.29.0)
       gds-api-adapters
       govuk_app_config
@@ -337,7 +344,7 @@ DEPENDENCIES
   gds-api-adapters (~> 63.5)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_app_config (~> 2.1.0)
-  govuk_frontend_toolkit (~> 9.0.0)
+  govuk_frontend_toolkit!
   govuk_publishing_components (~> 21.29.0)
   govuk_template (= 0.26.0)
   govuk_test
@@ -364,4 +371,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
Update to (temporarily) use a branch of the frontend toolkit gem, which uses the branch `add-tracking-see-where-js-is-being-used` of govuk_frontend_toolkit.

If a user has given permission, this will fire a GA event to let us know which JavaScript is being used and where. 

We can then see if / where these JavaScripts are being used and know where to provide a suitable replacement.