### PR TITLE
Update header logo link

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -20,6 +20,7 @@
   emergency_banner: emergency_banner,
   full_width: false,
   global_bar: user_satisfaction_survey + global_bar,
+  logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
   title: "#{heading} - GOV.UK",
 } do %>
   <div class="govuk-grid-row">

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -19,6 +19,7 @@
   emergency_banner: emergency_banner,
   full_width: full_width,
   global_bar: user_satisfaction_survey + global_bar,
+  logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
   navigation_items: [
   {
     text: "Account",
@@ -45,5 +46,4 @@
     },
   }],
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
-
 } %>


### PR DESCRIPTION
## What

Update the `gem_layout` to be able to set the header logo link depending on the what's been set in the environment.

## Why

So that the `gem_layout` template has feature parity with the `core_layout` template.

## Visual differences

None.
