### PR TITLE
Add Smart Surveys domain to decorate links

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -139,6 +139,7 @@ var analyticsInit = function() {
       'selfservice.payments.service.gov.uk',
       'send-money-to-prisoner.service.gov.uk',
       'signin.service.gov.uk',
+      'www.smartsurvey.co.uk',
       'sorn.service.gov.uk',
       'staff.helpwithcourtfees.service.gov.uk',
       'student-finance.service.gov.uk',


### PR DESCRIPTION
We already do this for forms[1] but this is a quick and simple
mechanism we already have in using the allowLinker feature in GA.

[1] https://github.com/alphagov/static/blob/master/app/assets/javascripts/surveys.js#L204