### PR TITLE
Add 502 page

### DIFF
--- a/app/views/root/502.html.erb
+++ b/app/views/root/502.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "error_page", locals: {
+  heading: "Sorry, we're experiencing technical difficulties",
+  intro: "<p>Please try again in a few moments.</p>",
+  status_code: 502
+} %>


### PR DESCRIPTION
A recent incident reveals that we do not have a 502 error page, which means an unsightly nginx 404 is served when this error occurs. 