### PR TITLE
Split the font property into separate properties for consistency

### DIFF
--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -62,7 +62,9 @@
 
   .govuk-header__link--homepage {
     display: inline-block;
-    font: bold 30px "GDS Transport", nta, Arial, sans-serif;
+    font-weight: bold;
+    font-size: 30px;
+    font-family: "nta", Arial, sans-serif;
     line-height: 1;
 
     &:link,


### PR DESCRIPTION
We've used separate font properties for other areas of GOV.UK. This PR updates to use the same method for consistency, and removed "GDS Transport" from the font stack since we aren't currently using v2 of the font on GOV.UK. 