### PR TITLE
Remove redundant config

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,8 +6,6 @@ REPOSITORY = 'static'
 
 node {
   govuk.buildProject(
-    beforeTest: { sh("yarn install") },
-    sassLint: false,
     publishingE2ETests: true,
     brakeman: true,
   )


### PR DESCRIPTION
The sassLint option was removed in https://github.com/alphagov/govuk-jenkinslib/pull/80
And the Yarn install step is unnecessary as of https://github.com/alphagov/govuk-jenkinslib/pull/82