### PR TITLE
Update links for coronavirus landing page

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,7 +1,7 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
   title = "Coronavirus (COVID-19): what you need to do"
-  title_href = "/government/topical-events/coronavirus-covid-19-uk-government-response"
+  title_href = "/coronavirus"
   link_text = false
   link_href = false
 

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -48,7 +48,7 @@
             <a data-track-category="footerClicked"
                data-track-action="coronavirusLinks"
                data-track-label="Coronavirus (COVID-19): what you need to do"
-               href="/government/topical-events/coronavirus-covid-19-uk-government-response"
+               href="/coronavirus"
                class="govuk-link">
                Coronavirus (COVID-19): what you need to do
             </a>


### PR DESCRIPTION
Because /coronavirus currently redirects to the topical event page, this
can be merged and deployed whenever we like.

The topical event page will be redirected back to the new landing page once it
it published.

https://trello.com/c/9EMnRGEh/38-update-the-banner-link