### PR TITLE
Adding google analytics scroll depth tracking

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -393,6 +393,13 @@
     ],
     '/government/publications/vat-for-businesses-if-theres-no-brexit-deal/vat-for-businesses-if-theres-no-brexit-deal': [
       ['Heading', 'UK businesses importing goods from the EU']
+    ],
+    '/guidance/answers-to-the-most-common-topics-asked-about-by-the-public-for-the-coronavirus-press-conference': [
+      ['Percent', 20],
+      ['Percent', 40],
+      ['Percent', 60],
+      ['Percent', 80],
+      ['Percent', 100]
     ]
   };
 


### PR DESCRIPTION
Adding the tracking to the new guidance/answers-to-the-most-common-topics-asked-about-by-the-public-for-the-coronavirus-press-conference page

Added at the end of the config variable and set to percentage of scrolling in 20% increments

This PR replaces: https://github.com/alphagov/static/pull/2175 (I fixed a minor comma error)