### PR TITLE
Move skip link to after cookie banner

### DIFF
--- a/app/views/layouts/govuk_template.html.erb
+++ b/app/views/layouts/govuk_template.html.erb
@@ -39,13 +39,13 @@
 
     <%= yield :body_start %>
 
+    <%= render "govuk_publishing_components/components/cookie_banner" %>
+
     <div id="skiplink-container">
       <div>
         <a href="#content" class="skiplink govuk-link"><%= content_for?(:skip_link_message) ? yield(:skip_link_message) : "Skip to main content" %></a>
       </div>
     </div>
-
-    <%= render "govuk_publishing_components/components/cookie_banner" %>
 
     <% unless @omit_header %>
     <header role="banner" id="global-header" class="<%= yield(:header_class) %>">


### PR DESCRIPTION
## What

This switches the order of the cookie banner and the skip link

## Why

This follows the Design System guidance "Position the cookie banner after the opening <body> tag and before the ‘skip to main content’ link." and makes it more likely that users of assistive tech will encounter the cookie information.