### PR TITLE
Rename /transition to /brexit

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -28,7 +28,7 @@ var globalBarInit = {
   urlBlockList: function () {
     var paths = [
       '^/coronavirus/.*$',
-      '^/transition(.cy)?$',
+      '^/brexit(.cy)?$',
       '^/transition-check/.*$',
       '^/eubusiness(\\..*)?$'
     ]

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -13,7 +13,7 @@
 
   show_transition_link = false
   transition_title = "Brexit"
-  transition_href = "/transition"
+  transition_href = "/brexit"
   transition_subtext = "Check what you need to do"
 
   coronavirus_link_margin_bottom = show_transition_link ? { margin_bottom: 3 } : {}

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -108,7 +108,7 @@
             <a data-track-category="footerClicked"
                data-track-action="transitionLinks"
                data-track-label="Check what you need to do"
-               href="/transition"
+               href="/brexit"
                class="govuk-link">
                Check what you need to do
             </a>


### PR DESCRIPTION
www.gov.uk/transition is now www.gov.uk/brexit

https://trello.com/c/wxR5o06H/1539-implement-brexit-landing-page-url-change