### PR TITLE
Update error pages to use public layout template

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ development VM it's possible to increase the `proxy_read_timeout` value in
 
 Tests can run in browser at `/specs`
 
-Or in terminal to run only the jasmine tests you can use `RAILS_ENV=test bundle exec rake jasmine:ci`
+Or in terminal to run only the jasmine tests you can use `RAILS_ENV=test bundle exec rake jasmine:ci` or in Docker `govuk-docker run -e RAILS_ENV=test static-lite bundle exec rake jasmine:ci`

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,1 +1,17 @@
-//= require header-footer-only
+//= require govuk_publishing_components/dependencies
+
+//= require govuk_publishing_components/lib/cookie-functions
+//= require govuk_publishing_components/lib/header-navigation
+//= require govuk_publishing_components/lib/track-click
+
+//= require analytics
+
+//= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/feedback
+
+//= require modules/global-bar
+//= require modules/cross-domain-tracking
+
+//= require global-bar-init
+//= require surveys

--- a/app/assets/stylesheets/application-print.scss
+++ b/app/assets/stylesheets/application-print.scss
@@ -1,5 +1,14 @@
-// PRINT STYLESHEET COMPILER
-// OUTPUT
-// The following files and inline CSS will form the output of print.css
-@import "header-footer-only-print";
-@import "helpers/core-print";
+// is-print is used by govuk_frontend_toolkit to alter the printed font-stack
+$is-print: true;
+
+@import "govuk_publishing_components/govuk_frontend_support";
+@import "govuk_publishing_components/component_support";
+
+@import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/feedback";
+@import "govuk_publishing_components/components/print/layout-footer";
+@import "govuk_publishing_components/components/print/layout-header";
+@import "govuk_publishing_components/components/print/search";
+@import "govuk_publishing_components/components/print/skip-link";
+
+@import "helpers/print-base";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,9 +1,16 @@
-$govuk-compatibility-govuktemplate: true;
-$govuk-use-legacy-palette: false;
-
+@import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
-@import "header-footer-only";
 
-// styles
-@import "helpers/organisations";
-@import "helpers/wrapper";
+@import "govuk_publishing_components/components/action-link";
+@import "govuk_publishing_components/components/button";
+@import "govuk_publishing_components/components/cookie-banner";
+@import "govuk_publishing_components/components/feedback";
+@import "govuk_publishing_components/components/input";
+@import "govuk_publishing_components/components/layout-footer";
+@import "govuk_publishing_components/components/layout-for-public";
+@import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/skip-link";
+
+@import "components/emergency-banner";
+@import "components/global-bar";

--- a/app/assets/stylesheets/error-page-print.scss
+++ b/app/assets/stylesheets/error-page-print.scss
@@ -1,10 +1,6 @@
-$govuk-compatibility-govuktemplate: true;
-$govuk-use-legacy-palette: false;
-
 // is-print is used by govuk_frontend_toolkit to alter the printed font-stack
 $is-print: true;
 
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/component_support";
-@import "govuk_publishing_components/components/print/button";
-@import "govuk_publishing_components/components/print/feedback";
+
+@import "govuk_publishing_components/components/print/title";

--- a/app/assets/stylesheets/error-page.scss
+++ b/app/assets/stylesheets/error-page.scss
@@ -1,9 +1,2 @@
-$govuk-compatibility-govuktemplate: true;
-$govuk-use-legacy-palette: false;
-
 @import "govuk_publishing_components/govuk_frontend_support";
-@import "govuk_publishing_components/component_support";
-@import "govuk_publishing_components/components/cookie-banner";
-@import "govuk_publishing_components/components/button";
-@import "govuk_publishing_components/components/feedback";
-@import "govuk_publishing_components/components/action-link";
+@import "govuk_publishing_components/components/title";

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -8,10 +8,26 @@ class RootController < ApplicationController
   caches_page :template
 
   NON_LAYOUT_TEMPLATES = %w[
+    400
+    401
+    403
+    404
+    405
+    406
+    410
+    422
+    429
+    500
+    501
+    502
+    503
+    504
     campaign
+    scheduled_maintenance
     print
     proposition_menu
   ].freeze
+
   def template
     if NON_LAYOUT_TEMPLATES.include?(params[:template])
       render action: params[:template]

--- a/app/views/root/400.html.erb
+++ b/app/views/root/400.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "Sorry, there is a problem",
     intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
-    status_code: 400
+    status_code: 400,
 } %>

--- a/app/views/root/401.html.erb
+++ b/app/views/root/401.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not permitted to see this page",
     intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
-    status_code: 401
+    status_code: 401,
 } %>

--- a/app/views/root/403.html.erb
+++ b/app/views/root/403.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not permitted to see this page",
     intro: '<p class="govuk-body">This page is restricted to certain users only.</p>',
-    status_code: 403
+    status_code: 403,
 } %>

--- a/app/views/root/404.html.erb
+++ b/app/views/root/404.html.erb
@@ -2,5 +2,5 @@
     heading: "Page not found",
     intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
       <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
-    status_code: 404
+    status_code: 404,
 } %>

--- a/app/views/root/405.html.erb
+++ b/app/views/root/405.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "You are not allowed to do this action",
     intro: '<p class="govuk-body">This page does not support the action you requested.</p>',
-    status_code: 405
+    status_code: 405,
 } %>

--- a/app/views/root/406.html.erb
+++ b/app/views/root/406.html.erb
@@ -2,5 +2,5 @@
     heading: "The page you’re looking for cannot be found",
     intro: '<p class="govuk-body">If you entered a web address, check it is correct.</p>
       <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
-    status_code: 406
+    status_code: 406,
 } %>

--- a/app/views/root/410.html.erb
+++ b/app/views/root/410.html.erb
@@ -3,5 +3,5 @@
     intro: '<p class="govuk-body">It may have been moved or replaced.</p>
       <p class="govuk-body">If you entered a web address, check it is correct.</p>
       <p class="govuk-body">You can <a class="govuk-link" href="/">browse from the homepage</a> or use the search box above to find the information you need.</p>',
-    status_code: 410
+    status_code: 410,
 } %>

--- a/app/views/root/422.html.erb
+++ b/app/views/root/422.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
     heading: "Sorry, there is a problem",
     intro: '<p class="govuk-body">Go back and change the information you entered.</p>',
-    status_code: 422
+    status_code: 422,
 } %>

--- a/app/views/root/429.html.erb
+++ b/app/views/root/429.html.erb
@@ -2,5 +2,5 @@
     heading: "Sorry, there is a problem",
     intro: '<p class="govuk-body">There have been too many attempts to access this page.</p>
       <p class="govuk-body">Try again later.</p>',
-    status_code: 429
+    status_code: 429,
 } %>

--- a/app/views/root/500.html.erb
+++ b/app/views/root/500.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-  heading: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we’re experiencing technical difficulties",
   intro: '<p class="govuk-body">Please try again in a few moments.</p>',
-  status_code: 500
+  status_code: 500,
 } %>

--- a/app/views/root/501.html.erb
+++ b/app/views/root/501.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-  heading: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we’re experiencing technical difficulties",
   intro: '<p class="govuk-body">Please try again in a few moments.</p>',
-  status_code: 501
+  status_code: 501,
 } %>

--- a/app/views/root/502.html.erb
+++ b/app/views/root/502.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-  heading: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we’re experiencing technical difficulties",
   intro: '<p class="govuk-body">Please try again in a few moments.</p>',
-  status_code: 502
+  status_code: 502,
 } %>

--- a/app/views/root/503.html.erb
+++ b/app/views/root/503.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-  heading: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we’re experiencing technical difficulties",
   intro: '<p class="govuk-body">Please try again in a few moments.</p>',
-  status_code: 503
+  status_code: 503,
 } %>

--- a/app/views/root/504.html.erb
+++ b/app/views/root/504.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "error_page", locals: {
-  heading: "Sorry, we're experiencing technical difficulties",
+  heading: "Sorry, we’re experiencing technical difficulties",
   intro: '<p class="govuk-body">Please try again in a few moments.</p>',
-  status_code: 504
+  status_code: 504,
 } %>

--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -1,37 +1,40 @@
-<% content_for :title, "#{heading} - GOV.UK" %>
-
 <% content_for :head do %>
   <%= stylesheet_link_tag "error-page", media: "screen" %>
   <%= stylesheet_link_tag "error-page-print", media: "print" %>
 <% end %>
 
-<% content_for :body_end do %>
-  <%= javascript_include_tag "error-page" %>
-<% end %>
+<% if @emergency_banner then
+    emergency_banner = render "components/emergency_banner", {
+      campaign_class: @emergency_banner.campaign_class,
+      heading: @emergency_banner.heading,
+      link: @emergency_banner.link,
+      link_text: @emergency_banner.link_text,
+      short_description: @emergency_banner.short_description,
+    }
+  end
+  user_satisfaction_survey = '<div id="user-satisfaction-survey-container"></div>'
+  global_bar = render "components/global_bar"
+%>
 
-<% content_for :body_classes, "mainstream error" %>
-
-<% content_for :wrapper_content do %>
-  <main id="content" role="main" class="govuk-main-wrapper govuk-main-wrapper--l">
-    <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
-        <%= render "govuk_publishing_components/components/title", {
-          title: heading,
-          margin_top: 0,
-        } %>
-        <%= raw intro %>
-        <p class="govuk-body">You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
-        <br/>
-        <pre>Status code: <%= status_code %></pre>
-      </div>
+<%= render "govuk_publishing_components/components/layout_for_public", {
+  emergency_banner: emergency_banner,
+  full_width: false,
+  global_bar: user_satisfaction_survey + global_bar,
+  title: "#{heading} - GOV.UK",
+} do %>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <%= render "govuk_publishing_components/components/title", {
+        title: heading,
+        margin_top: 0,
+      } %>
+      <%= raw intro %>
+      <p class="govuk-body">You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
+      <pre class="govuk-!-margin-top-8">Status code: <%= status_code %></pre>
     </div>
-  </main>
-
-  <%= render "govuk_publishing_components/components/feedback" %>
-
-  <script type="text/javascript">
-    window.httpStatusCode = '<%= status_code %>';
+  </div>
+  <script>
+    window.httpStatusCode = '<%= status_code %>'
   </script>
 <% end %>
 
-<%= render partial: 'base', locals: { hide_account_navigation: true } %>

--- a/app/views/root/scheduled_maintenance.html.erb
+++ b/app/views/root/scheduled_maintenance.html.erb
@@ -2,12 +2,12 @@
 # This view is fetched by Puppet so that the loadbalancer can serve a nice
 # error when it's put into maintenance mode (to switch off the backend).
 %>
-<%= render partial: 'error_page', locals: {
+<%= render partial: "error_page", locals: {
   status_code: 503,
-  title: 'Scheduled maintenance',
-  heading: 'GOV.UK publishing tools are currently unavailable due to scheduled maintenance',
-  intro: '<p>Contact the GOV.UK lead (Single Point Of Contact) for your department or agency if you need to publish something in an <a href="https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds#emergency-support-requests">emergency</a>.</p>
+  title: "Scheduled maintenance",
+  heading: "GOV.UK publishing tools are currently unavailable due to scheduled maintenance",
+  intro: "<p class='govuk-body'>Contact the GOV.UK lead (Single Point Of Contact) for your department or agency if you need to publish something in an <a href='https://www.gov.uk/guidance/contact-the-government-digital-service/how-to-contact-gds#emergency-support-requests' class='govuk-link'>emergency</a>.</p>
 
-    <p><a href="https://status.publishing.service.gov.uk/">The GOV.UK status page</a> has more information about the scheduled maintenance.</p>',
+    <p class='govuk-body'><a class='govuk-link' href='https://status.publishing.service.gov.uk/'>The GOV.UK status page</a> has more information about the scheduled maintenance.</p>",
 }
 %>

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -4,28 +4,27 @@ class Error4XXTest < ActionDispatch::IntegrationTest
   should "render the 404 template" do
     visit "/templates/404.html.erb"
 
-    assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
       assert page.has_selector?("title", text: "Page not found - GOV.UK", visible: :all)
       assert page.has_selector?("link[href$='application.css']", visible: :all)
     end
 
-    within "body.mainstream.error" do
-      within "header#global-header" do
+    within "body" do
+      within "header.gem-c-layout-header.govuk-header" do
         assert page.has_selector?("form#search")
       end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")
 
-      within "#wrapper" do
+      within "#content" do
         assert page.has_selector?("h1", text: "Page not found")
         assert page.has_selector?("pre", text: "Status code: 404", visible: :all)
       end
 
       within "footer" do
-        assert page.has_selector?(".footer-categories")
-        assert page.has_selector?(".footer-meta")
+        assert page.has_selector?(".govuk-footer__navigation")
+        assert page.has_selector?(".govuk-footer__meta")
       end
     end
 

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -4,28 +4,27 @@ class Error5XXTest < ActionDispatch::IntegrationTest
   should "render the 500 template" do
     visit "/templates/500.html.erb"
 
-    assert page.has_selector?("body.mainstream.error")
     within "head", visible: :all do
-      assert page.has_selector?("title", text: "Sorry, we're experiencing technical difficulties - GOV.UK", visible: :all)
+      assert page.has_selector?("title", text: "Sorry, we’re experiencing technical difficulties - GOV.UK", visible: :all)
       assert page.has_selector?("link[href$='application.css']", visible: :all)
     end
 
-    within "body.mainstream.error" do
-      within "header#global-header" do
+    within "body" do
+      within "header.gem-c-layout-header.govuk-header" do
         assert page.has_selector?("form#search")
       end
 
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")
 
-      within "#wrapper" do
-        assert page.has_selector?("h1", text: "Sorry, we're experiencing technical difficulties")
+      within "#content" do
+        assert page.has_selector?("h1", text: "Sorry, we’re experiencing technical difficulties")
         assert page.has_selector?("pre", text: "Status code: 500", visible: :all)
       end
 
       within "footer" do
-        assert page.has_selector?(".footer-categories")
-        assert page.has_selector?(".footer-meta")
+        assert page.has_selector?(".govuk-footer__navigation")
+        assert page.has_selector?(".govuk-footer__meta")
       end
     end
 


### PR DESCRIPTION
## What

 * The base error page template has been updated to use the public layout component
 * Application stylesheet has been updated to include only the styles needed  for the public layout component, global bar, and emergency banner
 * Application JavaScript has been updated to only include the modules needed for the public layout component
 * Error page stylesheet has only the extra imports needed - in this case, only the the title component was needed
 * Minor tweak to make the apostrophe in the "We're" on some of the error pages look nicer
 * Fixes a minor bug where the heading styles weren't being included, so the `h1` on the error page was using the default browser font size for `h1`s.

## Why
Adding a template to static that uses the public layout component meant updating these error pages first, since they use the same default `application.scss` and `application.js` that the public layout component uses.

The default stylesheet and JavaScript file now contains only the things needed for the public layout component.

## Visual differences

Note - the page footer will look different as it the public layout component uses the [footer component](https://components.publishing.service.gov.uk/component-guide/layout_footer). These changes are outside the scope of this pull request and are best raised as issues on the [govuk_publishing_components repo](https://github.com/alphagov/govuk_publishing_components/issues?q=is%3Aissue+is%3Aopen)

| Page | Before | After |
| - | - | - |
| 400 | ![before - firefox - 400-html-erb](https://user-images.githubusercontent.com/1732331/111992831-c91eb280-8b0d-11eb-8cd6-7039df69694e.png) | ![firefox-400-html-erb](https://user-images.githubusercontent.com/1732331/111992863-d045c080-8b0d-11eb-9567-dcd50a2af449.png) |
| 401 | ![before - firefox - 401-html-erb](https://user-images.githubusercontent.com/1732331/111992834-ca4fdf80-8b0d-11eb-80ee-821d37c9e2b9.png) | ![firefox-401-html-erb](https://user-images.githubusercontent.com/1732331/111992866-d0de5700-8b0d-11eb-9aeb-14aa5fe5a978.png) |
| 403 | ![before - firefox - 403-html-erb](https://user-images.githubusercontent.com/1732331/111992836-cae87600-8b0d-11eb-9a7a-3ebbc70ef957.png) | ![firefox-403-html-erb](https://user-images.githubusercontent.com/1732331/111992868-d0de5700-8b0d-11eb-8a04-579d1c411c20.png) |
| 404 | ![before - firefox - 404-html-erb](https://user-images.githubusercontent.com/1732331/111992839-cb810c80-8b0d-11eb-82ba-5202cce24a07.png) | ![firefox-404-html-erb](https://user-images.githubusercontent.com/1732331/111992870-d176ed80-8b0d-11eb-96df-7c57a70c6086.png) |
| 405 | ![before - firefox - 405-html-erb](https://user-images.githubusercontent.com/1732331/111992840-cb810c80-8b0d-11eb-990c-175fc9265f62.png) | ![firefox-405-html-erb](https://user-images.githubusercontent.com/1732331/111992874-d20f8400-8b0d-11eb-96a0-938450531ee1.png) |
| 406 | ![before - firefox - 406-html-erb](https://user-images.githubusercontent.com/1732331/111992841-cc19a300-8b0d-11eb-99da-1469f228b0ae.png) | ![firefox-406-html-erb](https://user-images.githubusercontent.com/1732331/111992877-d20f8400-8b0d-11eb-8348-c1fad7bcc0ee.png) |
| 410 | ![before - firefox - 410-html-erb](https://user-images.githubusercontent.com/1732331/111992842-ccb23980-8b0d-11eb-948a-6e8b881938bf.png) | ![firefox-410-html-erb](https://user-images.githubusercontent.com/1732331/111992879-d2a81a80-8b0d-11eb-8525-2ff78c25444e.png) |
| 422 | ![before - firefox - 422-html-erb](https://user-images.githubusercontent.com/1732331/111992843-ccb23980-8b0d-11eb-94a4-658d4208b69a.png) | ![firefox-422-html-erb](https://user-images.githubusercontent.com/1732331/111992882-d340b100-8b0d-11eb-952d-8f921e4d31df.png) |
| 429 | ![before - firefox - 429-html-erb](https://user-images.githubusercontent.com/1732331/111992847-cd4ad000-8b0d-11eb-9b4d-5e5f011f91e7.png) | ![firefox-429-html-erb](https://user-images.githubusercontent.com/1732331/111992886-d3d94780-8b0d-11eb-8696-c54caf917c74.png) |
| 500 | ![before - firefox - 500-html-erb](https://user-images.githubusercontent.com/1732331/111992850-cde36680-8b0d-11eb-8d7d-07144a0e3325.png) | ![firefox-500-html-erb](https://user-images.githubusercontent.com/1732331/111992889-d3d94780-8b0d-11eb-8aac-89cf35280dc4.png) |
| 501 | ![before - firefox - 501-html-erb](https://user-images.githubusercontent.com/1732331/111992851-ce7bfd00-8b0d-11eb-8f14-903941d0a503.png) | ![firefox-501-html-erb](https://user-images.githubusercontent.com/1732331/111992890-d471de00-8b0d-11eb-870c-becde7c2f8f4.png) |
| 502 | ![before - firefox - 502-html-erb](https://user-images.githubusercontent.com/1732331/111992857-ce7bfd00-8b0d-11eb-9619-7e71c7f8b72c.png) | ![firefox-502-html-erb](https://user-images.githubusercontent.com/1732331/111992894-d50a7480-8b0d-11eb-90fe-19a4573962cf.png) |
| 503 | ![before - firefox - 503-html-erb](https://user-images.githubusercontent.com/1732331/111992859-cf149380-8b0d-11eb-96f5-cbf7e44292c3.png) | ![firefox-503-html-erb](https://user-images.githubusercontent.com/1732331/111992896-d5a30b00-8b0d-11eb-9384-3ca361d22420.png) |
| 504 | ![before - firefox - 504-html-erb](https://user-images.githubusercontent.com/1732331/111992861-cfad2a00-8b0d-11eb-99eb-d55702544c39.png) | ![firefox-504-html-erb](https://user-images.githubusercontent.com/1732331/111992898-d63ba180-8b0d-11eb-9b69-41cd7fb0a02b.png) |