### PR TITLE
Adds coronavirus section to footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -42,6 +42,20 @@
   <% unless local_assigns[:hide_footer_links] %>
     <div class="govuk-grid-row footer-categories" data-module="track-click">
       <div class="govuk-grid-column-two-thirds">
+        <h2>Coronavirus (COVID-19)</h2>
+        <ul>
+          <li>
+            <a data-track-category="footerClicked"
+               data-track-action="coronavirusLinks"
+               data-track-label="Coronavirus (COVID-19): what you need to do"
+               href="/government/topical-events/coronavirus-covid-19-uk-government-response"
+               class="govuk-link">
+               Coronavirus (COVID-19): what you need to do
+            </a>
+          </li>
+        </ul>
+      </div>
+      <div class="govuk-grid-column-one-third">
         <h2>Transition period</h2>
         <ul>
           <li>


### PR DESCRIPTION
Trello link:
https://trello.com/c/gWEwtJXq/21-coronavirus-link-updates-for-footer-and-popular-links

## Designs
<img width="1216" alt="Screenshot 2020-03-16 14 18 12" src="https://user-images.githubusercontent.com/4599889/76777800-b0fcb080-67a0-11ea-96bc-5784b5b77c91.png">
