### PR TITLE
Fix survey banner layout

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -15,7 +15,7 @@
   var templateBase = function (children) {
     return (
       '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-      '  <div class="survey-wrapper">' +
+      '  <div class="survey-wrapper govuk-width-container">' +
       '    <a class="govuk-link survey-close-button" href="#user-survey-cancel" aria-labelledby="survey-title user-survey-cancel" id="user-survey-cancel" role="button">Close</a>' +
       '    <h2 class="survey-title" id="survey-title">{{title}}</h2>' +
            children +


### PR DESCRIPTION
### What & Why
Set a "govuk-width-container" to make sure the content of the banner doesn't go full-width.

### Note
The change was tested with both `core_layout` (see `smart-answer` example below) and `gem_layout` (with [`collections`](https://github.com/alphagov/collections/pull/2446))

### Visual changes
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![smart-answers-before](https://user-images.githubusercontent.com/788096/123403096-51df3b80-d5a0-11eb-96a3-af58d58e0d7d.png)


</td><td valign="top">

![smart-answers-after](https://user-images.githubusercontent.com/788096/123403110-54419580-d5a0-11eb-814f-8fd78fc6ee05.png)


</td></tr>
</table>

[Trello card](https://trello.com/c/qQ5Je6n4)