### PR TITLE
Add account pages to global bar BlockList

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -30,7 +30,8 @@ var globalBarInit = {
       '^/coronavirus/.*$',
       '^/brexit(.cy)?$',
       '^/transition-check/.*$',
-      '^/eubusiness(\\..*)?$'
+      '^/eubusiness(\\..*)?$',
+      '^/account/.*$'
     ]
 
     var ctaLink = document.querySelector('.js-call-to-action')


### PR DESCRIPTION
The Accounts team are moving the account homepage to the `frontend` app, with the plan of transitioning other parts of the account manager to be rendered by `frontend`, as we retire the `govuk-account-manager-prototype` app. 

Seeing as the `frontend` app uses `static`, the global bar (currently Coronavirus bar) is automatically added to the new `/account/home` page. The design for the account manager excludes this additional bar currently.

This adds paths beginning with `/account/` (assuming that any future account-related pages will live under `/account`) to the `urlBlockList` in the global bar script.

### Before (bar)
<img width="1091" alt="Screenshot 2021-06-21 at 16 52 48" src="https://user-images.githubusercontent.com/7116819/122794440-2dd7dd80-d2b4-11eb-9636-6c3f3b11cf52.png">

### After (no bar)
<img width="1088" alt="Screenshot 2021-06-21 at 16 56 02" src="https://user-images.githubusercontent.com/7116819/122794642-624b9980-d2b4-11eb-9211-bc5138d71c74.png">

------
https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page