### PR TITLE
Remove header overrides

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -20,22 +20,3 @@ $govuk-use-legacy-palette: false;
 @import "helpers/draft";
 @import "helpers/footer";
 @import "helpers/header";
-
-// The following overrides are in place to allow the govuk-header play nicely
-// with govuk_template in our attempt to show account navigation in certain apps
-.header-global {
-  position: relative;
-}
-
-.govuk-header__content {
-  padding: 0 govuk-spacing(3);
-}
-
-.govuk-header__menu-button {
-  top: govuk-spacing(2);
-  right: govuk-spacing(3);
-}
-
-.gem-c-header__nav {
-  clear: both;
-}

--- a/app/assets/stylesheets/helpers/_header.scss
+++ b/app/assets/stylesheets/helpers/_header.scss
@@ -87,6 +87,10 @@
     box-sizing: border-box;
   }
 
+  .header-global {
+    position: relative;
+  }
+
   .header-wrapper .header-global .site-search {
     float: right;
 


### PR DESCRIPTION
These temporary overrides don't have any effect now, so we can remove them. All these declarations end up overridden in production because of additional style added to the layout_header in govuk_publishing_components.