### PR TITLE
Enforce line break on global banner text

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -516,6 +516,10 @@ $covid-grey: #262828;
   }
 }
 
+.global-bar-title__nowrap {
+  white-space: nowrap;
+}
+
 .global-bar-title__icon {
   display: inline-block;
   display: -ms-flexbox;

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,6 +1,6 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
-  title = "Coronavirus (COVID-19): <span class='global-bar-title__nowrap'>what you need to do</span>"
+  title = sanitize("Coronavirus (COVID-19): <span class='global-bar-title__nowrap'>what you need to do</span>")
   title_href = "/coronavirus"
   title_icon = true
   link_text = false
@@ -38,10 +38,10 @@
       <% if title %>
         <% if title_href %>
           <span class="<%= title_icon_class %>">
-            <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= raw title %></a>
+            <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= title %></a>
           </span>
         <% else %>
-          <span class="<%= title_classes.join(' ') %>"><%= raw title %></span>
+          <span class="<%= title_classes.join(' ') %>"><%= title %></span>
         <% end %>
       <% end %>
 

--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -1,6 +1,6 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
-  title = "Coronavirus (COVID-19): what you need to do"
+  title = "Coronavirus (COVID-19): <span class='global-bar-title__nowrap'>what you need to do</span>"
   title_href = "/coronavirus"
   title_icon = true
   link_text = false
@@ -38,10 +38,10 @@
       <% if title %>
         <% if title_href %>
           <span class="<%= title_icon_class %>">
-            <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= title %></a>
+            <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= raw title %></a>
           </span>
         <% else %>
-          <span class="<%= title_classes.join(' ') %>"><%= title %></span>
+          <span class="<%= title_classes.join(' ') %>"><%= raw title %></span>
         <% end %>
       <% end %>
 


### PR DESCRIPTION
Wraps part of the global banner text in a non-whitespace-wrapping span, so that the text wraps nicer on smaller screens. No change on desktop.

Before:

<img width="376" alt="Screenshot 2020-04-16 at 15 50 17" src="https://user-images.githubusercontent.com/861310/79472447-c4977300-7ffb-11ea-9fa9-4997cfa16404.png">

After:

<img width="383" alt="Screenshot 2020-04-16 at 15 50 25" src="https://user-images.githubusercontent.com/861310/79472464-c9f4bd80-7ffb-11ea-9973-a45d1e5965c8.png">
