### PR TITLE
Small updates to www.gov.uk/humans.txt

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,1 +1,3 @@
-GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London, Bristol and Manchester. If you'd like to join us, see https://jobs.jobvite.com/gds.
+GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
+Bristol and Manchester.  If you'd like to join us, see https://jobs.jobvite.com/gds.
+

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,1 +1,1 @@
-GOV.UK is built by a team at the Government Digital Service in London (with thanks to Martha!). If you'd like to join us, see https://jobs.jobvite.com/gds.
+GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London, Bristol and Manchester. If you'd like to join us, see https://jobs.jobvite.com/gds.


### PR DESCRIPTION
Firstly, clarify that GDS is not just London now - we've got offices in Bristol and Manchester

Secondly, wrap text at 100 characters, so it's not so difficult to read.