### PR TITLE
Fix mobile search toggle button positioning

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -127,7 +127,7 @@
     background-repeat: no-repeat;
     display: block;
     height: 30px;
-    margin: govuk-spacing(2) govuk-spacing(3);
+    margin: 0 govuk-spacing(3);
     overflow: hidden;
     padding: 0;
     text-indent: -5000px;


### PR DESCRIPTION
Recent changes to the global search input in static seem to have introduced an alignment issue on mobile.

Before | After
------------ | -------------
<img width="522" alt="Screenshot 2020-10-30 at 13 47 46" src="https://user-images.githubusercontent.com/7116819/97712665-a7695400-1ab6-11eb-8daf-dbcf2fb949ca.png">|<img width="522" alt="Screenshot 2020-10-30 at 13 48 02" src="https://user-images.githubusercontent.com/7116819/97712669-a89a8100-1ab6-11eb-9a1d-08767b5ce87d.png">
