### PR TITLE
Remove the tracking that fires when old JS is initialised

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ group :development, :test do
 end
 
 gem "gds-api-adapters", "~> 63.5"
-# gem "govuk_frontend_toolkit", "~> 9.0.0"
-gem "govuk_frontend_toolkit", github: "alphagov/govuk_frontend_toolkit_gem", submodules: true, branch: "add-tracking-see-where-js-is-being-used"
+gem "govuk_frontend_toolkit", "~> 9.0.0"
 gem "govuk_template", "0.26.0"
 gem "plek", "3.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/govuk_frontend_toolkit_gem.git
-  revision: 7174cd5f0e6b934f9fa4843c352c4f1cb9106645
-  branch: add-tracking-see-where-js-is-being-used
-  submodules: true
-  specs:
-    govuk_frontend_toolkit (9.0.0)
-      railties (>= 3.1.0)
-      sass (>= 3.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -109,6 +99,9 @@ GEM
       sentry-raven (>= 2.7.1, < 2.14.0)
       statsd-ruby (~> 1.4.0)
       unicorn (>= 5.4, < 5.6)
+    govuk_frontend_toolkit (9.0.0)
+      railties (>= 3.1.0)
+      sass (>= 3.2.0)
     govuk_publishing_components (21.29.1)
       gds-api-adapters
       govuk_app_config
@@ -344,7 +337,7 @@ DEPENDENCIES
   gds-api-adapters (~> 63.5)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk_app_config (~> 2.1.0)
-  govuk_frontend_toolkit!
+  govuk_frontend_toolkit (~> 9.0.0)
   govuk_publishing_components (~> 21.29.1)
   govuk_template (= 0.26.0)
   govuk_test


### PR DESCRIPTION
This used up a lot - a lot! - of events, so is being reverted to prevent the quota from being exhausted. 

The gem has been commented out rather than deleted, since we will need to use it again to check again where the JavaScript is being initialised in the near future.