### PR TITLE
Update Account links in the `gem_layout` template

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -36,7 +36,7 @@
   <% unless hide_account_navigation %>
     <%= render "govuk_publishing_components/components/layout_header", {
       remove_bottom_border: true,
-      navigation_items: [
+      navigation_items: [ # Remember to update the links in _gem_base.html.erb as well.
       {
         text: "Account",
         href: Plek.new.find("account-manager"),

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -20,7 +20,7 @@
   full_width: full_width,
   global_bar: user_satisfaction_survey + global_bar,
   logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
-  navigation_items: [
+  navigation_items: [ # Remember to update the links in _base.html.erb as well.
   {
     text: "Account",
     href: Plek.new.find("account-manager"),
@@ -31,7 +31,7 @@
   },
   {
     text: "Sign out",
-    href: Plek.new.website_root + "/transition-check/logout",
+    href: Plek.new.website_root + "/sign-out",
     data: {
       module: "explicit-cross-domain-links",
       link_for: "accounts-signed-in",
@@ -39,7 +39,7 @@
   },
   {
     text: "Sign in",
-    href: Plek.new.website_root + "/transition-check/login",
+    href: Plek.new.website_root + "/sign-in",
     data: {
       module: "explicit-cross-domain-links",
       link_for: "accounts-signed-out",


### PR DESCRIPTION
## What

Update the Account sign in / sign out / account links in the header section of the `gem_layout` template to match the links in `core_layout` template.

## Why

The links weren't updated when `core_layout` was updated.

## Visual changes

None.
