### PR TITLE
Revert "Bump govuk_publishing_components from 23.10.1 to 23.12.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,11 +93,9 @@ GEM
     erubi (1.10.0)
     execjs (2.7.0)
     exifr (1.3.7)
-    faraday (1.3.0)
-      faraday-net_http (~> 1.0)
+    faraday (1.1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
-    faraday-net_http (1.0.0)
     ffi (1.13.1)
     fspath (3.1.2)
     gds-api-adapters (68.2.0)
@@ -118,7 +116,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (23.12.1)
+    govuk_publishing_components (23.10.1)
       govuk_app_config
       kramdown
       plek
@@ -137,7 +135,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.7)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     image_optim (0.27.0)
       exifr (~> 1.2, >= 1.2.2)
@@ -240,7 +238,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     raindrops (0.19.1)
-    rake (13.0.3)
+    rake (13.0.1)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)


### PR DESCRIPTION
Reverts alphagov/static#2379

It seems to have caused an issue with the build:

> NoMethodError: undefined method `hour' for 1:Integer

