### PR TITLE
Add main navigation for accounts

### DIFF
--- a/app/assets/javascripts/header-footer-only.js
+++ b/app/assets/javascripts/header-footer-only.js
@@ -4,4 +4,5 @@
 //= require start-modules
 //= require govuk/selection-buttons
 //= require govuk/shim-links-with-button-role
+//= require govuk_publishing_components/components/header
 //= require core

--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -6,6 +6,7 @@ $govuk-use-legacy-palette: false;
 // collections uses the action-link component and relies upon this line, see
 // https://github.com/alphagov/collections/pull/1754
 @import "govuk_publishing_components/components/_action-link";
+@import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/_search";
 
 /* govuk_frontend_toolkit includes */
@@ -29,3 +30,22 @@ $govuk-use-legacy-palette: false;
 // implementation existing in multiple apps would need to be updated to make
 // that change just make it available globally for the moment.
 @import "helpers/selectable";
+
+// The following overrides are in place to allow the govuk-header play nicely
+// with govuk_template in our attempt to show account navigation in certain apps
+.header-global {
+  position: relative;
+}
+
+.govuk-header__content {
+  padding: 0 govuk-spacing(3);
+}
+
+.govuk-header__menu-button {
+  top: govuk-spacing(2);
+  right: govuk-spacing(3);
+}
+
+.gem-c-header__nav {
+  clear: both;
+}

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -28,7 +28,7 @@
   <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
     <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav class="gem-c-header__nav">
-      <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+      <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
           <a class="govuk-header__link" href="<% Plek.new.website_root %>/transition-check/login">Sign in</a>
         </li>
@@ -39,7 +39,7 @@
   <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
     <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
     <nav class="gem-c-header__nav">
-      <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+      <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
           <a class="govuk-header__link" href="<% Plek.find("account-manager") %>">Account</a>
         </li>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -30,7 +30,7 @@
     <nav class="gem-c-header__nav">
       <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="https://www.gov.uk/transition-check/login">Sign in</a>
+          <a class="govuk-header__link" href="<% Plek.new.website_root %>/transition-check/login">Sign in</a>
         </li>
       </ul>
     </nav>
@@ -41,10 +41,10 @@
     <nav class="gem-c-header__nav">
       <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
         <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="https://www.account.publishing.service.gov.uk/">Account</a>
+          <a class="govuk-header__link" href="<% Plek.find("account-manager") %>">Account</a>
         </li>
         <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="https://www.gov.uk/transition-check/logout">Sign out</a>
+          <a class="govuk-header__link" href="<% Plek.new.website_root %>/transition-check/logout">Sign out</a>
         </li>
       </ul>
     </nav>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -24,6 +24,31 @@
       } %>
     </div>
   </form>
+
+  <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+    <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav class="gem-c-header__nav">
+      <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://www.gov.uk/transition-check/login">Sign in</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+
+  <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+    <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+    <nav class="gem-c-header__nav">
+      <ul id="navigation" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://www.account.publishing.service.gov.uk/">Account</a>
+        </li>
+        <li class="govuk-header__navigation-item">
+          <a class="govuk-header__link" href="https://www.gov.uk/transition-check/logout">Sign out</a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 <% end %>
 
 <% content_for :after_header do %>


### PR DESCRIPTION
This snappy change adds main navigation for accounts to be used via [slimmer config](See https://github.com/alphagov/slimmer/pull/255).

Note this menu is not compatible with the search input. The search needs to be disabled when navigation is enabled otherwise they will visually clash.

This was tested locally in `finder-frontend` – since this is the primary usage – and will work for both `core_layout` and `header_footer_only` templates in static.

<table>
<tr><th>Signed in</th><th>Signed out</th></tr>
<tr><td valign="top">

![signed-in-desktop](https://user-images.githubusercontent.com/788096/97456353-b3c3a480-1930-11eb-98dd-2e8e7accc2ac.png)


</td><td valign="top">

![signed-out-desktop](https://user-images.githubusercontent.com/788096/97456361-b6be9500-1930-11eb-9598-248bc4fcd287.png)


</td></tr>

<tr><td valign="top">

![signed-in-mobile](https://user-images.githubusercontent.com/788096/97456396-bfaf6680-1930-11eb-8e1f-120e1795ee8b.png)


</td><td valign="top">

![signed-out-mobile](https://user-images.githubusercontent.com/788096/97456410-c211c080-1930-11eb-81e4-4225122fbb67.png)

</td></tr>
</table>

[Trello card](https://trello.com/c/vdZrgBRy)