### PR TITLE
Replace EU transition with Brexit transition in the footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -65,7 +65,7 @@
         </ul>
       </div>
       <div class="govuk-grid-column-one-third">
-        <h2>The UK has left the EU</h2>
+        <h2>Brexit transition</h2>
         <ul>
           <li>
             <a data-track-category="footerClicked"


### PR DESCRIPTION
## What

Following renaming of the transition taxon, and site wide changes to use the more SEO friendly term 'Brexit transition', we should make the footer consistent.

## Before

<img width="1067" alt="Screenshot 2020-11-18 at 14 38 41" src="https://user-images.githubusercontent.com/17908089/99544051-c66b4f80-29ab-11eb-8a3c-6289bb864874.png">

## After

<img width="1135" alt="Screenshot 2020-11-18 at 15 00 08" src="https://user-images.githubusercontent.com/17908089/99546872-ccaefb00-29ae-11eb-9a70-4a5d290e2b84.png">


[Trello](https://trello.com/c/ynxEAip9/616-update-the-transition-wording-on-the-govuk-homepage-and-govuk-footer)
