### PR TITLE
Make mobile menu toggle a button

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -269,6 +269,36 @@
     }
   }
 
+  .mobile-menu-toggle {
+    @include govuk-font(16);
+    float: right;
+    padding: 6px 0 4px 0;
+    color: govuk-colour("white");
+    background: none;
+    border: 0;
+
+    @include govuk-media-query($from: tablet) {
+      display: none;
+    }
+
+    &:focus {
+      @include govuk-focused-text;
+    }
+
+    &:after {
+      display: inline-block;
+      font-size: 8px;
+      height: 8px;
+      padding-left: 5px;
+      vertical-align: middle;
+      content: " \25BC";
+    }
+
+    &.js-visible:after {
+      content: " \25B2";
+    }
+  }
+
   .header-proposition {
     a {
       &.menu {

--- a/app/views/root/proposition_menu.html.erb
+++ b/app/views/root/proposition_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="header-proposition">
   <div class="content">
-    <a href="#proposition-links" class="js-header-toggle menu">Menu</a>
+    <button data-search-toggle-for="proposition-links" class="js-header-toggle mobile-menu-toggle">Menu</button>
   </div>
 </div>


### PR DESCRIPTION
- was formerly a link, which failed accessibility requirements because it behaved like a button
- uses existing JS for this (header-navigation.js, in govuk_publishing_components for reference, fact fans)
- copied and modified the styling from govuk-template (as it no longer applies) in order to preserve the look of the element exactly, CSS may therefore not be as nice as it could be, but this should all be replaced by the proper header at some point anyway

<img width="324" alt="Screenshot 2020-09-24 at 11 11 26" src="https://user-images.githubusercontent.com/861310/94132161-cd1b9180-fe56-11ea-808c-9c916cc9e384.png">

Should be no visual changes.

Trello card: https://trello.com/c/2bL11sIv/414-mobile-menu-button-looks-like-a-link

---

Interesting note - this code for the menu toggle is in `static` (obviously). The JS that controls it (and also the search toggle for mobile, just above it) is in `govuk_publishing_components`. The menu that appears when you toggle this button appears to come from `whitehall` (https://github.com/alphagov/whitehall/blob/master/app/views/layouts/frontend.html.erb).

The sooner we get the header consolidated into one component the better.