### PR TITLE
Only import feedback component CSS on error pages

### DIFF
--- a/app/assets/stylesheets/error-page-print.scss
+++ b/app/assets/stylesheets/error-page-print.scss
@@ -1,0 +1,10 @@
+$govuk-compatibility-govuktemplate: true;
+$govuk-use-legacy-palette: false;
+
+// is-print is used by govuk_frontend_toolkit to alter the printed font-stack
+$is-print: true;
+
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/feedback";

--- a/app/assets/stylesheets/error-page.scss
+++ b/app/assets/stylesheets/error-page.scss
@@ -1,2 +1,8 @@
 $govuk-compatibility-govuktemplate: true;
-@import "govuk_publishing_components/all_components";
+$govuk-use-legacy-palette: false;
+
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+@import "govuk_publishing_components/components/_cookie-banner";
+@import "govuk_publishing_components/components/_button";
+@import "govuk_publishing_components/components/_feedback";

--- a/app/assets/stylesheets/header-footer-only-print.scss
+++ b/app/assets/stylesheets/header-footer-only-print.scss
@@ -2,8 +2,6 @@
 $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
-@import "govuk_publishing_components/components/print/feedback";
-
 // STYLEGUIDE
 // Mixins to be shared across gov.uk sites. Anything set in these
 // files can be used in the view files.

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -3,7 +3,6 @@ $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/_cookie-banner";
-@import "govuk_publishing_components/components/_feedback";
 
 /* govuk_frontend_toolkit includes */
 @import "colours";

--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -3,7 +3,6 @@ $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/_cookie-banner";
-@import "govuk_publishing_components/components/_feedback";
 
 @import "header-footer-only";
 
@@ -19,5 +18,3 @@ $govuk-use-legacy-palette: false;
 @import "helpers/publisher";
 @import "helpers/text";
 @import "helpers/wrapper";
-
-@import "static-pages/error-pages";

--- a/app/views/root/404.html.erb
+++ b/app/views/root/404.html.erb
@@ -3,6 +3,6 @@
     heading: "Page not found",
     intro: '<p>If you entered a web address please check it was correct.</p>
 
-            <p>You can also <a href="/search/all">search GOV.UK</a> or <a href="/">browse from the homepage</a> to find the information you need.</p>',
+            <p>You can also <a class="govuk-link" href="/search/all">search GOV.UK</a> or <a class="govuk-link" href="/">browse from the homepage</a> to find the information you need.</p>',
     status_code: 404
 } %>

--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "error_page", locals: {
     title: "Page not found - 406",
     heading: "The page you are looking for can't be found",
-    intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>',
+    intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a class="govuk-link" href="/">GOV.UK</a> to find the information you need.</p>',
     status_code: 406
 } %>

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -2,6 +2,6 @@
     title: "Page no longer here - 410",
     heading: "The page you are looking for is no longer here",
     intro: '<p>It may have been moved or replaced.</p>
-      <p>Please check that you have entered the correct web address, or try using the search box above or explore <a href="/">GOV.UK</a> to find the information you need.</p>',
+      <p>Please check that you have entered the correct web address, or try using the search box above or explore <a class="govuk-link" href="/">GOV.UK</a> to find the information you need.</p>',
     status_code: 410
 } %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -3,6 +3,7 @@
 
 <% content_for :head do %>
   <%= stylesheet_link_tag "error-page", media: "screen" %>
+  <%= stylesheet_link_tag "error-page-print", media: "print" %>
 <% end %>
 
 <% content_for :body_end do %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -15,4 +15,5 @@ Rails.application.config.assets.precompile += %w{
   core-layout*.css
   static-print.css
   error-page.css
+  error-page-print.css
 }


### PR DESCRIPTION
## What

- Remove imports of feedback component CSS in general static stylesheets (e.g: static, core, header-and-footer-only). Instead, only import the feedback component where it's used in the error-page.css.
- Don't import all components in the error pages - we don't need everything
- Don't import error page css in the general css file. The error page template supplies a stylesheet tag for the error-page.css
- Add govuk-link class to error page content for consistent focus states

## Why
The feedback component is only shown on error pages within Static. In other cases, the frontend applications themselves are pulling in the feedback component HTML and CSS.

The existing behaviour meant we had duplicated CSS for the feedback component as it was being imported once by static and once by the frontend app. This commit stops that from happening.

## Visual (should look no different)
![static dev gov uk_templates_404 html erb](https://user-images.githubusercontent.com/29889908/76087677-91020b80-5fae-11ea-8265-1286d03f0783.png)
