### PR TITLE
Mobile search toggle button

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -117,6 +117,7 @@
       padding: 0;
       text-indent: -5000px;
       width: 36px;
+      border: 0;
 
       &:focus {
         border-width: 0;

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -11,7 +11,7 @@
 <% end %>
 
 <% content_for :inside_header do %>
-  <a href="#search" class="search-toggle js-header-toggle">Search</a>
+  <button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show or hide search</button>
   <% # The /search page redirects to a finder if keywords are included. Be careful about
      # changing this, as the redirect adds some parameters to the search query. %>
   <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search" aria-label="Sitewide">


### PR DESCRIPTION
Modify search toggle button to use button markup instead of an anchor tag, to more closely match the presentation and intended function of the element.

This is dependent on Javascript from `govuk_publishing_components`. The JS assumes that this button is an anchor tag and will throw an error if it cannot find a `href`. Therefore [this PR](https://github.com/alphagov/govuk_publishing_components/pull/1682) needs to go out first.