### PR TITLE
Add list subheading as optional attribute to ecommerce tracking

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -19,20 +19,24 @@
 
       ecommerceRows.each(function(index, ecommerceRow) {
         var $ecommerceRow = $(ecommerceRow);
-
+        var listSubheading  = $ecommerceRow.data('ecommerce-subheading') || undefined;
         var contentId = $ecommerceRow.attr('data-ecommerce-content-id'),
           path = $ecommerceRow.attr('data-ecommerce-path');
 
-        addImpression(contentId, path, index + startPosition, searchQuery, listTitle, variant);
-        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant, trackClickLabel);
+        addImpression(contentId, path, index + startPosition, searchQuery, listTitle, listSubheading, variant);
+        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, listSubheading, variant, trackClickLabel);
       });
     }
 
-    function constructData(contentId, path, position, listTitle, searchQuery, variant) {
+    function constructData(contentId, path, position, listTitle, listSubheading, searchQuery, variant) {
       var data = {
         position: position,
         list: listTitle,
         dimension71: searchQuery
+      }
+
+      if (listSubheading !== undefined) {
+        data.dimension94 = listSubheading
       }
 
       if (contentId !== undefined) {
@@ -50,17 +54,17 @@
       return data
     }
 
-    function addImpression (contentId, path, position, searchQuery, listTitle, variant) {
+    function addImpression (contentId, path, position, searchQuery, listTitle, listSubheading, variant) {
       if (contentId || path) {
-        var impressionData = constructData(contentId, path, position, listTitle, searchQuery, variant)
+        var impressionData = constructData(contentId, path, position, listTitle, listSubheading, searchQuery, variant)
         ga('ec:addImpression', impressionData);
       }
     }
 
-    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, variant, trackClickLabel) {
+    function trackProductOnClick (row, contentId, path, position, searchQuery, listTitle, listSubheading, variant, trackClickLabel) {
       row.click(function() {
         if (contentId || path) {
-          var clickData = constructData(contentId, path, position, listTitle, searchQuery, variant)
+          var clickData = constructData(contentId, path, position, listTitle, listSubheading, searchQuery, variant)
           ga('ec:addProduct', clickData);
         }
 

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -79,6 +79,28 @@ describe('Ecommerce reporter for results pages', function() {
     });
   });
 
+  it('tracks ecommerce subheading', function() {
+    element = $('\
+      <div data-analytics-ecommerce data-search-query data-list-title="ecommerce-list" data-ecommerce-start-index="1">\
+        <div \
+          data-ecommerce-row=1\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-subheading="Human Readable Subheading"\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      name: "/path/to/page",
+      position: 1,
+      list: 'ecommerce-list',
+      dimension71: '',
+      dimension94: 'Human Readable Subheading',
+    });
+  })
+
   it('tracks multiple lists individually', function() {
     element = $('\
       <div> \


### PR DESCRIPTION
trello: https://trello.com/c/wyHXRVll/138-add-ecommerce-tracking-to-mainstream-browse

Depends on: https://github.com/alphagov/static/pull/2072

## What

Adds an optional `list-subheading` attribute that will be sent to google analytics as dimension 94. If the tracked element has an attribute `ecommerce-subtitle` the value will be sent, otherwise dimension94 will not be included in the playload to GA.

## Why

We are adding ecommerce tracking to many of our browse pages. Some lists have subheadings that internally group rows. It is a requirement that we are able to track these too.

This work in an effort to build better baseline data around the browse experience on GOV.UK ahead of considering changes.