### PR TITLE
Update modules script

### DIFF
--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,4 +1,4 @@
-// = require govuk/modules
+// = require govuk_publishing_components/modules
 // = require modules/global-bar
 // = require modules/sticky-element-container
 // = require modules/toggle


### PR DESCRIPTION
## What
Use the modules script from [`govuk_publishing_components`](https://github.com/alphagov/govuk_publishing_components/blob/master/app/assets/javascripts/govuk_publishing_components/modules.js) instead of [`govuk_frontend_toolkit`](https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/modules.js).

## Why
We recently [updated the `modules.js`](https://github.com/alphagov/govuk_publishing_components/pull/1472) in `govuk_publishing_components` without realising that `static` is still using the `modules.js` from `govuk_frontend_toolkit`.