### PR TITLE
Crown in header updated to use aria-hidden="true"

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -60,7 +60,7 @@
                data-track-category="homeLinkClicked"
                data-track-action="homeHeader">
               <span class="govuk-header__logotype">
-                <svg role="presentation"
+                <svg aria-hidden="true"
                      focusable="false"
                      class="govuk-header__logotype-crown"
                      xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
GOV.UK Frontend updated the crown SVG in the header component to use `aria-hidden="true"` instead of `role="presentation"` - see the commit https://github.com/alphagov/govuk-frontend/commit/7278efe3d085fab1b637c509cf9262e4d51a4b5d for more information.

This updates the header in static to do the same thing - `role="presentation"` has been removed and `aria-hidden="true"` has been added.