### PR TITLE
Add comment to sass

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -3,6 +3,8 @@ $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/components/_cookie-banner";
+// collections uses the action-link component and relies upon this line, see
+// https://github.com/alphagov/collections/pull/1754
 @import "govuk_publishing_components/components/_action-link";
 
 /* govuk_frontend_toolkit includes */


### PR DESCRIPTION
Static has the Sass for the action link component because we're using it in the global banner on every page of GOV.UK. Collections is also using the action link component. Rather than duplicate the CSS, collections is relying on the copy in static. 

This PR adds a comment to the Sass to explain that to prevent someone from removing the Sass from static without putting it into collections first.

Should have been part of https://github.com/alphagov/static/pull/2192. See also https://github.com/alphagov/collections/pull/1754