### PR TITLE
Exclude business page from the coronavirus banner

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,7 +26,8 @@ var globalBarInit = {
 
   urlBlockList: function() {
     var paths = [
-      "^/coronavirus$"
+      "^/coronavirus$",
+      "^/coronavirus/business-support$"
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,7 +26,6 @@ var globalBarInit = {
 
   urlBlockList: function() {
     var paths = [
-      "^/coronavirus$",
       "^/coronavirus/business-support$"
     ]
 


### PR DESCRIPTION
We'll show a breadcrumb back to the coronavirus page.

We don't need to include it in the "auto-hide the banner if you've seen this page" logic because the banner duplicates /coronavirus content and not /coronavirus/business-support logic

We can remove the explicit coronavirus link here too, as it's picked up by the call to action code below the exclusion list

https://trello.com/c/CXuwza3f/136-hide-the-coronavirus-banner-on-the-business-landing-page