### PR TITLE
Add data attributes to accounts links we need to decorate

### DIFF
--- a/app/views/root/_account_navigation.html.erb
+++ b/app/views/root/_account_navigation.html.erb
@@ -3,7 +3,7 @@
   <nav class="gem-c-header__nav">
     <ul id="navigation-out" class="govuk-header__navigation govuk-header__navigation--end" aria-label="Top Level Navigation">
       <li class="govuk-header__navigation-item">
-        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login">Sign in</a>
+        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/login" data-module="explicit-cross-domain-links">Sign in</a>
       </li>
     </ul>
   </nav>
@@ -17,7 +17,7 @@
         <a class="govuk-header__link" href="<%= Plek.new.find("account-manager") %>">Account</a>
       </li>
       <li class="govuk-header__navigation-item">
-        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout">Sign out</a>
+        <a class="govuk-header__link" href="<%= Plek.new.website_root %>/transition-check/logout" data-module="explicit-cross-domain-links">Sign out</a>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
These are links to www.gov.uk, but we need to decorate them with the
cross-domain _ga param, as they may redirect to the accounts
domain (the redirect will preserve the param).

---

[Trello card](https://trello.com/c/ISYymNsg/426-fix-cross-domain-tracking-on-redirects)