### PR TITLE
Add coronavirus-shielding-support.service.gov.uk

### DIFF
--- a/app/assets/javascripts/analytics/init.js.erb
+++ b/app/assets/javascripts/analytics/init.js.erb
@@ -74,6 +74,7 @@ var analyticsInit = function() {
       'contractsfinder.service.gov.uk',
       'coronavirus.data.gov.uk',
       'coronavirus-business-volunteers.service.gov.uk',
+      'coronavirus-shielding-support.service.gov.uk',
       'coronavirus-vulnerable-people.service.gov.uk',
       'courttribunalfinder.service.gov.uk',
       'create-energy-label.service.gov.uk',


### PR DESCRIPTION
So that we can track journeys through the service.

[Trello card](https://trello.com/c/rnnkIpT5/55-shielded-vulnerable-people-service-start-page)