### PR TITLE
Reset humans.txt

### DIFF
--- a/public/humans.txt
+++ b/public/humans.txt
@@ -12,5 +12,5 @@ makes working on GOV.UK great. Our applications, our developer tools, our
 documentation - in thousands of pull requests, Issy has made everything better.
 
 Issy - thank you for all your hard work. GDS won’t be the same without you, but
-we’re looking forward to seeing all your future successes. Keep being amazing!
+we’re looking forward to seeing all your future successes. Keep being amazing! 🦄🚀
 

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,16 +1,3 @@
 GOV.UK is built by a team at the Government Digital Service (with thanks to Martha!) in London,
 Bristol and Manchester.  If you'd like to join us, see https://jobs.jobvite.com/gds
 
-Just for today we’d like to use www.gov.uk/humans.txt to say goodbye to Issy
-Long - one of GDS’ longest serving engineers.
-
-Issy joined GDS in 2014, and helped us smoothly deal with the fallout of
-transitioning hundreds of separate websites onto the single GOV.UK domain.
-
-Over the last six years they’ve never been afraid to do the hard work that
-makes working on GOV.UK great. Our applications, our developer tools, our
-documentation - in thousands of pull requests, Issy has made everything better.
-
-Issy - thank you for all your hard work. GDS won’t be the same without you, but
-we’re looking forward to seeing all your future successes. Keep being amazing! 🦄🚀
-


### PR DESCRIPTION
We temporarily updated www.gov.uk/humans.txt to say goodbye to Issy. It shouldn't be a permanent feature though, otherwise it looks like a bit of an overreaction.

This reverts the commits that added the message, but leaves the one that removes the trailing full stop from the first sentence (as that's a small visual improvement we can keep).