### PR TITLE
Add explore_header templates

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_super_navigation_header ||= false # will be shown or hidden by A/B Test variable
+  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : false # will be shown or hidden by A/B Test variable
 %>
 
 <% if show_super_navigation_header %>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -12,6 +12,8 @@
   <%= render :partial => 'stylesheet', :locals => { :css_file => local_assigns[:css_file] || 'application' } %>
 <% end %>
 
+<% content_for :show_explore_header, local_assigns[:show_explore_header] %>
+
 <% content_for :inside_header do %>
   <button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show or hide search</button>
   <%

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,10 +1,11 @@
 <%
   @emergency_banner = emergency_banner_notification
 
-  product_name ||= nil
-  omit_feedback_form ||= nil
   logo_link ||= Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/"
   full_width ||= false
+  omit_feedback_form ||= nil
+  product_name ||= nil
+  show_explore_header ||= false
 
   if @emergency_banner
     emergency_banner = render "components/emergency_banner", {
@@ -23,10 +24,8 @@
 <%= render "govuk_publishing_components/components/layout_for_public", {
   emergency_banner: emergency_banner.presence,
   full_width: full_width,
-  omit_feedback_form: omit_feedback_form,
   global_bar: user_satisfaction_survey + global_bar,
   logo_link: logo_link,
-  product_name: product_name,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
   {
     text: "Account",
@@ -52,5 +51,8 @@
       link_for: "accounts-signed-out",
     },
   }],
+  omit_feedback_form: omit_feedback_form,
+  product_name: product_name,
+  show_explore_header: show_explore_header,
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
 } %>

--- a/app/views/root/core_layout_explore_header.html.erb
+++ b/app/views/root/core_layout_explore_header.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: 'base', locals: {
+  hide_nav: true, # no breadcrumbs, you can include them using components if
+                  # you need them, rather than using slimmer
+  show_explore_header: true,
+  css_file: 'core-layout',
+  js_file: 'header-footer-only'
+} %>

--- a/app/views/root/gem_layout_explore_header.html.erb
+++ b/app/views/root/gem_layout_explore_header.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "gem_base", locals: { show_explore_header: true } %>

--- a/app/views/root/header_footer_only_explore_header.html.erb
+++ b/app/views/root/header_footer_only_explore_header.html.erb
@@ -1,4 +1,5 @@
 <%= render partial: 'base', locals: {
   css_file: 'header-footer-only',
   js_file: 'header-footer-only',
+  show_explore_header: true,
 } %>


### PR DESCRIPTION
This will allow us to switch between the current header menu and the newer design that we want to AB test with. This means that frontend apps using the AB Test gem can request a different template via Slimmer.

See https://github.com/alphagov/government-frontend/pull/2156 for example

Trello https://trello.com/c/LUhrajXF/323-prepare-the-new-menu-a-b-test-for-sections-of-govuk