### PR TITLE
Fix crash on cookie setting

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -15,13 +15,13 @@ var globalBarInit = {
   },
 
   getLatestCookie: function() {
+    if (!window.GOVUK.cookie('cookies_policy')) {
+      window.GOVUK.setDefaultConsentCookie()
+    }
     var currentCookie = window.GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)
 
-    if (currentCookie == null) {
-      return currentCookie
-    } else {
-      return currentCookie
-    }
+    return currentCookie
+
   },
 
   urlBlockList: function() {


### PR DESCRIPTION
The banner code was trying to manipulate a cookie that doesn't
yet exist. This sets the default if none is present and removes
a redundant if statement.

The bug can be seen by going in an incognito window (so no cookies are set for the site) to http://www.gov.uk/help/cookies - the js crashes and makes it impossible to set cookie preferences which is the purpose of that page. This probably only affects this page as elsewhere the cookie defaults are set in the cookie banner that is excluded from appearing here. 
