### PR TITLE
Add scroll-tracking to the DIT landing page

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -400,6 +400,9 @@
       ['Percent', 60],
       ['Percent', 80],
       ['Percent', 100]
+    ],
+    '/eubusiness': [
+      ['Heading', 'Additional help and support']
     ]
   };
 


### PR DESCRIPTION
We need to know how many people view the "Additional help and support" section of the[ DIT landing page](https://www.gov.uk/eubusiness), and to do this we'll need some GA event tracking for scrolling on the page.

trello: https://trello.com/c/7BVy9uRt/433-dit-google-analytics-event-scroll-tracking