### PR TITLE
Call cookie banner component JS

### DIFF
--- a/app/assets/javascripts/start-modules.js
+++ b/app/assets/javascripts/start-modules.js
@@ -1,4 +1,5 @@
 // = require govuk_publishing_components/modules
+// = require govuk_publishing_components/components/cookie-banner
 // = require modules/global-bar
 // = require modules/sticky-element-container
 // = require modules/toggle


### PR DESCRIPTION
Calls the cookie banner component JS wherever the JS in static references the related JS in the gem's lib dir.