### PR TITLE
Clarify transition footer text

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -56,15 +56,15 @@
         </ul>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h2>Transition period</h2>
+        <h2>The UK has left the EU</h2>
         <ul>
           <li>
             <a data-track-category="footerClicked"
                data-track-action="transitionLinks"
-               data-track-label="Transition period: check how to get ready"
+               data-track-label="Transition period: get ready for 2021"
                href="/transition"
                class="govuk-link">
-               Transition period: check how to get ready
+               Transition period: get ready for 2021
             </a>
           </li>
         </ul>


### PR DESCRIPTION
https://trello.com/c/N5PXmpHC/123-change-transition-period-section-of-govuk-footer

This is not about 'coronavirus transition (of out lockdown)'. Our
 analytics shows users are confused about this particular link.