### PR TITLE
Change Sign in and Sign out paths

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -43,7 +43,7 @@
       },
       {
         text: "Sign out",
-        href: Plek.new.website_root + "/transition-check/logout",
+        href: Plek.new.website_root + "/sign-out",
         data: {
           module: "explicit-cross-domain-links",
           link_for: "accounts-signed-in",
@@ -51,7 +51,7 @@
       },
       {
         text: "Sign in",
-        href: Plek.new.website_root + "/transition-check/login",
+        href: Plek.new.website_root + "/sign-in",
         data: {
           module: "explicit-cross-domain-links",
           link_for: "accounts-signed-out",


### PR DESCRIPTION
[A part of this trello ticket](https://trello.com/c/43FM4pwv/673-switch-to-the-new-sign-in-out-endpoints)

A part of the work to broaden the transition checker login prototype to
the whole of GOV.UK. As outlined in [RFC#134][1] we are moving sign in
and sign out paths from being nested in finder-frontend (which would be
strange for a GOV.UK-wide login!) onto their own paths.

See the RFC for more detail on these two paths:
- [Sign in][2]
- [Sign out][3]

[1]: https://github.com/alphagov/govuk-rfcs/pull/134
[2]: https://github.com/alphagov/govuk-rfcs/pull/134/files#diff-f5a6037308ea735f2a6e63b3080e78792499608bcad7386a49cf94799634d1beR224
[3]: https://github.com/alphagov/govuk-rfcs/pull/134/files#diff-f5a6037308ea735f2a6e63b3080e78792499608bcad7386a49cf94799634d1beR243