### PR TITLE
Allow stripping query string parameters from Analytics

### DIFF
--- a/app/assets/javascripts/analytics/pii.js
+++ b/app/assets/javascripts/analytics/pii.js
@@ -5,6 +5,7 @@
   var EMAIL_PATTERN = /[^\s=/?&]+(?:@|%40)[^\s=/?&]+/g
   var POSTCODE_PATTERN = /[A-PR-UWYZ][A-HJ-Z]?[0-9][0-9A-HJKMNPR-Y]?(?:[\s+]|%20)*[0-9](?!refund)[ABD-HJLNPQ-Z]{2,3}/gi
   var DATE_PATTERN = /\d{4}(-?)\d{2}(-?)\d{2}/g
+  var ESCAPE_REGEX_PATTERN = /[|\\{}()[\]^$+*?.]/g
 
   // specific URL parameters to be redacted from accounts URLs
   var RESET_PASSWORD_TOKEN_PATTERN = /reset_password_token=[a-zA-Z0-9-]+/g
@@ -19,9 +20,24 @@
     return ($('meta[name="govuk:static-analytics:strip-postcodes"]').length > 0)
   }
 
+  function queryStringParametersToStrip() {
+    var value = $('meta[name="govuk:static-analytics:strip-query-string-parameters"]').attr('content')
+    var parameters = []
+
+    if (value) {
+      var split = value.split(",")
+      for (var i = 0; i < split.length; i++) {
+        parameters.push(split[i].trim())
+      }
+    }
+
+    return parameters
+  }
+
   var pii = function () {
     this.stripDatePII = shouldStripDates()
     this.stripPostcodePII = shouldStripPostcodes()
+    this.queryStringParametersToStrip = queryStringParametersToStrip()
   }
 
   pii.prototype.stripPII = function (value) {
@@ -41,6 +57,7 @@
     stripped = stripped.replace(RESET_PASSWORD_TOKEN_PATTERN, 'reset_password_token=[reset_password_token]')
     stripped = stripped.replace(UNLOCK_TOKEN_PATTERN, 'unlock_token=[unlock_token]')
     stripped = stripped.replace(STATE_PATTERN, 'state=[state]')
+    stripped = this.stripQueryStringParameters(stripped)
 
     if (this.stripDatePII === true) {
       stripped = stripped.replace(DATE_PATTERN, '[date]')
@@ -73,6 +90,17 @@
       array[i] = this.stripPII(elem)
     }
     return array
+  }
+
+  pii.prototype.stripQueryStringParameters = function (string) {
+    for (var i = 0; i < this.queryStringParametersToStrip.length; i++) {
+      var parameter = this.queryStringParametersToStrip[i]
+      var escaped = parameter.replace(ESCAPE_REGEX_PATTERN, '\\$&')
+      var regexp = new RegExp('((?:\\?|&)' + escaped + '=)(?:[^&#\\s]*)', 'g')
+      string = string.replace(regexp, '$1[' + parameter + ']')
+    }
+
+    return string
   }
 
   GOVUK.pii = pii

--- a/spec/javascripts/analytics/pii.spec.js
+++ b/spec/javascripts/analytics/pii.spec.js
@@ -62,7 +62,7 @@ describe("GOVUK.PII", function() {
       var state = pii.stripPII('https://www.account.publishing.service.gov.uk/new-account?state=4be6f4db-f32a-4d75-b0c7-3b3533ff31c4&somethingelse=24342fdjfskf')
       expect(state).toEqual('https://www.account.publishing.service.gov.uk/new-account?state=[state]&somethingelse=24342fdjfskf')
     })
-  })  
+  })
 
   describe('when configured to remove all PII', function() {
     beforeEach(function() {
@@ -138,9 +138,44 @@ describe("GOVUK.PII", function() {
     });
   });
 
+  describe('when there is a govuk:static-analytics:strip-query-string-parameters meta tag present', function() {
+    afterEach(function() {
+      resetHead()
+    })
+
+    it('strips specified query strings that are identified in a string', function() {
+      pageWantsQueryStringParametersStripped(['strip-parameter-1', 'strip-parameter-2'])
+      pii = new GOVUK.pii()
+      var string = pii.stripPII('this is a string with a url /test?strip-parameter-1=secret&strip-parameter-2=more-secret')
+      expect(string).toEqual('this is a string with a url /test?strip-parameter-1=[strip-parameter-1]&strip-parameter-2=[strip-parameter-2]')
+    })
+
+    it('can strip query strings with special characters', function() {
+      pageWantsQueryStringParametersStripped(['parameter[]'])
+      pii = new GOVUK.pii()
+      var string = pii.stripPII('/url?parameter[]=secret&parameter[]=more-secret')
+      expect(string).toEqual('/url?parameter[]=[parameter[]]&parameter[]=[parameter[]]')
+    })
+
+    it('matches a URL with a fragment', function() {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.pii()
+      var string = pii.stripPII('/url?parameter=secret#anchor')
+      expect(string).toEqual('/url?parameter=[parameter]#anchor')
+    })
+
+    it('doesn\'t match params without a query string prefix', function() {
+      pageWantsQueryStringParametersStripped(['parameter'])
+      pii = new GOVUK.pii()
+      var string = pii.stripPII('parameter=secret')
+      expect(string).toEqual('parameter=secret')
+    })
+  })
+
   function resetHead() {
     $('head').find('meta[name="govuk:static-analytics:strip-postcodes"]').remove();
     $('head').find('meta[name="govuk:static-analytics:strip-dates"]').remove();
+    $('head').find('meta[name="govuk:static-analytics:strip-query-string-parameters"]').remove();
   }
 
   function pageWantsDatesStripped() {
@@ -149,5 +184,9 @@ describe("GOVUK.PII", function() {
 
   function pageWantsPostcodesStripped() {
     $('head').append('<meta name="govuk:static-analytics:strip-postcodes" value="does not matter" />');
+  }
+
+  function pageWantsQueryStringParametersStripped (parameters) {
+    $('head').append('<meta name="govuk:static-analytics:strip-query-string-parameters" content="' + parameters.join(", ") + '" />')
   }
 });


### PR DESCRIPTION
Trello: https://trello.com/c/LiAOrW5F/1000-remove-or-redact-values-at-the-end-of-postcode-look-up-string-that-dont-match-postcode-format

This adds a new meta tag approach to stripping PII data from being sent
to analytics. This allows for particular query string parameters to be
redacted and for an application to specify them.

To use this an application should create a meta element of:

```
<meta name="govuk:static-analytics:strip-query-string-parameters"
content="param-1, param-2">
```

Where param-1, param-2 is a comma separated list of parameter names.
Formatting for this is inspired by `<meta name=keywords>`

Then when analytics data is sent to GA the strings are looked for a
match of the query string parameter and any found are replaced. To illustrate:
were a url of `https://www.gov.uk?param-1=secret` be sent to analytics,
and param-1 was flagged for stripping, then this was be replaced to be
`https://www.gov.uk?param-1=[param-1]`.

There are a few caveats of this approach that should be outlined:

It's just a regular expression that tries to match query strings and this
is done rather crudely. It just looks for a part of a string which is
`?parameter_name=<some value>` or `&paramater_name=<some value>`, so it is
possible that for some strings this could be a false positive. A more
thorough approach could be to parse URIs that are recognised in input
and break them down to constituent parts to identify query strings, but
it isn't clear this is needed.

This won't match a URL that is urlencoded - for example &amp; - this
feels like something that would occur if we were showing someone
publicly the URL they used - which seems a bit strange for PII.

As the means to specify query string parameters is a comma separated list,
this technique will not support any query string that use a comma in the
parameter name. This seemed pretty low risk to me, were we to want to support
this we may want to switch to a JSON encoded approach to defining parameter
names to strip.

An application of this can be seen in: https://github.com/alphagov/collections/pull/2202