### PR TITLE
Add linked domain

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -74,6 +74,7 @@ var analyticsInit = function() {
       'compare-school-performance.service.gov.uk',
       'complete-deputy-report.service.gov.uk',
       'contractsfinder.service.gov.uk',
+      'coronavirus.data.gov.uk',
       'courttribunalfinder.service.gov.uk',
       'create-energy-label.service.gov.uk',
       'cymraeg.registertovote.service.gov.uk',


### PR DESCRIPTION
Add domain into cross domain tracking linker.

Trello card: https://trello.com/c/pqWQYsnV/403-onboard-coronavirus-dashboard-to-cross-domain-tracking
