### PR TITLE
Fix :visited :focus state for link in banner

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -528,7 +528,7 @@ $light-blue: #259EDA;
   padding: govuk-spacing(5) 0;
 
   .global-bar-message {
-    .global-bar-title {
+    .global-bar-title:link {
       color: govuk-colour("white");
     }
   }


### PR DESCRIPTION
## What

The focus state for the link in the banner was white when visited, instead of black.

## Why

Fixed to meet the contrast criteria to make the link readable and accessible.

## Visual changes

Before:
![image](https://user-images.githubusercontent.com/1732331/76550529-2e1ae380-648a-11ea-8a96-7e1a1afd4b2b.png)

After:

![image](https://user-images.githubusercontent.com/1732331/76550588-4854c180-648a-11ea-832e-b353f87dac64.png)
