### PR TITLE
Prepare static for a multilingual eubusiness page

### DIFF
--- a/app/assets/javascripts/analytics/scroll-tracker.js
+++ b/app/assets/javascripts/analytics/scroll-tracker.js
@@ -402,7 +402,7 @@
       ['Percent', 100]
     ],
     '/eubusiness': [
-      ['Heading', 'Additional help and support']
+      ['Heading', 'Webinars for EU-based businesses trading with the UK']
     ]
   };
 

--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -29,7 +29,7 @@ var globalBarInit = {
       "^/coronavirus/.*$",
       "^/transition(.cy)?$",
       "^/transition-check/.*$",
-      "^/eubusiness$",
+      "^/eubusiness(\..*)?$",
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
- **Update the global-bar blocklist**
Update the `eubusiness` regex in the `global-bar-init.js` regex blocklist to match translation URLs as we prepare to rollout alphagov/collections#2134. By doing this we prevent the global bar banner from appearing on translation pages of the `/eubusiness` page (for example `/eubusiness.es`)

- **Update eubusiness heading copy**
It seems like the `scroll-tracker.js` script looks for hardcoded content at the bottom of the `/eubusiness` page, content that we update in alphagov/collections#2134.

[Trello card](https://trello.com/c/ZfMI7LNc)