### PR TITLE
Fix mobile menu for accounts

### DIFF
--- a/app/views/root/_account_navigation.html.erb
+++ b/app/views/root/_account_navigation.html.erb
@@ -1,7 +1,7 @@
 <div id="accounts-signed-out" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation-out" aria-label="Show or hide Top Level Navigation">Menu</button>
   <nav class="gem-c-header__nav">
-    <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+    <ul id="navigation-out" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
       <li class="govuk-header__navigation-item">
         <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
       </li>
@@ -10,9 +10,9 @@
 </div>
 
 <div id="accounts-signed-in" class="govuk-header__content gem-c-header__content" data-module="govuk-header">
-  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+  <button role="button" class="govuk-header__menu-button gem-c-header__menu-button govuk-js-header-toggle" aria-controls="navigation-in" aria-label="Show or hide Top Level Navigation">Menu</button>
   <nav class="gem-c-header__nav">
-    <ul class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
+    <ul id="navigation-in" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
       <li class="govuk-header__navigation-item">
         <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
       </li>


### PR DESCRIPTION
(hopefully) fixes the mobile menu for accounts in the header.

- the UL that is supposed to appear when the button is clicked should have an ID matching the aria-controls attribute of the button, for the JS to work
- I've used two different IDs just in case slimmer has a problem with duplicates, although some kind of magic seems to be occurring here to make only one chunk of this markup render at any one time

<img width="349" alt="Screenshot 2020-11-04 at 10 39 20" src="https://user-images.githubusercontent.com/861310/98101530-4234aa80-1e8a-11eb-86c5-1d2ebde0b603.png">

Trello card: https://trello.com/c/ICDC0esK/368-accounts-snag-list-%F0%9F%8C%AD