### PR TITLE
Update banner message and styles

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -483,25 +483,18 @@ $light-blue: #259EDA;
     @extend %site-width-container;
     position: relative;
 
-    @include govuk-media-query($until: mobile) {
-      .dismiss {
-        position: relative;
-      }
+    .global-bar__dismiss {
+      display: inline-block;
+      position: relative;
+      margin-top: govuk-spacing(4);
     }
 
     @include govuk-media-query($from: tablet) {
-      .dismiss {
+      .global-bar__dismiss {
         position: absolute;
+        margin-top: 0;
         right: 0;
         top: 0;
-      }
-    }
-
-    @include govuk-media-query($from: mobile) {
-      .dismiss {
-        position: absolute;
-        right: 0;
-        bottom: 0;
       }
     }
   }
@@ -509,14 +502,9 @@ $light-blue: #259EDA;
   .global-bar-message {
     margin-bottom: 0;
     margin-top: 0;
-    max-width: 70%;
-
-    @include govuk-media-query($from: tablet) {
-      max-width: auto;
-    }
 
     .global-bar-title {
-      display: block;
+      display: inline-block;
       font-weight: 700;
       margin-right: govuk-spacing(2);
       margin-bottom: govuk-spacing(1);
@@ -525,5 +513,21 @@ $light-blue: #259EDA;
         margin: 0;
       }
     }
+  }
+}
+
+.global-bar--warning {
+  background-color: govuk-colour("red");
+  border-top: none;
+  padding: govuk-spacing(5) 0;
+
+  .global-bar-message {
+    .global-bar-title {
+      color: govuk-colour("white");
+    }
+  }
+
+  .global-bar__dismiss:link {
+    color: govuk-colour("white");
   }
 }

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,14 +1,20 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
-  title = "Get information on the government’s response to coronavirus (COVID-19)"
+  title = "Coronavirus (COVID-19): what you need to do"
   title_href = "/government/topical-events/coronavirus-covid-19-uk-government-response"
   link_text = false
   link_href = false
+
+  # Toggles the banner to have a red background and white text.
+  warning ||= true
 
   # Toggles banner being permanently visible
   # If true, banner is always_visible & does not disappear automatically after 3 pageviews
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
+
+  global_bar_classes = %w(global-bar dont-print)
+  global_bar_classes << "global-bar--warning" if warning
 -%>
 
 <% if show_global_bar %>
@@ -21,7 +27,7 @@
     </script>
   <% end %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="global-bar dont-print" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %>>
+  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %>>
     <div class="global-bar-message-container">
     <p class="global-bar-message">
       <% if title %>
@@ -46,7 +52,7 @@
       <% end %>
     </p>
     <a href="#hide-message"
-       class="govuk-link dismiss"
+       class="govuk-link global-bar__dismiss dismiss"
        role="button"
        aria-controls="global-bar">Hide&nbsp;message</a>
     </div>


### PR DESCRIPTION
## What

Update to the banner message copy and styles - the red warning layout is toggled with `warning ||= true` in the partial.

Design from @stephenjoe1

## Visual differences

Before:

![image](https://user-images.githubusercontent.com/1732331/76538839-d6737c80-6477-11ea-86aa-e86ac01190f7.png)

After:

![image](https://user-images.githubusercontent.com/1732331/76543274-2f461380-647e-11ea-9af8-d29115d1b6ef.png)


Warning:

![image](https://user-images.githubusercontent.com/1732331/76539071-2d795180-6478-11ea-83e7-854e6c2f00d8.png)


<table>
<tr>
<th>Before</th>
<th>After</th>
<th>Warning</th>
</tr>
<tr><td valign="top">

![image](https://user-images.githubusercontent.com/1732331/76539010-176b9100-6478-11ea-84a5-f7e36f37c940.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/76543455-72a08200-647e-11ea-88ac-723f07202741.png)

</td><td>

![image](https://user-images.githubusercontent.com/1732331/76539132-3f5af480-6478-11ea-9296-0e213495e5e6.png)


</td>
</tr></table>