### PR TITLE
Switch dismissable banner off

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -10,9 +10,9 @@
   # If true, banner is always_visible & does not disappear automatically after 3 pageviews
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
-  
+
   # Toggle additional banner
-  show_additional_banner = true
+  show_additional_banner = false
 
   global_bar_classes = %w(global-bar dont-print)
 


### PR DESCRIPTION
This is a follow up PR on the work done by @DilwoarH here #2170
We have been given the go-ahead to switch the dismissible banner off for good.

This toggles the banner off by setting the `show_additional_banner` flag to `false`

https://trello.com/c/u4L3Xoet