### PR TITLE
Add pii redactions for accounts

### DIFF
--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -6,6 +6,11 @@
   var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
 
+  // specific URL parameters to be redacted from accounts URLs
+  var RESET_PASSWORD_TOKEN_PATTERN = /reset_password_token=[a-zA-Z0-9-]+/g
+  var UNLOCK_TOKEN_PATTERN = /unlock_token=[a-zA-Z0-9-]+/g
+  var STATE_PATTERN = /state=.[^&]+/g
+
   function shouldStripDates() {
     return ($('meta[name="govuk:static-analytics:strip-dates"]').length > 0)
   }
@@ -33,6 +38,10 @@
 
   pii.prototype.stripPIIFromString = function (string) {
     var stripped = string.replace(EMAIL_PATTERN, '[email]')
+    stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
+    stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
+    stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
+
     if (this.stripDatePII === true) {
       stripped = stripped.replace(DATE_PATTERN, '[date]')
     }

--- a/spec/javascripts/analytics/pii.spec.js
+++ b/spec/javascripts/analytics/pii.spec.js
@@ -51,6 +51,19 @@ describe("GOVUK.PII", function() {
     })
   })
 
+  describe('by default for account specific PII', function () {
+    it('redacts the expected list of URL parameters', function () {
+      var resetPasswordToken = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?reset_password_token=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(resetPasswordToken).toEqual('https://www.account.publishing.service.gov.uk/new-account?reset_password_token=[reset_password_token]&somethingelse=24342fdjfskf')
+
+      var unlockToken = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?unlock_token=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(unlockToken).toEqual('https://www.account.publishing.service.gov.uk/new-account?unlock_token=[unlock_token]&somethingelse=24342fdjfskf')
+
+      var state = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?state=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
+      expect(state).toEqual('https://www.account.publishing.service.gov.uk/new-account?state=[state]&somethingelse=24342fdjfskf')
+    })
+  })  
+
   describe('when configured to remove all PII', function() {
     beforeEach(function() {
       pageWantsDatesStripped()


### PR DESCRIPTION
This is the same change made in https://github.com/alphagov/govuk_publishing_components/pull/1807 but applied here in static, where it can be used by the intended target, `finder-frontend`.

Once the analytics code is fully migrated to the components gem we won't need to have to create duplicate PRs like this.

Trello card: https://trello.com/c/bjcoDa2N/462-remove-or-redact-potential-pii-from-urls