### PR TITLE
Add routing constraints to restrict icon formats

### DIFF
--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,3 +2,5 @@
 
 # Add new mime types for use in respond_to blocks:
 # Mime::Type.register "text/richtext", :rtf
+
+Mime::Type.register "image/x-icon", :ico

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,27 +16,38 @@ Rails.application.routes.draw do
   end
 
   # Icon redirects
-  get "/favicon.ico", to: "icon_redirects#show"
-  get "/apple-touch-icon.png", to: "icon_redirects#show"
-  get "/apple-touch-icon-180x180.png", to: "icon_redirects#show"
-  get "/apple-touch-icon-167x167.png", to: "icon_redirects#show"
-  get "/apple-touch-icon-152x152.png", to: "icon_redirects#show"
+  controller "icon_redirects" do
+    scope action: "show" do
+      scope format: "ico" do
+        get "/favicon"
+      end
 
-  # Old devices with old OSs may still request these old image sizes
-  # They should receive a working image.
-  # It's acceptable to send them a higher resolution image which they will downscale.
-  # https://mathiasbynens.be/notes/touch-icons
-  get "/apple-touch-icon-120x120.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-76x76.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-60x60.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-114x114-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-120x120-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-144x144-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-152x152-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-176x176-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-180x180-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-57x57-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-72x72-precomposed.png", to: "icon_redirects#apple_old_size_icon"
-  get "/apple-touch-icon-76x76-precomposed.png", to: "icon_redirects#apple_old_size_icon"
+      scope format: "png" do
+        get "/apple-touch-icon"
+        get "/apple-touch-icon-180x180"
+        get "/apple-touch-icon-167x167"
+        get "/apple-touch-icon-152x152"
+      end
+    end
+
+    # Old devices with old OSs may still request these old image sizes
+    # They should receive a working image.
+    # It's acceptable to send them a higher resolution image which they will downscale.
+    # https://mathiasbynens.be/notes/touch-icons
+    scope action: "apple_old_size_icon", format: "png" do
+      get "/apple-touch-icon-120x120"
+      get "/apple-touch-icon-76x76"
+      get "/apple-touch-icon-60x60"
+      get "/apple-touch-icon-precomposed"
+      get "/apple-touch-icon-114x114-precomposed"
+      get "/apple-touch-icon-120x120-precomposed"
+      get "/apple-touch-icon-144x144-precomposed"
+      get "/apple-touch-icon-152x152-precomposed"
+      get "/apple-touch-icon-176x176-precomposed"
+      get "/apple-touch-icon-180x180-precomposed"
+      get "/apple-touch-icon-57x57-precomposed"
+      get "/apple-touch-icon-72x72-precomposed"
+      get "/apple-touch-icon-76x76-precomposed"
+    end
+  end
 end

--- a/test/integration/icon_redirects_test.rb
+++ b/test/integration/icon_redirects_test.rb
@@ -43,4 +43,21 @@ class IconRedirectsTest < ActionDispatch::IntegrationTest
       assert_equal "http://example.org/assets/static/apple-touch-icon.png", last_response.location
     end
   end
+
+  [
+    "favicon.txt",
+    "favicon.ico.txt",
+    "apple-touch-icon.txt",
+    "apple-touch-icon.png.txt",
+    "apple-touch-icon-180x180.txt",
+    "apple-touch-icon-180x180.png.txt",
+    "apple-touch-icon-167x167.txt",
+    "apple-touch-icon-167x167.png.txt",
+    "apple-touch-icon-152x152.txt",
+    "apple-touch-icon-152x152.png.txt",
+  ].each do |file|
+    should "raise a routing error for disallowed content types" do
+      assert_raises(ActionController::RoutingError) { get "/#{file}" }
+    end
+  end
 end


### PR DESCRIPTION
Previously the icon redirect routes would accept any format and be recognised. Since this path is passed directly into `asset_path` to find the destination digest path for the redirect it seems advisable to only allow the expected types.

The paths could've been set to `format: false` but this leaves them being recognised as the default type (text/html) which could have unintended side effects.