### PR TITLE
Correct outdated Gds API Adapters usage

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -141,14 +141,9 @@ namespace :publishing_api do
   task publish_special_routes: :environment do
     require "gds_api/publishing_api/special_route_publisher"
 
-    publishing_api = GdsApi::PublishingApiV2.new(
-      Plek.new.find("publishing-api"),
-      bearer_token: ENV["PUBLISHING_API_BEARER_TOKEN"] || "example",
-    )
-
     publisher = GdsApi::PublishingApi::SpecialRoutePublisher.new(
       logger: Logger.new(STDOUT),
-      publishing_api: publishing_api,
+      publishing_api: GdsApi.publishing_api,
     )
 
     ROUTES.each do |route|


### PR DESCRIPTION
The PublishingApiV2 namespace has been removed. I also simplified the Publishing API call since we can use the GdsApi.publishing_api method to access the adapter.