### PR TITLE
Add button component sass to static

### DIFF
--- a/app/assets/stylesheets/static.scss
+++ b/app/assets/stylesheets/static.scss
@@ -2,6 +2,7 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/components/_button";
 @import "govuk_publishing_components/components/_cookie-banner";
 
 @import "header-footer-only";


### PR DESCRIPTION
Buttons in the cookie banner are unstyled in some applications following the move to individual component sass inclusion, if the application in question does not include buttons already.

e.g. calendars:

<img width="1081" alt="Screenshot 2020-04-24 at 09 23 20" src="https://user-images.githubusercontent.com/861310/80191195-46475c00-860d-11ea-82b9-8e32d6fedf22.png">

Adding the button sass into static like this fixes this problem but introduces duplicate CSS for users where applications already include the button sass, so this is a temporary solution while we figure out something better.