### PR TITLE
Update Dockerfile to reflect it should only run in RAILS_ENV=production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,10 @@ FROM ruby:2.7.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 
+# This image is only intended to be able to run this app in a production RAILS_ENV
+ENV RAILS_ENV production
+
 ENV GOVUK_APP_NAME static
-ENV RAILS_ENV development
 ENV REDIS_URL redis://redis
 ENV PORT 3013
 
@@ -17,6 +19,6 @@ RUN bundle install
 
 ADD . $APP_HOME
 
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk RAILS_ENV=production bundle exec rails assets:precompile
+RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bundle exec rails assets:precompile
 
 CMD foreman run web

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
 ADD .ruby-version $APP_HOME/
 ADD Gemfile* $APP_HOME/
-RUN bundle install
+RUN bundle config set deployment 'true'
+RUN bundle config set without 'development test'
+RUN bundle install --jobs 4
 
 ADD . $APP_HOME
 


### PR DESCRIPTION
This Dockerfile is only used in RAILS_ENV=production environments and doesn't have the system dependencies installed for other environments (and shouldn't have these unless they're used and thus tested). This change reflects this by changing the default RAILS_ENV to production and installing only the production gems.