### PR TITLE
Disable additional banner section

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -15,7 +15,7 @@
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
 
-  show_additional_banner = true
+  show_additional_banner = false
 
   global_bar_classes = %w(global-bar dont-print)
 


### PR DESCRIPTION
My thought is to leave the markup section as is, as this will make it _much_ easier for messages to go up at short notice.