### PR TITLE
Error template markup adjustments

### DIFF
--- a/app/views/root/400.html.erb
+++ b/app/views/root/400.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "Sorry, there is a problem",
-    intro: '<p>Go back and change the information you entered.</p>',
+    intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
     status_code: 400
 } %>

--- a/app/views/root/401.html.erb
+++ b/app/views/root/401.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not permitted to see this page",
-    intro: '<p>This page is restricted to certain users only.</p>',
+    intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
     status_code: 401
 } %>

--- a/app/views/root/403.html.erb
+++ b/app/views/root/403.html.erb
@@ -1,6 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not permitted to see this page",
-    intro: '<p>This page is restricted to certain users only.</p>',
+    intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
     status_code: 403
 } %>
-

--- a/app/views/root/404.html.erb
+++ b/app/views/root/404.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "error_page", locals: {
     heading: "Page not found",
-    intro: '<p>If you entered a web address, check it is correct.</p>
-      <p>You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
     status_code: 404
 } %>

--- a/app/views/root/405.html.erb
+++ b/app/views/root/405.html.erb
@@ -1,6 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not allowed to do this action",
-    intro: '<p>This page does not support the action you requested.</p>',
+    intro: '<p class="govuk-body">This page does not support the action you requested.</p>',
     status_code: 405
 } %>
-

--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "error_page", locals: {
     heading: "The page you’re looking for cannot be found",
-    intro: '<p>If you entered a web address, check it is correct.</p>
-      <p>You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
     status_code: 406
 } %>

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -1,7 +1,7 @@
 <%= render partial: "error_page", locals: {
     heading: "The page you’re looking for is no longer here",
-    intro: '<p>It may have been moved or replaced.</p>
-      <p>If you entered a web address, check it is correct.</p>
-      <p>You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
+    intro: '<p class="govuk-body">It may have been moved or replaced.</p>
+      <p class="govuk-body">If you entered a web address, check it is correct.</p>
+      <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
     status_code: 410
 } %>

--- a/app/views/root/422.html.erb
+++ b/app/views/root/422.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "Sorry, there is a problem",
-    intro: '<p>Go back and change the information you entered.</p>',
+    intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
     status_code: 422
 } %>

--- a/app/views/root/429.html.erb
+++ b/app/views/root/429.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: "error_page", locals: {
     heading: "Sorry, there is a problem",
-    intro: '<p>There have been too many attempts to access this page.</p>
-      <p>Try again later.</p>',
+    intro: '<p class="govuk-body">There have been too many attempts to access this page.</p>
+      <p class="govuk-body">Try again later.</p>',
     status_code: 429
 } %>

--- a/app/views/root/500.html.erb
+++ b/app/views/root/500.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
   heading: "Sorry, we're experiencing technical difficulties",
-  intro: "<p>Please try again in a few moments.</p>",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
   status_code: 500
 } %>

--- a/app/views/root/501.html.erb
+++ b/app/views/root/501.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
   heading: "Sorry, we're experiencing technical difficulties",
-  intro: "<p>Please try again in a few moments.</p>",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
   status_code: 501
 } %>

--- a/app/views/root/502.html.erb
+++ b/app/views/root/502.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
   heading: "Sorry, we're experiencing technical difficulties",
-  intro: "<p>Please try again in a few moments.</p>",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
   status_code: 502
 } %>

--- a/app/views/root/503.html.erb
+++ b/app/views/root/503.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
   heading: "Sorry, we're experiencing technical difficulties",
-  intro: "<p>Please try again in a few moments.</p>",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
   status_code: 503
 } %>

--- a/app/views/root/504.html.erb
+++ b/app/views/root/504.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
   heading: "Sorry, we're experiencing technical difficulties",
-  intro: "<p>Please try again in a few moments.</p>",
+  intro: '<p class="govuk-body">Please try again in a few moments.</p>',
   status_code: 504
 } %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -12,29 +12,26 @@
 <% content_for :body_classes, "mainstream error" %>
 
 <% content_for :wrapper_content do %>
-<main id="content" role="main" class="group">
-  <header class="page-header group">
-    <div>
-      <h1><%= heading %></h1>
-    </div>
-  </header>
-  <div class="article-container">
-    <article role="article" class="group">
-      <div class="inner">
+  <main id="content" role="main" class="govuk-main-wrapper govuk-main-wrapper--l">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= render "govuk_publishing_components/components/title", {
+          title: heading,
+          margin_top: 0,
+        } %>
         <%= raw intro %>
-        <p>You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
+        <p class="govuk-body">You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
         <br/>
         <pre>Status code: <%= status_code %></pre>
       </div>
-    </article>
-  </div>
+    </div>
+  </main>
 
   <%= render "govuk_publishing_components/components/feedback" %>
 
   <script type="text/javascript">
     window.httpStatusCode = '<%= status_code %>';
   </script>
-</main>
 <% end %>
 
 <%= render partial: 'base', locals: { hide_account_navigation: true } %>


### PR DESCRIPTION
Update the error pages layout to more closely match the Design system [pattern for error pages](https://design-system.service.gov.uk/patterns/page-not-found-pages/default/index.html) and amend some spacing issues.

There is now more space between the page header and the content, which were previously too close together on mobile. Additionally, the content is now inside a `two-thirds` column instead of running full-width.

https://trello.com/c/Mmv4gF5o

Before | After
------------ | -------------
<img width="389" alt="Screenshot 2021-01-20 at 10 39 39" src="https://user-images.githubusercontent.com/7116819/105164051-8d1aa180-5b0c-11eb-90ce-ba09354ca3b1.png"> | <img width="384" alt="Screenshot 2021-01-20 at 10 42 35" src="https://user-images.githubusercontent.com/7116819/105164073-9441af80-5b0c-11eb-895a-226e36627c15.png">

### Before
<img width="1224" alt="Screenshot 2021-01-20 at 10 44 00" src="https://user-images.githubusercontent.com/7116819/105164141-ae7b8d80-5b0c-11eb-93af-9923c464b614.png">

### After
<img width="1224" alt="Screenshot 2021-01-20 at 10 43 43" src="https://user-images.githubusercontent.com/7116819/105164127-ac193380-5b0c-11eb-94a7-cb79806e7615.png">

