### PR TITLE
Hide the emergency banner when a page is printed

### DIFF
--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -1,4 +1,4 @@
-<div class="emergency-banner emergency-banner--<%= campaign_class %>" role="banner" data-nosnippet>
+<div class="emergency-banner emergency-banner--<%= campaign_class %> dont-print" role="banner" data-nosnippet>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
## What

Stop the emergency banner from appearing when a page is being printed.

Note - whilst the `dont-print` class works and is fine, the preferred `govuk-!-display-none-print` class from GOV.UK Frontend doesn't work because it's imported into a stylesheet with the media set to screen.

## Why

The other banners - cookie, Brexit, and COVID - don't appear when printed. This brings consistency to the behaviour of the banners on the site.

## Visual differences

| Print preview before | Print preview after |
| -- | -- |
| ![Screenshot 2021-04-15 at 13 57 54](https://user-images.githubusercontent.com/1732331/114872954-b63c8c80-9df2-11eb-9043-f786d943a690.png) | ![image](https://user-images.githubusercontent.com/1732331/114872892-a58c1680-9df2-11eb-8263-c29ade2c3bf0.png) |
