### PR TITLE
scheduled_maintenance: Link to StatusPage, not the old GOV.UK blog

### DIFF
--- a/app/views/root/scheduled_maintenance.html.erb
+++ b/app/views/root/scheduled_maintenance.html.erb
@@ -8,6 +8,6 @@
   heading: 'GOV.UK publishing tools are currently unavailable due to scheduled maintenance',
   intro: '<p>Contact the GOV.UK lead (Single Point Of Contact) for your department or agency if you need to publish something in an <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds#emergency-support-requests">emergency</a>.</p>
 
-    <p>The Inside GOV.UK blog has <a href="https://insidegovuk.blog.gov.uk/status/">more about the scheduled maintenance</a>.</p>',
+    <p><a href="https://status.publishing.service.gov.uk/">The GOV.UK status page</a> has more information about the scheduled maintenance.</p>',
 }
 %>


### PR DESCRIPTION
- We moved away from updating the GOV.UK blog a while ago. If any users got to this page during scheduled maintenance and clicked through, they would have then had to click another link to get to the reason for the maintenance.
