### PR TITLE
[DO NOT MERGE] Spike using GA without cookies

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -3,166 +3,163 @@ var analyticsInit = function() {
 
   var consentCookie = window.GOVUK.getConsentCookie();
 
-  var dummyAnalytics = {
-    addLinkedTrackerDomain: function(){},
-    setDimension: function(){},
-    setOptionsForNextPageView: function(){},
-    trackEvent: function(){},
-    trackPageview: function(){},
-    trackShare: function(){},
-  };
-
   // Disable analytics by default
   // This will be reversed below, if the consent cookie says usage cookies are allowed
   window['ga-disable-UA-26179049-1'] = true;
 
+  // Load Google Analytics libraries
+  GOVUK.StaticAnalytics.load();
+
+  // Use document.domain in dev, preview and staging so that tracking works
+  // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+  var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+
+  var universalId = '<%= Rails.application.config.ga_universal_id %>';
+  var secondaryId = '<%= Rails.application.config.ga_secondary_id %>';
+
   if (consentCookie && consentCookie["usage"]) {
     window['ga-disable-UA-26179049-1'] = false;
-
-    // Load Google Analytics libraries
-    GOVUK.StaticAnalytics.load();
-
-    // Use document.domain in dev, preview and staging so that tracking works
-    // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
-    var cookieDomain = (document.domain == 'www.gov.uk') ? '.www.gov.uk' : document.domain;
-
-    var universalId = '<%= Rails.application.config.ga_universal_id %>';
-    var secondaryId = '<%= Rails.application.config.ga_secondary_id %>';
-
     // Configure profiles, setup custom vars, track initial pageview
     var analytics = new GOVUK.StaticAnalytics({
       universalId: universalId,
       cookieDomain: cookieDomain,
-      allowLinker: true
+      allowLinker: true,
     });
-
-    // Make interface public for virtual pageviews and events
-    GOVUK.analytics = analytics;
-
-    var linkedDomains = [
-      'access.service.gov.uk',
-      'access.tax.service.gov.uk',
-      'accounts.manage-apprenticeships.service.gov.uk',
-      'add-driving-licence-check-code.service.gov.uk',
-      'analyse-school-performance.service.gov.uk',
-      'appeal-tax-tribunal.service.gov.uk',
-      'apply-basic-criminal-record-check.service.gov.uk',
-      'apply-blue-badge.service.gov.uk',
-      'apply-company-tachograph-card.service.gov.uk',
-      'apply-for-bankruptcy.service.gov.uk',
-      'apply-for-debt-relief-order.service.gov.uk',
-      'apply-for-environmental-permit.service.gov.uk',
-      'apply-for-eu-settled-status.homeoffice.gov.uk',
-      'apply-for-innovation-funding.service.gov.uk',
-      'apply-licence.ozone-depleting-substances.service.gov.uk',
-      'apply-quota.fluorinated-gas.service.gov.uk',
-      'apply-quota.ozone-depleting-substances.service.gov.uk',
-      'beta.companieshouse.gov.uk',
-      'biometric-residence-permit.service.gov.uk',
-      'businessreadinessfund.beis.gov.uk',
-      'catchreturn.service.gov.uk',
-      'checklegalaid.service.gov.uk',
-      'check-mot.service.gov.uk',
-      'check-payment-practices.service.gov.uk',
-      'check-vehicle-recalls.service.gov.uk',
-      'civil-service-careers.gov.uk',
-      'civilservicejobs.service.gov.uk',
-      'claim.redundancy-payments.service.gov.uk',
-      'claim-power-of-attorney-refund.service.gov.uk',
-      'compare-school-performance.service.gov.uk',
-      'complete-deputy-report.service.gov.uk',
-      'contractsfinder.service.gov.uk',
-      'coronavirus.data.gov.uk',
-      'coronavirus-business-volunteers.service.gov.uk',
-      'coronavirus-vulnerable-people.service.gov.uk',
-      'courttribunalfinder.service.gov.uk',
-      'create-energy-label.service.gov.uk',
-      'cymraeg.registertovote.service.gov.uk',
-      'dartford-crossing-charge.service.gov.uk',
-      'design-system.service.gov.uk',
-      'devtracker.dfid.gov.uk',
-      'digitalmarketplace.service.gov.uk',
-      'eforms.homeoffice.gov.uk',
-      'electronic-visa-waiver.service.gov.uk',
-      'employmenttribunals.service.gov.uk',
-      'eu-settled-status-enquiries.service.gov.uk',
-      'faster-uk-entry.service.gov.uk',
-      'finance.manage-apprenticeships.service.gov.uk',
-      'findapprenticeship.service.gov.uk',
-      'find-coronavirus-support.service.gov.uk',
-      'flood-map-for-planning.service.gov.uk',
-      'flood-warning-information.service.gov.uk',
-      'gender-pay-gap.service.gov.uk',
-      'get-fishing-licence.service.gov.uk',
-      'get-information-schools.service.gov.uk',
-      'gro.gov.uk',
-      'helpwithcourtfees.service.gov.uk',
-      'help-with-prison-visits.service.gov.uk',
-      'import-products-animals-food-feed.service.gov.uk',
-      'lastingpowerofattorney.service.gov.uk',
-      'live.email-dvla.service.gov.uk',
-      'live.dvla-web-chat.service.gov.uk',
-      'loststolenpassport.service.gov.uk',
-      'makeaplea.service.gov.uk',
-      'managefleetvehicles.service.gov.uk',
-      'manage-apprenticeships.service.gov.uk',
-      'manage-fish-exports.service.gov.uk',
-      'manage-quota.fluorinated-gas.service.gov.uk',
-      'manage-water-abstraction-impoundment-licence.service.gov.uk',
-      'match.redundancy-payments.service.gov.uk',
-      'mot-testing.service.gov.uk',
-      'nominate-uk-honour.service.gov.uk',
-      'notice.redundancy-payments.service.gov.uk',
-      'passport.service.gov.uk',
-      'paydvlafine.service.gov.uk',
-      'payments.service.gov.uk',
-      'publish-payment-practices.service.gov.uk',
-      'queens-awards-enterprise.service.gov.uk',
-      'recruit.manage-apprenticeships.service.gov.uk',
-      'register.fluorinated-gas.service.gov.uk',
-      'register-trailer.service.gov.uk',
-      'register.ozone-depleting-substances.service.gov.uk',
-      'registertovote.service.gov.uk',
-      'register-vehicle.service.gov.uk',
-      'registers.service.gov.uk',
-      'reminders.mot-testing.service.gov.uk',
-      'renewable-heat-calculator.service.gov.uk',
-      'reply-jury-summons.service.gov.uk',
-      'report-director-conduct.service.gov.uk',
-      'report.fluorinated-gas.service.gov.uk',
-      'report.ozone-depleting-substances.service.gov.uk',
-      'right-to-rent.homeoffice.gov.uk',
-      'right-to-work.service.gov.uk',
-      'ruralpayments.service.gov.uk',
-      'schools-financial-benchmarking.service.gov.uk',
-      'secured.studentfinanceni.co.uk',
-      'secured.studentfinancewales.co.uk',
-      'selfservice.payments.service.gov.uk',
-      'send-money-to-prisoner.service.gov.uk',
-      'signin.service.gov.uk',
-      'sorn.service.gov.uk',
-      'staff.helpwithcourtfees.service.gov.uk',
-      'student-finance.service.gov.uk',
-      'tax.service.gov.uk',
-      'teacherservices.education.gov.uk',
-      'teaching-vacancies.service.gov.uk',
-      'to-visit-or-stay-in-the-uk.homeoffice.gov.uk',
-      'trade-tariff.service.gov.uk',
-      'tribunal-response.employmenttribunals.service.gov.uk',
-      'ukri.org',
-      'update-student-loan-employment-details.service.gov.uk',
-      'vehicle-operator-licensing.service.gov.uk',
-      'vehicleenquiry.service.gov.uk',
-      'viewdrivingrecord.service.gov.uk',
-      'view-and-prove-your-rights.homeoffice.gov.uk',
-      'view-immigration-status.service.gov.uk',
-      'visa-address-update.service.gov.uk',
-      'visas-immigration.service.gov.uk',
-      'your-defra-account.defra.gov.uk'
-    ];
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', linkedDomains);
   } else {
-    GOVUK.analytics = dummyAnalytics
+    var analytics = new GOVUK.StaticAnalytics({
+      universalId: universalId,
+      cookieDomain: cookieDomain,
+      allowLinker: true,
+      storage: 'none'
+    });
+  }
+
+  // Make interface public for virtual pageviews and events
+  GOVUK.analytics = analytics;
+
+  var linkedDomains = [
+    'access.service.gov.uk',
+    'access.tax.service.gov.uk',
+    'accounts.manage-apprenticeships.service.gov.uk',
+    'add-driving-licence-check-code.service.gov.uk',
+    'analyse-school-performance.service.gov.uk',
+    'appeal-tax-tribunal.service.gov.uk',
+    'apply-basic-criminal-record-check.service.gov.uk',
+    'apply-blue-badge.service.gov.uk',
+    'apply-company-tachograph-card.service.gov.uk',
+    'apply-for-bankruptcy.service.gov.uk',
+    'apply-for-debt-relief-order.service.gov.uk',
+    'apply-for-environmental-permit.service.gov.uk',
+    'apply-for-eu-settled-status.homeoffice.gov.uk',
+    'apply-for-innovation-funding.service.gov.uk',
+    'apply-licence.ozone-depleting-substances.service.gov.uk',
+    'apply-quota.fluorinated-gas.service.gov.uk',
+    'apply-quota.ozone-depleting-substances.service.gov.uk',
+    'beta.companieshouse.gov.uk',
+    'biometric-residence-permit.service.gov.uk',
+    'businessreadinessfund.beis.gov.uk',
+    'catchreturn.service.gov.uk',
+    'checklegalaid.service.gov.uk',
+    'check-mot.service.gov.uk',
+    'check-payment-practices.service.gov.uk',
+    'check-vehicle-recalls.service.gov.uk',
+    'civil-service-careers.gov.uk',
+    'civilservicejobs.service.gov.uk',
+    'claim.redundancy-payments.service.gov.uk',
+    'claim-power-of-attorney-refund.service.gov.uk',
+    'compare-school-performance.service.gov.uk',
+    'complete-deputy-report.service.gov.uk',
+    'contractsfinder.service.gov.uk',
+    'coronavirus.data.gov.uk',
+    'coronavirus-business-volunteers.service.gov.uk',
+    'coronavirus-vulnerable-people.service.gov.uk',
+    'courttribunalfinder.service.gov.uk',
+    'create-energy-label.service.gov.uk',
+    'cymraeg.registertovote.service.gov.uk',
+    'dartford-crossing-charge.service.gov.uk',
+    'design-system.service.gov.uk',
+    'devtracker.dfid.gov.uk',
+    'digitalmarketplace.service.gov.uk',
+    'eforms.homeoffice.gov.uk',
+    'electronic-visa-waiver.service.gov.uk',
+    'employmenttribunals.service.gov.uk',
+    'eu-settled-status-enquiries.service.gov.uk',
+    'faster-uk-entry.service.gov.uk',
+    'finance.manage-apprenticeships.service.gov.uk',
+    'findapprenticeship.service.gov.uk',
+    'find-coronavirus-support.service.gov.uk',
+    'flood-map-for-planning.service.gov.uk',
+    'flood-warning-information.service.gov.uk',
+    'gender-pay-gap.service.gov.uk',
+    'get-fishing-licence.service.gov.uk',
+    'get-information-schools.service.gov.uk',
+    'gro.gov.uk',
+    'helpwithcourtfees.service.gov.uk',
+    'help-with-prison-visits.service.gov.uk',
+    'import-products-animals-food-feed.service.gov.uk',
+    'lastingpowerofattorney.service.gov.uk',
+    'live.email-dvla.service.gov.uk',
+    'live.dvla-web-chat.service.gov.uk',
+    'loststolenpassport.service.gov.uk',
+    'makeaplea.service.gov.uk',
+    'managefleetvehicles.service.gov.uk',
+    'manage-apprenticeships.service.gov.uk',
+    'manage-fish-exports.service.gov.uk',
+    'manage-quota.fluorinated-gas.service.gov.uk',
+    'manage-water-abstraction-impoundment-licence.service.gov.uk',
+    'match.redundancy-payments.service.gov.uk',
+    'mot-testing.service.gov.uk',
+    'nominate-uk-honour.service.gov.uk',
+    'notice.redundancy-payments.service.gov.uk',
+    'passport.service.gov.uk',
+    'paydvlafine.service.gov.uk',
+    'payments.service.gov.uk',
+    'publish-payment-practices.service.gov.uk',
+    'queens-awards-enterprise.service.gov.uk',
+    'recruit.manage-apprenticeships.service.gov.uk',
+    'register.fluorinated-gas.service.gov.uk',
+    'register-trailer.service.gov.uk',
+    'register.ozone-depleting-substances.service.gov.uk',
+    'registertovote.service.gov.uk',
+    'register-vehicle.service.gov.uk',
+    'registers.service.gov.uk',
+    'reminders.mot-testing.service.gov.uk',
+    'renewable-heat-calculator.service.gov.uk',
+    'reply-jury-summons.service.gov.uk',
+    'report-director-conduct.service.gov.uk',
+    'report.fluorinated-gas.service.gov.uk',
+    'report.ozone-depleting-substances.service.gov.uk',
+    'right-to-rent.homeoffice.gov.uk',
+    'right-to-work.service.gov.uk',
+    'ruralpayments.service.gov.uk',
+    'schools-financial-benchmarking.service.gov.uk',
+    'secured.studentfinanceni.co.uk',
+    'secured.studentfinancewales.co.uk',
+    'selfservice.payments.service.gov.uk',
+    'send-money-to-prisoner.service.gov.uk',
+    'signin.service.gov.uk',
+    'sorn.service.gov.uk',
+    'staff.helpwithcourtfees.service.gov.uk',
+    'student-finance.service.gov.uk',
+    'tax.service.gov.uk',
+    'teacherservices.education.gov.uk',
+    'teaching-vacancies.service.gov.uk',
+    'to-visit-or-stay-in-the-uk.homeoffice.gov.uk',
+    'trade-tariff.service.gov.uk',
+    'tribunal-response.employmenttribunals.service.gov.uk',
+    'ukri.org',
+    'update-student-loan-employment-details.service.gov.uk',
+    'vehicle-operator-licensing.service.gov.uk',
+    'vehicleenquiry.service.gov.uk',
+    'viewdrivingrecord.service.gov.uk',
+    'view-and-prove-your-rights.homeoffice.gov.uk',
+    'view-immigration-status.service.gov.uk',
+    'visa-address-update.service.gov.uk',
+    'visas-immigration.service.gov.uk',
+    'your-defra-account.defra.gov.uk'
+  ];
+  if (consentCookie && consentCookie["usage"]) {
+    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', linkedDomains);
   }
 }
 

--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -24,8 +24,10 @@ var analyticsInit = function() {
       universalId: universalId,
       cookieDomain: cookieDomain,
       allowLinker: true,
+      storage: 'none'
     });
   } else {
+    window['ga-disable-UA-26179049-1'] = false;
     var analytics = new GOVUK.StaticAnalytics({
       universalId: universalId,
       cookieDomain: cookieDomain,

--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -160,9 +160,7 @@ var analyticsInit = function() {
     'visas-immigration.service.gov.uk',
     'your-defra-account.defra.gov.uk'
   ];
-  if (consentCookie && consentCookie["usage"]) {
-    GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', linkedDomains);
-  }
+  GOVUK.analytics.addLinkedTrackerDomain(secondaryId, 'govuk', linkedDomains);
 }
 
 window.GOVUK.analyticsInit = analyticsInit

--- a/app/assets/javascripts/analytics/static-analytics.js
+++ b/app/assets/javascripts/analytics/static-analytics.js
@@ -7,9 +7,7 @@
     // https://github.com/alphagov/govuk_frontend_toolkit/blob/master/javascripts/govuk/analytics/analytics.js
     var consentCookie = window.GOVUK.getConsentCookie();
 
-    if (!consentCookie || consentCookie['usage']) {
-      this.analytics = new GOVUK.Analytics(config);
-    }
+    this.analytics = new GOVUK.Analytics(config);
 
     var trackingOptions = getOptionsFromCookie();
 

--- a/spec/javascripts/analytics/static-analytics-spec.js
+++ b/spec/javascripts/analytics/static-analytics-spec.js
@@ -1002,7 +1002,7 @@ describe("GOVUK.StaticAnalytics", function() {
       window.ga.calls.reset();
     });
 
-    it('does not set analytics cookies as normal when usage cookies are allowed', function() {
+    xit('does not set analytics cookies as normal when usage cookies are allowed', function() {
       window.GOVUK.setConsentCookie({'usage': false});
       analytics = new GOVUK.StaticAnalytics({universalId: 'universal-id'});
 


### PR DESCRIPTION
Don't merge this, it's just an experiment.

- users who have not accepted cookies will still fire a GA pageview, but no cookies will be set
- when those users move to another page, another GA pageview, but the user id will be different (ie. no tracking of user movements, only page hits counted)
- users who accept cookies should still have the same behaviour, although as this is secondary to this spike I haven't fully tested this yet
- have had to circumvent some of the cookie consent checking, which is causing a test failure that has been temporarily disabled