### PR TITLE
Stop covid banner on transition pages

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -26,7 +26,9 @@ var globalBarInit = {
 
   urlBlockList: function() {
     var paths = [
-      "^/coronavirus/.*$"
+      "^/coronavirus/.*$",
+      "^/transition(.cy)?$",
+      "^/transition-check/.*$",
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
We don't want to see the coronavirus banner on:
- /transition
- /transition.cy
- /transition-check/questions
- /transition-check/results (or any other checker URLs that appear)

https://trello.com/c/sIFjKsm9/306-stop-covid-banner-from-appearing-on-transition-pages