### PR TITLE
Say goodbye to Issy

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,3 +1,3 @@
 GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
-Bristol and Manchester.  If you'd like to join us, see https://jobs.jobvite.com/gds.
+Bristol and Manchester.  If you'd like to join us, see https://jobs.jobvite.com/gds
 

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -12,5 +12,5 @@ makes working on GOV.UK great. Our applications, our developer tools, our
 documentation - in thousands of pull requests, Issy has made everything better.
 
 Issy - thank you for all your hard work. GDS won’t be the same without you, but
-we’re looking forward to seeing all your future successes. Keep being amazing! 🦄🚀
+we’re looking forward to seeing all your future successes. Keep being amazing!
 

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,3 +1,16 @@
 GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
 Bristol and Manchester.  If you'd like to join us, see https://jobs.jobvite.com/gds
 
+Just for today we’d like to use www.gov.uk/humans.txt to say goodbye to Issy
+Long - one of GDS’ longest serving engineers.
+
+Issy joined GDS in 2014, and helped us smoothly deal with the fallout of
+transitioning hundreds of separate websites onto the single GOV.UK domain.
+
+Over the last six years they’ve never been afraid to do the hard work that
+makes working on GOV.UK great. Our applications, our developer tools, our
+documentation - in thousands of pull requests, Issy has made everything better.
+
+Issy - thank you for all your hard work. GDS won’t be the same without you, but
+we’re looking forward to seeing all your future successes. Keep being amazing! 🦄🚀
+


### PR DESCRIPTION
From http://humanstxt.org/ -

> humans.txt is an initiative for knowing the people behind a website.
> It's a TXT file that contains information about the different people who
> have contributed to building the website.

> The internet is for humans...
> We are always saying that, but the only file we generate is one full
> of additional information for the searchbots: robots.txt. Then why not
> doing one for ourselves?

My proposal here is to:

* Update www.gov.uk/humans.txt with a short message saying goodbye and
 thank you
* Leave it up for about a day
* Revert this PR to set it back to the old version

I think this is a nice thing to do, and well within the intended purpose of
the humans.txt file - it's not going to affect any users of GOV.UK who
aren't looking for humans.

Thanks Issy - we'll miss you!

Screenshot from firefox, against static running locally:

![Screenshot_2020-09-11 Screenshot](https://user-images.githubusercontent.com/1696784/92884659-f32e4400-f409-11ea-9329-b3bfd9ffef69.png)
