### PR TITLE
Restore asset compress after Rails 6 upgrade

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,6 +35,15 @@ Rails.application.configure do
   config.sass.style = :compressed
   config.sass.line_comments = false
 
+  # Compress static CSS assets using the SASS compressor.
+  Sprockets.register_postprocessor "text/css", :static_postprocessor do |input|
+    if input[:filename].match?(/\.css/)
+      { data: Sprockets::SassCompressor.call(input) }
+    else
+      { data: input[:data] }
+    end
+  end
+
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -22,6 +22,9 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
+  # Compress JS using a preprocessor.
+  config.assets.js_compressor = :uglifier
+
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass
 


### PR DESCRIPTION
## What

Changes to production.rb to restore asset compression to previous output.

## Why

* The upgrade to Rails 6 disabled JS compression because it now defaults to using webpack.
* Working around an issue with sassc and min()/max() functions caused CSS assets to be uncompressed.

## Visual differences

None.
