### PR TITLE
Update brexit link copy in footer

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -70,10 +70,10 @@
           <li>
             <a data-track-category="footerClicked"
                data-track-action="transitionLinks"
-               data-track-label="Check how the new rules affect you"
+               data-track-label="Check how the new Brexit rules affect you"
                href="/transition"
                class="govuk-link">
-               Check how the new rules affect you
+               Check how the new Brexit rules affect you
             </a>
           </li>
         </ul>


### PR DESCRIPTION
To keep it 'in sync' with the contextual sidebar https://github.com/alphagov/govuk_publishing_components/pull/1851

[Trello card](https://trello.com/c/vFkN8alA)