### PR TITLE
Add emergency banner helper to gem_layout

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,4 +1,6 @@
 <%
+  @emergency_banner = emergency_banner_notification
+
   full_width ||= false
 
   if @emergency_banner
@@ -16,7 +18,7 @@
 %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
-  emergency_banner: emergency_banner,
+  emergency_banner: emergency_banner.presence,
   full_width: full_width,
   global_bar: user_satisfaction_survey + global_bar,
   logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",


### PR DESCRIPTION
## What

Adds in the emergency banner helper into the `gem_layout` template

## Why

So that the emergency banner can be deployed successfully to frontend applications that are using the `gem_layout` template

## Visual changes

Homepage (frontend) before:

![Screenshot 2021-06-22 at 15-12-52 Welcome to GOV UK](https://user-images.githubusercontent.com/1732331/123072599-96869d80-d40d-11eb-894e-ed75c095dc09.png)

Homepage (frontend) after:

![Screenshot 2021-06-22 at 15-12-32 Welcome to GOV UK](https://user-images.githubusercontent.com/1732331/123072653-a0a89c00-d40d-11eb-9633-ab8e0e329f6d.png)

Browse (collections) before:

![Screenshot 2021-06-22 at 15-13-35 All categories - GOV UK](https://user-images.githubusercontent.com/1732331/123072792-bfa72e00-d40d-11eb-978c-8231635e3a1a.png)

Browse (collections after:
![Screenshot 2021-06-22 at 15-13-27 All categories - GOV UK](https://user-images.githubusercontent.com/1732331/123072805-c33ab500-d40d-11eb-8fd6-b5a1744f9f51.png)


