### PR TITLE
Add missing pages for known errors

### DIFF
--- a/app/assets/stylesheets/error-page-print.scss
+++ b/app/assets/stylesheets/error-page-print.scss
@@ -8,3 +8,4 @@ $is-print: true;
 @import "govuk_publishing_components/component_support";
 @import "govuk_publishing_components/components/print/button";
 @import "govuk_publishing_components/components/print/feedback";
+@import "govuk_publishing_components/components/_warning-text";

--- a/app/assets/stylesheets/error-page.scss
+++ b/app/assets/stylesheets/error-page.scss
@@ -6,3 +6,4 @@ $govuk-use-legacy-palette: false;
 @import "govuk_publishing_components/components/_cookie-banner";
 @import "govuk_publishing_components/components/_button";
 @import "govuk_publishing_components/components/_feedback";
+@import "govuk_publishing_components/components/_warning-text";

--- a/app/views/root/400.html.erb
+++ b/app/views/root/400.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Bad request - 400",
+    title: "Bad request",
     heading: "Bad request",
     intro: '',
     status_code: 400

--- a/app/views/root/401.html.erb
+++ b/app/views/root/401.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Unauthorized - 401",
+    title: "Unauthorized",
     heading: "You are not permitted to access this page",
     intro: '<p>This page is restricted to certain users only.</p>',
     status_code: 401

--- a/app/views/root/401.html.erb
+++ b/app/views/root/401.html.erb
@@ -1,0 +1,6 @@
+<%= render partial: "error_page", locals: {
+    title: "Unauthorized - 401",
+    heading: "You are not permitted to access this page",
+    intro: '<p>This page is restricted to certain users only.</p>',
+    status_code: 401
+} %>

--- a/app/views/root/403.html.erb
+++ b/app/views/root/403.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Forbidden - 403",
+    title: "Forbidden",
     heading: "You are not permitted to see this page",
     intro: '<p>This page is restricted to certain users only.</p>',
     status_code: 403

--- a/app/views/root/404.html.erb
+++ b/app/views/root/404.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Page not found - 404",
+    title: "Page not found",
     heading: "Page not found",
     intro: '<p>If you entered a web address please check it was correct.</p>
 

--- a/app/views/root/405.html.erb
+++ b/app/views/root/405.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "error_page", locals: {
+    title: "Method Not Allowed - 405",
+    heading: "You are not permitted to perform this action",
+    intro: '<p>This page does not support the action you requested.</p>',
+    status_code: 405
+} %>
+

--- a/app/views/root/405.html.erb
+++ b/app/views/root/405.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Method Not Allowed - 405",
+    title: "Method not allowed",
     heading: "You are not permitted to perform this action",
     intro: '<p>This page does not support the action you requested.</p>',
     status_code: 405

--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Page not found - 406",
+    title: "Page not found",
     heading: "The page you are looking for can't be found",
     intro: '<p>Please check that you have entered the correct web address, or try using the search box above or explore <a class="govuk-link" href="/">GOV.UK</a> to find the information you need.</p>',
     status_code: 406

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-    title: "Page no longer here - 410",
+    title: "Page no longer here",
     heading: "The page you are looking for is no longer here",
     intro: '<p>It may have been moved or replaced.</p>
       <p>Please check that you have entered the correct web address, or try using the search box above or explore <a class="govuk-link" href="/">GOV.UK</a> to find the information you need.</p>',

--- a/app/views/root/429.html.erb
+++ b/app/views/root/429.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "error_page", locals: {
+    title: "Sorry, there was a problem",
+    heading: "Sorry, there was a problem",
+    intro: '<p>You have made too many requests to this page.</p>
+      <p>Try again later.</p>',
+    status_code: 429
+} %>

--- a/app/views/root/500.html.erb
+++ b/app/views/root/500.html.erb
@@ -1,1 +1,6 @@
-<%= render partial: "error_page", locals: {status_code: 500} %>
+<%= render partial: "error_page", locals: {
+  title: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we're experiencing technical difficulties",
+  intro: "<p>Please try again in a few moments.</p>",
+  status_code: 500
+} %>

--- a/app/views/root/501.html.erb
+++ b/app/views/root/501.html.erb
@@ -1,1 +1,6 @@
-<%= render partial: "error_page", locals: {status_code: 501} %>
+<%= render partial: "error_page", locals: {
+  title: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we're experiencing technical difficulties",
+  intro: "<p>Please try again in a few moments.</p>",
+  status_code: 501
+} %>

--- a/app/views/root/503.html.erb
+++ b/app/views/root/503.html.erb
@@ -1,1 +1,6 @@
-<%= render partial: "error_page", locals: {status_code: 503} %>
+<%= render partial: "error_page", locals: {
+  title: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we're experiencing technical difficulties",
+  intro: "<p>Please try again in a few moments.</p>",
+  status_code: 503
+} %>

--- a/app/views/root/504.html.erb
+++ b/app/views/root/504.html.erb
@@ -1,1 +1,6 @@
-<%= render partial: "error_page", locals: {status_code: 504} %>
+<%= render partial: "error_page", locals: {
+  title: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we're experiencing technical difficulties",
+  intro: "<p>Please try again in a few moments.</p>",
+  status_code: 504
+} %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -34,11 +34,9 @@
 
   <%= render "govuk_publishing_components/components/feedback" %>
 
-<% if status_code %>
   <script type="text/javascript">
     window.httpStatusCode = '<%= status_code %>';
   </script>
-<% end %>
 </main>
 <% end %>
 

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -14,7 +14,6 @@
 
 <% content_for :wrapper_content do %>
 <main id="content" role="main" class="group">
-
   <header class="page-header group">
     <div>
       <h1><%= heading %></h1>
@@ -33,9 +32,7 @@
     </article>
   </div>
 
-<% if status_code.in?(400..499) %>
   <%= render "govuk_publishing_components/components/feedback" %>
-<% end %>
 
 <% if status_code %>
   <script type="text/javascript">

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -27,6 +27,10 @@
   <div class="article-container">
     <article role="article" class="group">
       <div class="inner">
+        <%= render "govuk_publishing_components/components/warning_text", {
+          text: "Status code: #{status_code}"
+        } %>
+
         <% if local_assigns.include?(:intro) %>
           <%= raw intro %>
         <% else %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -17,11 +17,7 @@
 
   <header class="page-header group">
     <div>
-      <% if local_assigns.include?(:heading) %>
-        <h1><%= heading %></h1>
-      <% else %>
-        <h1>Sorry, we're experiencing technical difficulties</h1>
-      <% end %>
+      <h1><%= heading %></h1>
     </div>
   </header>
   <div class="article-container">
@@ -31,12 +27,7 @@
           text: "Status code: #{status_code}"
         } %>
 
-        <% if local_assigns.include?(:intro) %>
-          <%= raw intro %>
-        <% else %>
-          <p>Please try again in a few moments.</p>
-        <% end %>
-
+        <%= raw intro %>
         <p>You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       </div>
     </article>

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -6,8 +6,7 @@ class Error4XXTest < ActionDispatch::IntegrationTest
 
     assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
-      assert page.has_selector?("title", text: "Page not found - 404 - GOV.UK", visible: :all)
-
+      assert page.has_selector?("title", text: "Page not found - GOV.UK", visible: :all)
       assert page.has_selector?("link[href='/static/static.css']", visible: :all)
     end
 
@@ -21,11 +20,11 @@ class Error4XXTest < ActionDispatch::IntegrationTest
 
       within "#wrapper" do
         assert page.has_selector?("h1", text: "Page not found")
+        assert page.has_selector?(".govuk-warning-text__text", text: "Status code: 404", visible: :all)
       end
 
       within "footer" do
         assert page.has_selector?(".footer-categories")
-
         assert page.has_selector?(".footer-meta")
       end
     end

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -6,8 +6,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
 
     assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
-      assert page.has_selector?("title", text: "Sorry, we're experiencing technical difficulties (500 error) - GOV.UK", visible: :all)
-
+      assert page.has_selector?("title", text: "Sorry, we're experiencing technical difficulties - GOV.UK", visible: :all)
       assert page.has_selector?("link[href='/static/static.css']", visible: :all)
     end
 
@@ -21,11 +20,11 @@ class Error5XXTest < ActionDispatch::IntegrationTest
 
       within "#wrapper" do
         assert page.has_selector?("h1", text: "Sorry, we're experiencing technical difficulties")
+        assert page.has_selector?(".govuk-warning-text__text", text: "Status code: 500", visible: :all)
       end
 
       within "footer" do
         assert page.has_selector?(".footer-categories")
-
         assert page.has_selector?(".footer-meta")
       end
     end


### PR DESCRIPTION
https://trello.com/c/Uzpw1bDA/243-document-how-error-pages-work-on-govuk

Related to: https://github.com/alphagov/slimmer/pull/245

Previously the use of Slimmer meant that all unexpected responses
were treated as '500 Internal Server Error', which is incorrect and
misleading, since the fault is often with the client. This adds new
error pages to cover all public error responses in the last 30 days.
Please see the commits for more details.

## Before
### 500
<img width="817" alt="Screenshot 2020-05-13 at 14 51 26" src="https://user-images.githubusercontent.com/9029009/81821108-62159200-9529-11ea-900c-233f715666ae.png">

### 404
<img width="657" alt="Screenshot 2020-05-13 at 14 52 21" src="https://user-images.githubusercontent.com/9029009/81821110-62ae2880-9529-11ea-87bc-0320cc18ccb6.png">

## After
### 500
<img width="658" alt="Screenshot 2020-05-13 at 14 51 46" src="https://user-images.githubusercontent.com/9029009/81821192-7c4f7000-9529-11ea-9e97-97dee4b7b4cb.png">

### 404
<img width="681" alt="Screenshot 2020-05-13 at 14 53 08" src="https://user-images.githubusercontent.com/9029009/81821197-7ce80680-9529-11ea-83d6-245e9ae1859d.png">
