### PR TITLE
Remove (temporarily) the search box from header

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -10,19 +10,6 @@
   <%= render :partial => 'stylesheet', :locals => { :css_file => local_assigns[:css_file] || 'static' } %>
 <% end %>
 
-<% content_for :inside_header do %>
-  <a href="#search" class="search-toggle js-header-toggle">Search</a>
-  <% # The /search page redirects to a finder if keywords are included. Be careful about
-     # changing this, as the redirect adds some parameters to the search query. %>
-  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search">
-    <div class="content govuk-clearfix">
-      <label for="site-search-text">Search</label>
-      <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">
-      <input class="submit" type="submit" value="Search" />
-    </div>
-  </form>
-<% end %>
-
 <% content_for :after_header do %>
   <div id="user-satisfaction-survey-container"></div>
   <% if @emergency_banner %>

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -12,9 +12,10 @@ class Error4XXTest < ActionDispatch::IntegrationTest
     end
 
     within "body.mainstream.error" do
-      within "header#global-header" do
-        assert page.has_selector?("form#search")
-      end
+      # TODO: This is temporary
+      # within "header#global-header" do
+      #   assert page.has_selector?("form#search")
+      # end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -12,9 +12,10 @@ class Error5XXTest < ActionDispatch::IntegrationTest
     end
 
     within "body.mainstream.error" do
-      within "header#global-header" do
-        assert page.has_selector?("form#search")
-      end
+      # TODO: This is temporary
+      # within "header#global-header" do
+      #   assert page.has_selector?("form#search")
+      # end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")

--- a/test/integration/templates/header_footer_only_test.rb
+++ b/test/integration/templates/header_footer_only_test.rb
@@ -11,9 +11,10 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header#global-header" do
-        assert page.has_selector?("form#search")
-      end
+      # TODO: This is temporary
+      # within "header#global-header" do
+      #   assert page.has_selector?("form#search")
+      # end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")

--- a/test/integration/templates/homepage_test.rb
+++ b/test/integration/templates/homepage_test.rb
@@ -11,9 +11,10 @@ class HomepageTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header#global-header" do
-        assert page.has_selector?("form#search")
-      end
+      # TODO: This is temporary
+      # within "header#global-header" do
+      #   assert page.has_selector?("form#search")
+      # end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")

--- a/test/integration/templates/wrapper_test.rb
+++ b/test/integration/templates/wrapper_test.rb
@@ -11,9 +11,10 @@ class WrapperTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header#global-header" do
-        assert page.has_selector?("form#search")
-      end
+      # TODO: This is temporary
+      # within "header#global-header" do
+      #   assert page.has_selector?("form#search")
+      # end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")


### PR DESCRIPTION
This is because we want to prevent load on our search service.

## Screenshots

### Desktop
![Screenshot at Mar 23 6-16-43 pm](https://user-images.githubusercontent.com/424772/77349530-0dc51180-6d33-11ea-84c3-c6ce5646c5de.png)
### Mobile
![mobile-searchless](https://user-images.githubusercontent.com/424772/77349658-41a03700-6d33-11ea-8652-d1b452cbd4ba.png)
