### PR TITLE
Hide Brexit global bar

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -11,7 +11,7 @@
   coronavirus_href = "/coronavirus"
   coronavirus_subtext = "Rules, guidance and support"
 
-  show_transition_link = true
+  show_transition_link = false
   transition_title = "Brexit"
   transition_href = "/transition"
   transition_subtext = "Check what you need to do"


### PR DESCRIPTION
We are adding a new global banner.
This hides the Brexit link to reduce the size of the global banner.

https://docs.publishing.service.gov.uk/manual/emergency-publishing.html#2-hide-the-brexit-link-from-the-global-bar