### PR TITLE
Hide the coronavirus banner from the DIT landing page.

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -29,6 +29,7 @@ var globalBarInit = {
       "^/coronavirus/.*$",
       "^/transition(.cy)?$",
       "^/transition-check/.*$",
+      "^/eubusiness$",
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
## What 
A new DIT landing page is being developed at the moment. Once it's live, it should not display the emergency coronavirus banner.

Trello: https://trello.com/c/BWoZhE3E/369-build-dit-campaign-page