### PR TITLE
Add aria-label of "Sitewide" to main header search

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -14,7 +14,7 @@
   <a href="#search" class="search-toggle js-header-toggle">Search</a>
   <% # The /search page redirects to a finder if keywords are included. Be careful about
      # changing this, as the redirect adds some parameters to the search query. %>
-  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search">
+  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search" aria-label="Sitewide">
     <div class="content govuk-clearfix">
       <label for="site-search-text">Search</label>
       <input type="search" name="q" id="site-search-text" title="Search" class="js-search-focus">


### PR DESCRIPTION
- this relates to some changes in finder-frontend to do with roles and aria-labels
- you can have more than one role="search" on a page but they need distinguishing labels
- this adds an aria-label so that the purpose of the search in the header can be distinguished from other search elements on a page e.g. in finders such as /search/news-and-communications

Related PR: https://github.com/alphagov/finder-frontend/pull/2192

Example:

<img width="990" alt="Screenshot 2020-09-09 at 10 48 57" src="https://user-images.githubusercontent.com/861310/92585753-47f88000-f28d-11ea-8b99-afb066ded892.png">


Trello card: https://trello.com/c/pv1P0xgu/362-search-results-wrong-use-of-search-aria-role