### PR TITLE
Add feature flag for new link styles

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,3 +1,5 @@
+$govuk-new-link-styles: true;
+
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 


### PR DESCRIPTION
## What
Apply's the feature flag for new link styles from the latest release of GOV.UK Frontend

## Why
For the new gem layout, the component styles in static are overriding a few things across govuk apps. This has meant that apps that are currently set to use the new link styles and the gem layout are using mixed link styles. This ensure that we are using the new link styles everywhere.