### PR TITLE
Upgrade govuk_publishing_components (with build fix)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,9 +93,11 @@ GEM
     erubi (1.10.0)
     execjs (2.7.0)
     exifr (1.3.7)
-    faraday (1.1.0)
+    faraday (1.3.0)
+      faraday-net_http (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords
+    faraday-net_http (1.0.0)
     ffi (1.13.1)
     fspath (3.1.2)
     gds-api-adapters (68.2.0)
@@ -116,7 +118,7 @@ GEM
     govuk_frontend_toolkit (9.0.0)
       railties (>= 3.1.0)
       sass (>= 3.2.0)
-    govuk_publishing_components (23.10.1)
+    govuk_publishing_components (23.12.1)
       govuk_app_config
       kramdown
       plek
@@ -135,7 +137,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.5)
+    i18n (1.8.7)
       concurrent-ruby (~> 1.0)
     image_optim (0.27.0)
       exifr (~> 1.2, >= 1.2.2)
@@ -238,7 +240,7 @@ GEM
       thor (~> 1.0)
     rainbow (3.0.0)
     raindrops (0.19.1)
-    rake (13.0.1)
+    rake (13.0.3)
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)

--- a/config/application.rb
+++ b/config/application.rb
@@ -4,6 +4,7 @@ require "rails"
 
 require "action_controller/railtie"
 require "action_view/railtie"
+require "active_support/time"
 require "sprockets/railtie"
 require "rails/test_unit/railtie"
 


### PR DESCRIPTION
Second attempt at merging #2379, this time with a fix for the build issue,
which I've verified works locally.
  
We have to `require "active_support/time"` to define the helper methods
we use to set the Cache-Control header in the [test][] and [development][]
environments.

I don't know why bumping the govuk_publishing_components gem from
v23.10.1 to v23.12.1 has caused this issue in both [Static][]
and [Feedback][] (nor why the tests passed on the PR and only
subsequently failed after merge).

Looking at the Gemfile.lock changes in Static (in
7c79e8dcdd22e88189700dcf8a1d99129532b603), there's no obvious
culprit there. I tried reverting the versions of all dependencies
except govuk_publishing_components, but the issue remained.

Looking at the [diff between the govuk_publishing_components gem versions][diff],
there are no code changes that could have caused this, but there
are a number of Gemfile.lock changes including a minor bump in
`activesupport`, from 6.0 to 6.1, but we've already
[upgraded activesupport via a rails bump][rails-bump], so I'm
not sure why that would be an issue.

It won't be a good use of time to investigate too much further,
so I'm happy that this is a harmless change which unblocks us
from deploying an important fix.

Trello: https://trello.com/c/YhIIykse/2291-3-fix-cross-site-scripting-vulnerabilities

[diff]: https://github.com/alphagov/govuk_publishing_components/compare/v23.10.1..v23.12.1
[development]: https://github.com/alphagov/static/blob/8d40903636dba086f855e3f18a99fa02af5055b8/config/environments/development.rb#L23
[test]: https://github.com/alphagov/static/blob/c2b5079b83094b540ad600663fe656a87bb50df9/config/environments/test.rb#L19
[Static]: https://github.com/alphagov/static/pull/2379
[Feedback]: https://github.com/alphagov/feedback/pull/1149
[rails-bump]: https://github.com/alphagov/static/commit/962f64a97c63563ef35b62a3727f770005eeb0f1