### PR TITLE
Fix search label cut off text

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -9,6 +9,7 @@
   $govuk-header-link-hover: govuk-colour("white");
   $govuk-header-link-active: #1d8feb;
   $govuk-header-nav-item-border-color: #2e3133;
+  position: relative;
 
   #logo {
     background: none;
@@ -104,7 +105,10 @@
   .search-toggle {
     display: none;
 
-    @media screen and (max-width: 379px) {
+    @include govuk-media-query($until: tablet) {
+      position: absolute;
+      right: 0;
+      top: 0;
       background-color: $govuk-brand-colour;
       background-image: image-url("search-button.png");
       background-position: 0 50%;
@@ -112,7 +116,7 @@
       display: block;
       float: right;
       height: 30px;
-      margin: -32px govuk-spacing(3);
+      margin: govuk-spacing(2) govuk-spacing(3);
       overflow: hidden;
       padding: 0;
       text-indent: -5000px;
@@ -255,7 +259,7 @@
       }
     }
 
-    @media screen and (max-width: 379px) {
+    @include govuk-media-query($until: tablet) {
       display: none;
       width: 100%;
 


### PR DESCRIPTION
The global site header search label text has been updated from **"Search"** to **"Search on GOV.UK"**.

This has lead to an issue where the label text is now appearing clipped on larger mobile adaptations as there simply is not enough space to accommodate it.
### Problem
<img width="426" alt="Screenshot 2020-10-22 at 10 05 56" src="https://user-images.githubusercontent.com/7116819/96849998-38ed1c00-144e-11eb-82f7-2931547add74.png">




This updates the CSS so that the search field is hidden on larger mobiles – same as it currently is for smaller mobiles. The search form can be shown/hidden using the search toggle button.


### Solution
<img width="943" alt="Screenshot 2020-10-22 at 10 10 19" src="https://user-images.githubusercontent.com/7116819/96850525-d34d5f80-144e-11eb-8465-ac201a28836f.png">


----- 

Thanks @issyl0 for bringing this to our attention 👉🏼 👉🏼 👉🏼  #2301 

https://trello.com/c/RbD3om74