### PR TITLE
Toggles additional banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -10,6 +10,9 @@
   # If true, banner is always_visible & does not disappear automatically after 3 pageviews
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
+  
+  # Toggle additional banner
+  show_additional_banner = true
 
   global_bar_classes = %w(global-bar dont-print)
 
@@ -60,25 +63,27 @@
         </p>
       <% end %>
     </div>
-    <div class="global-bar-additional global-bar-additional--show">
-      <div class="global-bar-additional__text govuk-width-container govuk-grid-row">
-        <%= render "govuk_publishing_components/components/govspeak", {
-        } do %>
-          <div class="global-bar-additional__text-govspeak govuk-grid-column-two-thirds govuk-!-padding-0">
-            <p class="govuk-!-margin-bottom-1">Coronavirus guidance is being updated.</p>
-            <p class="govuk-!-margin-top-0">Read <a href="/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do" class="govuk-link">what you can and cannot do</a></p>
-          </div>
-        <% end %>
-        <%= render 'notifications/covid_logos' %>
-      </div>
+    <% if show_additional_banner %>
+      <div class="global-bar-additional global-bar-additional--show">
+        <div class="global-bar-additional__text govuk-width-container govuk-grid-row">
+          <%= render "govuk_publishing_components/components/govspeak", {
+          } do %>
+            <div class="global-bar-additional__text-govspeak govuk-grid-column-two-thirds govuk-!-padding-0">
+              <p class="govuk-!-margin-bottom-1">Coronavirus guidance is being updated.</p>
+              <p class="govuk-!-margin-top-0">Read <a href="/government/publications/coronavirus-outbreak-faqs-what-you-can-and-cant-do" class="govuk-link">what you can and cannot do</a></p>
+            </div>
+          <% end %>
+          <%= render 'notifications/covid_logos' %>
+        </div>
 
-      <div class="govuk-width-container global-bar-dismiss-wrapper">
-        <a href="#hide-message"
-          class="<%= dismiss_classes.join(' ') %>"
-          role="button"
-          aria-controls="global-bar">Hide message</a>
+        <div class="govuk-width-container global-bar-dismiss-wrapper">
+          <a href="#hide-message"
+            class="<%= dismiss_classes.join(' ') %>"
+            role="button"
+            aria-controls="global-bar">Hide message</a>
+        </div>
       </div>
-    </div>
+    <% end %>
   </div>
   <!--<![endif]-->
 <% end %>


### PR DESCRIPTION
Provide a toggle to switch off the emergency banner message area (the bit in the red box in the screenshot). The main darker emergency banner section with the arrow link should remain.

We no longer need a holding message as guidance has been updated.

https://trello.com/c/u4L3Xoet/278-waiting-on-confirmation-switch-off-the-emergency-banner-message-area