### PR TITLE
Now matches the exact path for url blocking

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,14 +26,15 @@ var globalBarInit = {
 
   urlBlockList: function() {
     var paths = [
-      "/done",
-      "/transition-check",
-      "/coronavirus"
+      "^/done",
+      "^/transition-check$",
+      "^/coronavirus$"
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')
     if (ctaLink) {
-      paths.push(ctaLink.getAttribute('href'))
+      var ctaPath = "^" + ctaLink.getAttribute('href') + "$"
+      paths.push(ctaPath)
     }
 
     return new RegExp(paths.join("|")).test(window.location.pathname)


### PR DESCRIPTION
Previously it was checking for segments so if we had `/coranavirus` blocked, `/guidance/coronavirus-covid-19-information-for-the-public` would be blocked too as it has `/coronavirus` in the middle.

This change now forces the regex to check exact match so it would only match if the path is `/coronavirus` not `/guidance/coronavirus-covid-19-information-for-the-public`.

Trello: https://trello.com/c/a83JfZDG/60-check-why-the-banner-doesnt-appear-on-certain-pages