### PR TITLE
Add scroll tracking to some coronavirus pages

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -11,6 +11,27 @@
       ['Percent', 80],
       ['Percent', 100]
     ],
+    '/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do/coronavirus-outbreak-faqs-what-you-can-and-cant-do': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/government/publications/coronavirus-covid-19-online-education-resources/coronavirus-covid-19-list-of-online-education-resources-for-home-education': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
+    '/guidance/coronavirus-covid-19-information-for-the-public': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
+    ],
     '/guidance/saving-for-retirement-if-youre-aged-16-to-50': [
       ['Heading', 'Keep track of your State Pension'],
       ['Heading', 'Consider ways to improve your State Pension'],


### PR DESCRIPTION
Analysts want to be able to see any patterns of scrolling on specific
pages.

Trello card: https://trello.com/c/dOsIkYZi/1957-add-scroll-tracking-to-some-coronavirus-pages