### PR TITLE
Change CSS on sitewide banner

### DIFF
--- a/app/assets/stylesheets/components/_emergency-banner.scss
+++ b/app/assets/stylesheets/components/_emergency-banner.scss
@@ -50,12 +50,12 @@
 .emergency-banner__link {
   @include govuk-font(19);
 
-  &:link,
-  &:visited {
+  &.govuk-link:link,
+  &.govuk-link:visited {
     color: govuk-colour("white");
   }
 
-  &:focus {
+  &.govuk-link:focus {
     color: $govuk-focus-text-colour;
   }
 }

--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -7,7 +7,7 @@
           <p class="emergency-banner__description"><%= short_description %></p>
         <% end %>
         <% if link %>
-          <a href="<%= link %>" class="emergency-banner__link govuk-link"><%= link_text %></a>
+          <a href="<%= link %>" class="emergency-banner__link"><%= link_text %></a>
         <% end %>
       </div>
     </div>

--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -7,7 +7,7 @@
           <p class="emergency-banner__description"><%= short_description %></p>
         <% end %>
         <% if link %>
-          <a href="<%= link %>" class="emergency-banner__link"><%= link_text %></a>
+          <a href="<%= link %>" class="emergency-banner__link govuk-link"><%= link_text %></a>
         <% end %>
       </div>
     </div>

--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -4,7 +4,7 @@
       <div class="govuk-grid-column-two-thirds">
         <h2 class="emergency-banner__heading"><%= heading %></h2>
         <% if short_description %>
-          <p class="emergency-banner__description govuk-body"><%= short_description %></p>
+          <p class="emergency-banner__description"><%= short_description %></p>
         <% end %>
         <% if link %>
           <a href="<%= link %>" class="emergency-banner__link govuk-link"><%= link_text %></a>


### PR DESCRIPTION
This code was recently moved and had two CSS classes added which cause the link and summary of the banner to appear black and blue. Removing these classes makes the text appear white, which is the required behaviour.

## Before

<img width="673" alt="Screenshot 2021-04-09 at 13 02 34" src="https://user-images.githubusercontent.com/8124374/114177127-f18f1500-9933-11eb-9f3e-160f83c888eb.png">

## After

<img width="663" alt="Screenshot 2021-04-09 at 13 02 49" src="https://user-images.githubusercontent.com/8124374/114177132-f227ab80-9933-11eb-9b68-d9f817e62536.png">
