### PR TITLE
Hide coronavirus banner on coronavirus page

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -27,7 +27,8 @@ var globalBarInit = {
   urlBlockList: function() {
     var paths = [
       "/done",
-      "/transition-check"
+      "/transition-check",
+      "/coronavirus"
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
Stop the coronavirus global banner from appearing on the coronavirus page itself.

Trello card: https://trello.com/c/3kzzbqME/43-update-the-banner-to-not-show-on-coronavirus
