### PR TITLE
Adding relevant sass for search component

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -2,6 +2,8 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
+// The search component requires this helper mixin to render height #PR-2380
+@import "govuk_publishing_components/components/helpers/px-to-em";
 @import "govuk_publishing_components/components/_cookie-banner";
 // collections uses the action-link component and relies upon this line, see
 // https://github.com/alphagov/collections/pull/1754


### PR DESCRIPTION
## What?

Fix to resolve visual issue on `government-frontend` app within search input, adding support file directly to static so the search component pulls in correct mixin to calculate the height for an input field.

## Why?

There was an issue highlighted with search [on this page ](https://www.gov.uk/guidance/access-the-public-register-for-environmental-information)which was related to a [search PR](https://github.com/alphagov/govuk_publishing_components/pull/1793)

A [PR](https://github.com/alphagov/government-frontend/pull/1950) was raised to fix this issue directly on `government-frontend` however it was highlighted this isn't quite the correct fix.   This PR adds the relevant file directly to static so the header + search element has the sass that it needs.

## Visuals

Before
![Screenshot 2020-12-22 at 18 00 57](https://user-images.githubusercontent.com/71266765/102919097-2445f800-4480-11eb-8ef9-28c24adc9edf.png)

After
![Screenshot 2020-12-22 at 18 01 15](https://user-images.githubusercontent.com/71266765/102919094-227c3480-4480-11eb-9480-04c498ccc3a9.png)

## Anything else 

There was some conversation about this previously on [this PR](https://github.com/alphagov/static/pull/2049) and [this PR](https://github.com/alphagov/static/pull/2238) - raising as a draft.