### PR TITLE
Strip longer postcodes in Google analytics

### DIFF
--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -3,7 +3,7 @@
 
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2,3}/gi
+  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
 
   function shouldStripDates() {

--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -3,7 +3,7 @@
 
   var GOVUK = global.GOVUK || {}
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
-  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2}/gi
+  var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9][ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
 
   function shouldStripDates() {

--- a/spec/javascripts/analytics/pii.spec.js
+++ b/spec/javascripts/analytics/pii.spec.js
@@ -106,9 +106,9 @@ describe("GOVUK.PII", function() {
 
     it('observes the meta tag and strips out postcodes', function() {
       expect(pii.stripPostcodePII).toEqual(true);
-      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date"
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date, this is a p800refund"
 )
-      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date")
+      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date, this is a p800refund")
     });
   });
 

--- a/spec/javascripts/analytics/pii.spec.js
+++ b/spec/javascripts/analytics/pii.spec.js
@@ -106,8 +106,9 @@ describe("GOVUK.PII", function() {
 
     it('observes the meta tag and strips out postcodes', function() {
       expect(pii.stripPostcodePII).toEqual(true);
-      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a 2019-01-21 date")
-      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a 2019-01-21 date")
+      var string = pii.stripPII("this is an@email.com address, this is a sw1a 1aa postcode, this is a long GL194LYX postcode, this is a 2019-01-21 date"
+)
+      expect(string).toEqual("this is [email] address, this is a [postcode] postcode, this is a long [postcode] postcode, this is a 2019-01-21 date")
     });
   });
 


### PR DESCRIPTION
The data in google analytics was not properly redacting longer postcodes
and was incorrectly redacting the names of a form.

To redact longer postcodes we've added an optional extra letter to the
end of the regex for the postcode.

To check for the form name the word refund has been ignored in the regex.

Trello card: https://trello.com/c/NFJQdJg4/2201-3-adjust-google-analytics-pii-filtering