### PR TITLE
Switch off additional banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -15,7 +15,7 @@
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
 
-  show_additional_banner = true
+  show_additional_banner = false
 
   global_bar_classes = %w(global-bar dont-print)
 


### PR DESCRIPTION
## What
We should switch off the message area in the Coronavirus emergency banner (the dark grey banner), leaving the main bit (the black banner) in place.

![image](https://user-images.githubusercontent.com/7116819/85856851-a8a90e00-b7b0-11ea-8c3b-1b605392e083.png)


## Why
Guidance has been updated so we no longer need to direct people to the PM's speech.

https://trello.com/c/eAlNwog6