### PR TITLE
Update copy in site wide banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -66,7 +66,7 @@
         } do %>
           <div class="global-bar-additional__text-govspeak govuk-grid-column-two-thirds govuk-!-padding-0">
             <p class="govuk-!-margin-bottom-1">Coronavirus guidance is being updated.</p>
-            <p class="govuk-!-margin-top-0">Read the <a href="/government/speeches/pm-address-to-the-nation-on-coronavirus-10-may-2020" class="govuk-link">Prime Minister’s address</a> for the latest information.</p>
+            <p class="govuk-!-margin-top-0">Read <a href="/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do" class="govuk-link">what you can and cannot do</a></p>
           </div>
         <% end %>
         <%= render 'notifications/covid_logos' %>


### PR DESCRIPTION
Update site wide banner text as per slack conversation with @samdub 

<img width="345" alt="Screenshot 2020-05-11 at 16 47 24" src="https://user-images.githubusercontent.com/17908089/81581838-310d5400-93a7-11ea-9763-69adfd95f082.png">
<img width="417" alt="Screenshot 2020-05-11 at 16 47 44" src="https://user-images.githubusercontent.com/17908089/81581836-3074bd80-93a7-11ea-9082-08e06001a87b.png">
