### PR TITLE
Update colours from lime to lemon

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -472,13 +472,13 @@
   display: none;
 }
 
-$covid-green: #7eff8e;
+$covid-yellow: #ffe114;
 $covid-grey: #262828;
 
 .global-bar {
   @include core-19;
   background-color: govuk-colour("black");
-  border-top: govuk-spacing(2) solid $covid-green;
+  border-top: govuk-spacing(2) solid $covid-yellow;
   border-bottom: 1px solid govuk-colour("white");
   display: none;
 


### PR DESCRIPTION
Trello: https://trello.com/c/YT0f0FDN/133-update-theme-from-lime-to-lemon

## What
Update border-top colour for banner from green to yellow

## Why
To match the new branding colours for Public Health England