### PR TITLE
Add gem layout template variation for accounts

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -25,6 +25,7 @@ class RootController < ApplicationController
     campaign
     gem_layout
     gem_layout_full_width
+    gem_layout_account
     scheduled_maintenance
     print
     proposition_menu

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,6 +1,9 @@
 <%
   @emergency_banner = emergency_banner_notification
 
+  product_name ||= nil
+  omit_feedback_form ||= nil
+  logo_link ||= Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/"
   full_width ||= false
 
   if @emergency_banner
@@ -20,8 +23,10 @@
 <%= render "govuk_publishing_components/components/layout_for_public", {
   emergency_banner: emergency_banner.presence,
   full_width: full_width,
+  omit_feedback_form: omit_feedback_form,
   global_bar: user_satisfaction_survey + global_bar,
-  logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
+  logo_link: logo_link,
+  product_name: product_name,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
   {
     text: "Account",

--- a/app/views/root/gem_layout_account.html.erb
+++ b/app/views/root/gem_layout_account.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "gem_base", locals: {
+  product_name: "Account",
+  logo_link: Plek.find('account-manager'),
+  omit_feedback_form: true,
+} %>

--- a/docs/slimmer_templates.md
+++ b/docs/slimmer_templates.md
@@ -10,6 +10,12 @@ This is the same as the `gem_layout` template, except that this layout **doesn't
 
 Use this layout if you want to have full width content - such as the blue welcome bar on the GOV.UK homepage.
 
+## `gem_layout_account`
+
+This is a variation on the `gem_layout` template intended to be used on GOV.UK Account pages. This layout **doesn't** include the feedback component as the account pages use a different one from the rest of GOV.UK.
+
+This also includes the Account product name in the layout header and changes the logo link to the account homepage link.
+
 ## `core_layout` (default)
 
 This template contains styles for the black header bar, the footer and core layout classes. By default it will centre your content to the same width as the GOV.UK header. It provides classes for grid layouts using the column mixins from the frontend toolkit.


### PR DESCRIPTION
The Accounts team are [in the process of](https://github.com/alphagov/frontend/compare/msw/account-home-page) moving over some of the account pages to the `frontend` app. 

Since `frontend` app uses `static`, and certain aspects of the account manager template differ greatly from the default `gem_layout`, this warrants the introduction of a new template for use on accounts related pages (thanks @injms for suggesting this approach).
Some main differences are:
- the Account home link in the header should link to the account homepage (as opposed to linking to the GOVUK homepage)
- the Account product name should be present in the header
- there should be an account nav in the header
- the feedback component at the bottom of the page should be hidden as the account has its own version of a feedback component/link (the **Help improve GOV.UK accounts** box at the bottom of [this page](https://www.account.publishing.service.gov.uk/sign-in))

----

**Important**: depends on https://github.com/alphagov/govuk_publishing_components/pull/2160

-----

https://trello.com/c/lIDQNATi/813-implement-the-govuk-account-home-page