### PR TITLE
Set cache control on asset redirects

### DIFF
--- a/app/controllers/icon_redirects_controller.rb
+++ b/app/controllers/icon_redirects_controller.rb
@@ -1,4 +1,6 @@
 class IconRedirectsController < ApplicationController
+  before_action { expires_in(1.day, public: true) }
+
   def show
     redirect_to view_context.asset_path(request.path.to_s[1..-1]), status: :moved_permanently
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,4 +27,13 @@ Rails.application.routes.draw do
   get "/apple-touch-icon-76x76.png", to: "icon_redirects#apple_old_size_icon"
   get "/apple-touch-icon-60x60.png", to: "icon_redirects#apple_old_size_icon"
   get "/apple-touch-icon-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-114x114-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-120x120-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-144x144-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-152x152-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-176x176-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-180x180-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-57x57-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-72x72-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+  get "/apple-touch-icon-76x76-precomposed.png", to: "icon_redirects#apple_old_size_icon"
 end

--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -80,6 +80,60 @@ ROUTES = [
     title: "Crest for Apple iOS bookmarks",
     description: "Used by iOS when saving GOV.UK as a shortcut icon.",
   },
+  {
+    base_path: "/apple-touch-icon-114x114-precomposed.png",
+    content_id: "c15ee6fd-fb3a-45ab-b9e1-0efe1a8a6c2e",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-120x120-precomposed.png",
+    content_id: "2e676337-94f3-4f4f-8501-83a1c7813bf8",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-144x144-precomposed.png",
+    content_id: "5fd9d11e-997a-4850-ad69-a43a3aec8a9f",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-152x152-precomposed.png",
+    content_id: "39541207-fdce-4415-8498-42477fce4b58",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-176x176-precomposed.png",
+    content_id: "96833c45-64e2-4bdb-af43-90a96be2a1a3",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-180x180-precomposed.png",
+    content_id: "db853854-42a6-49ce-95c5-0b41b4bed921",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-57x57-precomposed.png",
+    content_id: "ead323b2-80e0-494f-8b1d-f7f998b9267c",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-72x72-precomposed.png",
+    content_id: "4068ca41-f6b1-48d5-a19d-3ea85be49434",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
+  {
+    base_path: "/apple-touch-icon-76x76-precomposed.png",
+    content_id: "0526a59d-c9f8-4d44-8649-e54d532a0b35",
+    title: "Crest for Apple iOS bookmarks",
+    description: "Used by iOS when saving GOV.UK as a shortcut icon.",
+  },
 ].freeze
 
 namespace :publishing_api do

--- a/test/integration/icon_redirects_test.rb
+++ b/test/integration/icon_redirects_test.rb
@@ -11,6 +11,7 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
     should "redirect #{file} to the asset path" do
       get "/#{file}"
       assert_equal 301, last_response.status
+      assert_equal last_response.headers["Cache-Control"], "max-age=86400, public"
       # In development and test mode the asset pipeline doesn't add the hashes to the URLs
       assert_equal "http://example.org/assets/static/#{file}", last_response.location
     end
@@ -37,6 +38,7 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
     should "redirect old icon size #{file} to the default apple-touch-icon.png icon" do
       get "/#{file}"
       assert_equal 301, last_response.status
+      assert_equal last_response.headers["Cache-Control"], "max-age=86400, public"
       # In development and test mode the asset pipeline doesn't add the hashes to the URLs
       assert_equal "http://example.org/assets/static/apple-touch-icon.png", last_response.location
     end


### PR DESCRIPTION
### What
- Set `cache-control` on asset redirects
- Extend the asset redirects based on recent log analysis

### Why
Recent log analysis revealed that we have some uncached redirects and 404s on apple-touch-icons requests. This change aims to prevent such request from reaching our servers by setting a cache-control in the redirects header that will be picked up by our CDN.

[Trello card](https://trello.com/c/hNHb5JS8); [Related Trello card](https://trello.com/c/CN2bhhZi)