### PR TITLE
Update header search button text

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -14,15 +14,19 @@
 
 <% content_for :inside_header do %>
   <button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show or hide search</button>
-  <% # The /search page redirects to a finder if keywords are included. Be careful about
-     # changing this, as the redirect adds some parameters to the search query. %>
+  <%
+    # The /search page redirects to a finder if keywords are included. Be
+    # careful about changing this, as the redirect adds some parameters to the
+    # search query.
+  %>
   <form id="search" class="site-search govuk-clearfix" action="/search" method="get" role="search" aria-label="Site-wide">
     <div class="content govuk-clearfix">
       <%= render "govuk_publishing_components/components/search", {
+        button_text: "Search GOV.UK",
         id: "site-search-text",
         label_text: "Search on GOV.UK",
+        margin_bottom: 0,
         no_border: true,
-        margin_bottom: 0
       } %>
     </div>
   </form>


### PR DESCRIPTION
## What
The button text for the search button in the header has been changed from "Search" to the more specific "Search GOV.UK".

## Why

The default text for the button in the sarch component is "Search" - this means that multiple forms can have the same submit text. This can cause confusion when navigating out of context - for example, a screenreader will pull out all of the interactive elements on a page and list them without the surrounding information.