### PR TITLE
Suppress banner for sub-pages of /coronavirus

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,7 +26,7 @@ var globalBarInit = {
 
   urlBlockList: function() {
     var paths = [
-      "^/coronavirus/business-support$"
+      "^/coronavirus/.*$"
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
We expect these to be hub pages which have a hefty breadcrumb linking back to the coronavirus landing page.

Example pages:
https://www.gov.uk/coronavirus/business-support
https://www.gov.uk/coronavirus/education-and-childcare
