### PR TITLE
Add data attributes for click event to track search submit

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -27,6 +27,11 @@
         label_text: "Search on GOV.UK",
         margin_bottom: 0,
         no_border: true,
+        data_attributes: {
+          track_category: "headerClicked",
+          track_action: "searchSubmitted",
+          track_label: "none",
+        },
       } %>
     </div>
   </form>


### PR DESCRIPTION
## What

Adds data attributes for analytics tracking the search button on the govuk_template based header.

Depends on https://github.com/alphagov/govuk_publishing_components/pull/2110

## Why

As part of gathering some baseline data ahead of updating the header design.

## Visual changes

None

[Trello](https://trello.com/c/CwPwNE60/321-implement-analytics-tracking-on-the-existing-headers)