### PR TITLE
Fix anchor styles in survey script

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -14,7 +14,7 @@
     return (
       '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
       '  <div class="survey-wrapper">' +
-      '    <a class="survey-close-button" href="#user-survey-cancel" aria-labelledby="survey-title user-survey-cancel" id="user-survey-cancel" role="button">Close</a>' +
+      '    <a class="govuk-link survey-close-button" href="#user-survey-cancel" aria-labelledby="survey-title user-survey-cancel" id="user-survey-cancel" role="button">Close</a>' +
       '    <h2 class="survey-title" id="survey-title">{{title}}</h2>' +
            children +
       '  </div>' +
@@ -24,14 +24,14 @@
 
   var URL_SURVEY_TEMPLATE = templateBase(
     '<p>' +
-      takeSurveyLink('{{surveyCta}}', 'survey-primary-link') +
+      takeSurveyLink('{{surveyCta}}', 'govuk-link survey-primary-link') +
     ' <span class="postscript-cta">{{surveyCtaPostscript}}</span>' +
     '</p>'
   )
 
   var EMAIL_SURVEY_TEMPLATE = templateBase(
     '<div id="email-survey-pre">' +
-    '  <a class="survey-primary-link" href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
+    '  <a class="govuk-link survey-primary-link" href="#email-survey-form" id="email-survey-open" rel="noopener noreferrer" role="button" aria-expanded="false">' +
     '    {{surveyCta}}' +
     '  </a>' +
     '</div>' +


### PR DESCRIPTION
Improves the accessibility of these links and makes their style consistent with the rest of GOV.UK.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![collections dev gov uk_eubusiness](https://user-images.githubusercontent.com/788096/101879970-104dec80-3b8a-11eb-914d-1838855855f4.png)


</td><td valign="top">

![collections dev gov uk_eubusiness (1)](https://user-images.githubusercontent.com/788096/101879976-12b04680-3b8a-11eb-98f9-70925f12b06b.png)


</td></tr>
</table>
