### PR TITLE
Hyphenate the word "sitewide" on search form aria-label

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -16,7 +16,7 @@
   <button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show or hide search</button>
   <% # The /search page redirects to a finder if keywords are included. Be careful about
      # changing this, as the redirect adds some parameters to the search query. %>
-  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search" aria-label="Sitewide">
+  <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search" aria-label="Site-wide">
     <div class="content govuk-clearfix">
       <%= render "govuk_publishing_components/components/search", {
         id: "site-search-text",


### PR DESCRIPTION
VoiceOver reads out the "Sitewide" `aria-label` on the search form in a strange way. It seems that writing it as "Site-wide" helps VoiceOver read it out more clearly.

### Before
https://user-images.githubusercontent.com/7116819/104621026-8eb91500-5687-11eb-800e-59d546c5e8f9.mov

### After
https://user-images.githubusercontent.com/7116819/104621049-95478c80-5687-11eb-89aa-07d07e4afe08.mov




