### PR TITLE
Add duplication guard to eCommerce event listeners

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -24,7 +24,9 @@
           path = $ecommerceRow.attr('data-ecommerce-path');
 
         addImpression(contentId, path, index + startPosition, searchQuery, listTitle, variant);
-        trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant, trackClickLabel);
+        if (this.eventListenersLoaded !== true) {
+          trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, variant, trackClickLabel);
+        }
       });
     }
 
@@ -73,6 +75,7 @@
   }
 
   Ecommerce.ecLoaded = false;
+  Ecommerce.eventListenersLoaded = false;
   Ecommerce.start = function (element) {
     if (!window.ga) { return }
     element = element || $('[data-analytics-ecommerce]');
@@ -86,6 +89,7 @@
         ecommerce.init($(this));
       })
     }
+    Ecommerce.eventListenersLoaded = true;
   }
 
   GOVUK.Ecommerce = Ecommerce;


### PR DESCRIPTION
Trello: https://trello.com/c/VqaaxwNB/144-prevent-duplicate-ecommerce-events-being-sent

## What
Prevents `GOVUK.Ecommerce.start();` setting further event listeners on a page if it has already been run once in that page.

## Why
We are adding ecommerce tracking to mainstream browse to establish baseline usage stats ahead of proposed changes.

Mainstream browse runs `GOVUK.Ecommerce.start();` in collections upon an initial page load. However after that point clicks through the browse experience trigger synthetic page loads with Ajax. To capture eCommerce impressions without major changes to the existing ecommerce codebase in static, we will need to run Ecommerce.start() a second time with these Ajax calls.

However, without this change, start sets two new event listeners each time it is run. As a consequence every time the user navigates up the hierarchy we get +2 duplicate click events. These stack on top of each other, so you can easily get n+2 events fired every time the user browses.

Current eCommerce tracking is very tightly coupled to the use case set up in search. A larger refactor is likely necessary to allow broader use cases like this one. However testing there should be done with a careful eye to existing tracking in Search, Transition pages and finders to ensure that modifications to not break any existing reports.

So here I've made the minimum intervention to allow us to get mainstream eCommerce tracking live and will follow up with some larger refactors in due course.