### PR TITLE
Migrate auto track event from toolkit

### DIFF
--- a/app/assets/javascripts/analytics.js
+++ b/app/assets/javascripts/analytics.js
@@ -7,6 +7,7 @@
 //= require analytics_toolkit/mailto-link-tracker
 //= require analytics_toolkit/external-link-tracker
 //= require analytics_toolkit/download-link-tracker
+//= require analytics_toolkit/auto-track-event
 
 //= require analytics/page-content
 //= require analytics/custom-dimensions

--- a/app/assets/javascripts/analytics_toolkit/auto-track-event.js
+++ b/app/assets/javascripts/analytics_toolkit/auto-track-event.js
@@ -1,0 +1,30 @@
+;(function (global) {
+  'use strict'
+
+  var GOVUK = global.GOVUK || {}
+  GOVUK.Modules = GOVUK.Modules || {}
+
+  GOVUK.Modules.AutoTrackEvent = function () {
+    this.start = function (element) {
+      var options = { nonInteraction: 1 } // automatic events shouldn't affect bounce rate
+      var category = element.data('track-category')
+      var action = element.data('track-action')
+      var label = element.data('track-label')
+      var value = element.data('track-value')
+
+      if (typeof label === 'string') {
+        options.label = label
+      }
+
+      if (value || value === 0) {
+        options.value = value
+      }
+
+      if (GOVUK.analytics && GOVUK.analytics.trackEvent) {
+        GOVUK.analytics.trackEvent(category, action, options)
+      }
+    }
+  }
+
+  global.GOVUK = GOVUK
+})(window)

--- a/spec/javascripts/analytics_toolkit/auto-track-event.spec.js
+++ b/spec/javascripts/analytics_toolkit/auto-track-event.spec.js
@@ -1,0 +1,54 @@
+/* global describe it expect beforeEach afterEach spyOn */
+
+var $ = window.jQuery
+
+describe('An auto event tracker', function () {
+  'use strict'
+  var GOVUK = window.GOVUK
+
+  var tracker,
+    element
+
+  beforeEach(function () {
+    GOVUK.analytics = {trackEvent: function () {}}
+    tracker = new GOVUK.Modules.AutoTrackEvent()
+  })
+
+  afterEach(function () {
+    delete GOVUK.analytics
+  })
+
+  it('tracks non-interactive events on start', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    element = $(
+      '<div ' +
+        'data-track-category="category"' +
+        'data-track-action="action">' +
+        'Some content' +
+      '</div>'
+    )
+
+    tracker.start(element)
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category', 'action', {nonInteraction: 1})
+  })
+
+  it('can track non-interactive events with optional label and value', function () {
+    spyOn(GOVUK.analytics, 'trackEvent')
+
+    element = $(
+      '<div ' +
+        'data-track-category="category"' +
+        'data-track-action="action"' +
+        'data-track-label="label"' +
+        'data-track-value="10">' +
+        'Some content' +
+      '</div>'
+    )
+
+    tracker.start(element)
+    expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith(
+      'category', 'action', {label: 'label', value: 10, nonInteraction: 1})
+  })
+})


### PR DESCRIPTION
After [migrating `frontend` from `wrapper` to `core_layout`](https://github.com/alphagov/frontend/pull/2154) we ended up in a position where `auto-track-event` was missing from our analytics bundle in `static`, causing [a gap in our GA data](https://govuk.zendesk.com/agent/tickets/4096617).

To fix this I migrated the `auto-track-event` from `govuk_frontend_toolkit` to `static`, as this was [planned work in the GOV.UK Frontend and Accessibility backlog](https://trello.com/c/TMYS2FKT/222-migrate-javascript-from-toolkit-into-static) anyway, and added it to the common analytics bundle in static making it available to `frontend` again.

You can test this by checking for `GOVUK.Modules.AutoTrackEvent` in the browser console in `frontend`.