### PR TITLE
Hide accounts links on error pages

### DIFF
--- a/app/views/root/_account_navigation.html.erb
+++ b/app/views/root/_account_navigation.html.erb
@@ -1,0 +1,24 @@
+<div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <nav class="gem-c-header__nav">
+    <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+      <li class="govuk-header__navigation-item">
+        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
+      </li>
+    </ul>
+  </nav>
+</div>
+
+<div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <nav class="gem-c-header__nav">
+    <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+      <li class="govuk-header__navigation-item">
+        <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
+      </li>
+      <li class="govuk-header__navigation-item">
+        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout">Sign out</a>
+      </li>
+    </ul>
+  </nav>
+</div>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -28,30 +28,7 @@
   </form>
 
   <% unless hide_account_navigation %>
-    <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-      <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-      <nav class="gem-c-header__nav">
-        <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-          <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
-
-    <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-      <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-      <nav class="gem-c-header__nav">
-        <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-          <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
-          </li>
-          <li class="govuk-header__navigation-item">
-            <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout">Sign out</a>
-          </li>
-        </ul>
-      </nav>
-    </div>
+    <%= render partial: 'account_navigation' %>
   <% end %>
 <% end %>
 

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -1,3 +1,5 @@
+<% hide_account_navigation ||= false %>
+
 <% content_for :homepage_url, Plek.new.website_root %>
 <% content_for :page_title, content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %>
 <% @emergency_banner = emergency_banner_notification %>
@@ -25,30 +27,32 @@
     </div>
   </form>
 
-  <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-    <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-    <nav class="gem-c-header__nav">
-      <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+  <% unless hide_account_navigation %>
+    <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+      <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav class="gem-c-header__nav">
+        <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
 
-  <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-    <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
-    <nav class="gem-c-header__nav">
-      <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
-        </li>
-        <li class="govuk-header__navigation-item">
-          <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout">Sign out</a>
-        </li>
-      </ul>
-    </nav>
-  </div>
+    <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
+      <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+      <nav class="gem-c-header__nav">
+        <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
+          </li>
+          <li class="govuk-header__navigation-item">
+            <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout">Sign out</a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  <% end %>
 <% end %>
 
 <% content_for :after_header do %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -37,4 +37,4 @@
 </main>
 <% end %>
 
-<%= render partial: 'base' %>
+<%= render partial: 'base', locals: { hide_account_navigation: true } %>


### PR DESCRIPTION
We're using slimmer to remove accounts links from the header, but the
error pages come straight from static and so don't go through slimmer.