### PR TITLE
Don't show banner content in google snippets

### DIFF
--- a/app/views/notifications/_emergency_banner.html.erb
+++ b/app/views/notifications/_emergency_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="govuk-emergency-banner <%= banner.campaign_class %>" role="banner">
+<div class="govuk-emergency-banner <%= banner.campaign_class %>" role="banner" data-nosnippet>
   <div>
     <h2><%= banner.heading %></h2>
     <% if banner.short_description %>

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -31,7 +31,7 @@
     </script>
   <% end %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %>>
+  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
     <div class="global-bar-message govuk-width-container">
       <% if title %>
         <% if title_href %>


### PR DESCRIPTION
Similar to https://github.com/alphagov/govuk_publishing_components/pull/1185

Banners don't hold content specific to each page, so shouldn't be shown in
search results.

https://developers.google.com/search/reference/robots_meta_tag#data-nosnippet-attr