### PR TITLE
Add and update survey styles to gem layout template

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,3 +14,4 @@
 
 @import "components/emergency-banner";
 @import "components/global-bar";
+@import "components/survey";

--- a/app/assets/stylesheets/components/_survey.scss
+++ b/app/assets/stylesheets/components/_survey.scss
@@ -46,7 +46,6 @@
   }
 
   .survey-wrapper {
-    @extend %site-width-container;
     padding-top: govuk-spacing(3);
     padding-bottom: govuk-spacing(4);
     clear: both;
@@ -113,5 +112,9 @@
     &:focus {
       outline: 3px solid $govuk-focus-colour;
     }
+  }
+
+  .js-hidden {
+    display: none;
   }
 }

--- a/docs/slimmer_templates.md
+++ b/docs/slimmer_templates.md
@@ -2,7 +2,7 @@
 
 ## `gem_layout`
 
-This template uses the [public layout component] from the GOV.UK Publishing Components gem. It supplies the header and footer only - this includes the cookie banner, skip to content link, header bar, emergency banner, survery banner, global bar, feedback, and footer. The content is constrained and centred.
+This template uses the [public layout component] from the GOV.UK Publishing Components gem. It supplies the header and footer only - this includes the cookie banner, skip to content link, header bar, emergency banner, survey banner, global bar, feedback, and footer. The content is constrained and centred.
 
 ## `gem_layout_full_width`
 


### PR DESCRIPTION
## What

Adds to the `gem_layout` template, as the styles were missing but the ability to show surveys was not.

## Why

The survey banner was being shown without any styles and looked quite broken.

## Visual differences
Before:

![image](https://user-images.githubusercontent.com/1732331/122259747-62b9ee00-ceca-11eb-86f5-58046b3e6706.png)


After:

![image](https://user-images.githubusercontent.com/1732331/122259847-82511680-ceca-11eb-99de-55e9ec6f9df0.png)
