### PR TITLE
Allow using data-ecommerce-index to override implicit index

### DIFF
--- a/app/assets/javascripts/analytics/ecommerce.js
+++ b/app/assets/javascripts/analytics/ecommerce.js
@@ -23,6 +23,9 @@
         var contentId = $ecommerceRow.attr('data-ecommerce-content-id'),
           path = $ecommerceRow.attr('data-ecommerce-path');
 
+        var index_override = $ecommerceRow.attr('data-ecommerce-index');
+        index = index_override ? parseInt(index_override, 10) - 1 : index;
+
         addImpression(contentId, path, index + startPosition, searchQuery, listTitle, listSubheading, variant);
         trackProductOnClick($ecommerceRow, contentId, path, index + startPosition, searchQuery, listTitle, listSubheading, variant, trackClickLabel);
       });

--- a/spec/javascripts/analytics/ecommerce.spec.js
+++ b/spec/javascripts/analytics/ecommerce.spec.js
@@ -56,6 +56,29 @@ describe('Ecommerce reporter for results pages', function() {
     });
   });
 
+  it('uses data-ecommerce-index to override the implicit index', function() {
+    element = $('\
+      <div data-ecommerce-start-index="1" data-search-query="search query">\
+        <div \
+          data-ecommerce-row\
+          data-ecommerce-path="/path/to/page"\
+          data-ecommerce-index="42"\
+          data-ecommerce-content-id="AAAA-1111">\
+        </div>\
+      </div>\
+    ');
+
+    ecommerce.init(element);
+
+    expect(ga).toHaveBeenCalledWith('ec:addImpression', {
+      id: 'AAAA-1111',
+      name: "/path/to/page",
+      position: 42,
+      list: 'Site search results',
+      dimension71: 'search query'
+    });
+  });
+
   it('tracks impressions with product variants', function() {
     element = $('\
       <div data-ecommerce-start-index="1" data-search-query="search query" data-ecommerce-variant="variant-x">\


### PR DESCRIPTION
We're going to use this on search results pages to track displaying
subpages (eg, parts of guides).  These are going to be tracked as
multiple results in the same position, but with different links.

---

[Trello card](https://trello.com/c/9EfcgjHZ/1415-add-ecommerce-tracking-for-parts-in-results)