### PR TITLE
Update coronavirus subtext in global banner

### DIFF
--- a/app/views/notifications/_global_bar.html.erb
+++ b/app/views/notifications/_global_bar.html.erb
@@ -8,7 +8,7 @@
 
   coronavirus_title = "Coronavirus (COVID-19)"
   coronavirus_href = "/coronavirus"
-  coronavirus_subtext = "Guidance and support"
+  coronavirus_subtext = "National restrictions in England from 5 November"
 
   transition_title = "The UK and EU transition"
   transition_href = "/transition"


### PR DESCRIPTION
To reflect the new national restrictions in England which come into
force on 5 November.