### PR TITLE
Specify asset host with ASSET_HOST env var over GOVUK_ASSET_ROOT

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module Static
     # Enable the asset pipeline
     config.assets.enabled = true
 
-    config.assets.prefix = "/static"
+    config.assets.prefix = "/assets/static"
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = "1.0"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   # rev filenames for assets
   config.assets.digest = false
 
-  config.asset_host = ENV["GOVUK_ASSET_ROOT"] || Plek.current.find("static")
+  config.asset_host = ENV["ASSET_HOST"] || ENV["GOVUK_ASSET_ROOT"] || Plek.current.find("static")
 
   # Expands the lines which load the assets
   config.assets.debug = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
   # apps we have the hostname set at the time of the app being built so can't
   # be set up in the app.json
   if ENV["HEROKU_APP_NAME"]
-    ENV["GOVUK_ASSET_ROOT"] = "https://#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("GOVUK_ASSET_ROOT")
+    ENV["ASSET_HOST"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("ASSET_HOST")
     ENV["PLEK_SERVICE_STATIC_URI"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("PLEK_SERVICE_STATIC_URI")
   end
 
@@ -64,7 +64,7 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners
   config.active_support.deprecation = :notify
 
-  config.action_controller.asset_host = ENV["GOVUK_ASSET_HOST"]
+  config.action_controller.asset_host = ENV["ASSET_HOST"] || ENV["GOVUK_ASSET_ROOT"]
 
   config.eager_load = true
 

--- a/lib/tasks/asset_compile.rake
+++ b/lib/tasks/asset_compile.rake
@@ -7,7 +7,7 @@ end
 namespace :asset_precompile do
   desc "Create aliases for assets with random/digest filenames"
   task create_non_digest_assets: :environment do
-    relative_asset_path = "public/static"
+    relative_asset_path = "public/assets/static"
     manifest_path = Dir.glob(Rails.root.join(relative_asset_path, ".sprockets-manifest-*.json")).first
 
     manifest_data = JSON.parse(File.read(manifest_path))

--- a/test/integration/icon_redirects_test.rb
+++ b/test/integration/icon_redirects_test.rb
@@ -12,11 +12,11 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
       get "/#{file}"
       assert_equal 301, last_response.status
       # In development and test mode the asset pipeline doesn't add the hashes to the URLs
-      assert_equal "http://example.org/static/#{file}", last_response.location
+      assert_equal "http://example.org/assets/static/#{file}", last_response.location
     end
 
     should "redirect #{file} to a location that exists" do
-      get "/static/#{file}"
+      get "/assets/static/#{file}"
       assert_equal 200, last_response.status
       assert last_response.body.size > 100
     end
@@ -24,7 +24,7 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
     should "ignore query string when redirecting #{file}" do
       get "/#{file}?foo=bar"
       assert_equal 301, last_response.status
-      assert_equal "http://example.org/static/#{file}", last_response.location
+      assert_equal "http://example.org/assets/static/#{file}", last_response.location
     end
   end
 
@@ -38,7 +38,7 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
       get "/#{file}"
       assert_equal 301, last_response.status
       # In development and test mode the asset pipeline doesn't add the hashes to the URLs
-      assert_equal "http://example.org/static/apple-touch-icon.png", last_response.location
+      assert_equal "http://example.org/assets/static/apple-touch-icon.png", last_response.location
     end
   end
 end

--- a/test/integration/templates/chromeless_test.rb
+++ b/test/integration/templates/chromeless_test.rb
@@ -7,7 +7,7 @@ class ChromelessTest < ActionDispatch::IntegrationTest
     within "head", visible: :all do
       assert page.has_selector?("title", text: "GOV.UK - The best place to find government services and information", visible: :all)
 
-      assert page.has_selector?("link[href='/static/header-footer-only.css']", visible: :all)
+      assert page.has_selector?("link[href$='header-footer-only.css']", visible: :all)
     end
 
     within "body" do
@@ -23,8 +23,8 @@ class ChromelessTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".footer-meta")
       end
 
-      assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-      assert page.has_selector?("script[src='/static/header-footer-only.js']", visible: :all)
+      assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+      assert page.has_selector?("script[src$='header-footer-only.js']", visible: :all)
     end
   end
 end

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -7,7 +7,7 @@ class Error4XXTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
       assert page.has_selector?("title", text: "Page not found - GOV.UK", visible: :all)
-      assert page.has_selector?("link[href='/static/static.css']", visible: :all)
+      assert page.has_selector?("link[href$='static.css']", visible: :all)
     end
 
     within "body.mainstream.error" do
@@ -29,7 +29,7 @@ class Error4XXTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-    assert page.has_selector?("script[src='/static/application.js']", visible: :all)
+    assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+    assert page.has_selector?("script[src$='application.js']", visible: :all)
   end
 end

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -7,7 +7,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
     assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
       assert page.has_selector?("title", text: "Sorry, we're experiencing technical difficulties - GOV.UK", visible: :all)
-      assert page.has_selector?("link[href='/static/static.css']", visible: :all)
+      assert page.has_selector?("link[href$='static.css']", visible: :all)
     end
 
     within "body.mainstream.error" do
@@ -29,7 +29,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-    assert page.has_selector?("script[src='/static/application.js']", visible: :all)
+    assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+    assert page.has_selector?("script[src$='application.js']", visible: :all)
   end
 end

--- a/test/integration/templates/header_footer_only_test.rb
+++ b/test/integration/templates/header_footer_only_test.rb
@@ -7,7 +7,7 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
     within "head", visible: :all do
       assert page.has_selector?("title", text: "GOV.UK - The best place to find government services and information", visible: :all)
 
-      assert page.has_selector?("link[href='/static/header-footer-only.css']", visible: :all)
+      assert page.has_selector?("link[href$='header-footer-only.css']", visible: :all)
     end
 
     within "body" do
@@ -26,8 +26,8 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".footer-meta")
       end
 
-      assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-      assert page.has_selector?("script[src='/static/header-footer-only.js']", visible: :all)
+      assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+      assert page.has_selector?("script[src$='header-footer-only.js']", visible: :all)
     end
   end
 end

--- a/test/integration/templates/homepage_test.rb
+++ b/test/integration/templates/homepage_test.rb
@@ -7,7 +7,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
     within "head", visible: :all do
       assert page.has_selector?("title", text: "GOV.UK - The best place to find government services and information", visible: :all)
 
-      assert page.has_selector?("link[href='/static/static.css']", visible: :all)
+      assert page.has_selector?("link[href$='static.css']", visible: :all)
     end
 
     within "body" do
@@ -27,7 +27,7 @@ class HomepageTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-    assert page.has_selector?("script[src='/static/application.js']", visible: :all)
+    assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+    assert page.has_selector?("script[src$='application.js']", visible: :all)
   end
 end

--- a/test/integration/templates/wrapper_test.rb
+++ b/test/integration/templates/wrapper_test.rb
@@ -7,7 +7,7 @@ class WrapperTest < ActionDispatch::IntegrationTest
     within "head", visible: :all do
       assert page.has_selector?("title", text: "GOV.UK - The best place to find government services and information", visible: :all)
 
-      assert page.has_selector?("link[href='/static/static.css']", visible: :all)
+      assert page.has_selector?("link[href$='static.css']", visible: :all)
     end
 
     within "body" do
@@ -27,7 +27,7 @@ class WrapperTest < ActionDispatch::IntegrationTest
       end
     end
 
-    assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-    assert page.has_selector?("script[src='/static/application.js']", visible: :all)
+    assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+    assert page.has_selector?("script[src$='application.js']", visible: :all)
   end
 end

--- a/test/integration/templates/wrapper_with_js_last.rb
+++ b/test/integration/templates/wrapper_with_js_last.rb
@@ -7,7 +7,7 @@ class WrapperWithJSLastTest < ActionDispatch::IntegrationTest
     within "head", visible: :all do
       assert page.has_selector?("title", text: "GOV.UK - The best place to find government services and information", visible: :all)
 
-      assert page.has_selector?("link[href='/static/static.css']", visible: :all)
+      assert page.has_selector?("link[href$='static.css']", visible: :all)
     end
 
     within "body" do
@@ -26,8 +26,8 @@ class WrapperWithJSLastTest < ActionDispatch::IntegrationTest
         assert page.has_selector?(".footer-meta")
       end
 
-      assert page.has_selector?("script[src='/static/libs/jquery/jquery-1.12.4.js']", visible: :all)
-      assert page.has_selector?("script[src='/static/application.js']", visible: :all)
+      assert page.has_selector?("script[src$='libs/jquery/jquery-1.12.4.js']", visible: :all)
+      assert page.has_selector?("script[src$='application.js']", visible: :all)
     end
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This is marked as a draft until the following PR's are merged (and in puppets case, deployed):

- [x] https://github.com/alphagov/govuk-puppet/pull/10360
- [x] https://github.com/alphagov/publishing-e2e-tests/pull/383
- [x] https://github.com/alphagov/govuk-docker/pull/351

As part of the work to enable RFC 115 [1] we intend to switch static
from serving assets on the asset hostname to instead use the regular www
hostname. Static, unlike other GOV.UK applications, requires a host name
to be set so that the live version of static can be used in development
environments and heroku preview environments.

Both environment variables are in use in these changes so that static
can continue to operate under both configurations.

[1]: https://github.com/alphagov/govuk-rfcs/blob/45e09c088bfde6c1d4dfb68f9bc1c635f63c9a39/rfc-115-enabling-http2-on-govuk.md