### PR TITLE
Add explore header templates for public_layout in gem

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,6 +8,7 @@
 
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/feedback
 
 //= require modules/global-bar

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-for-public";
 @import "govuk_publishing_components/components/layout-header";
+@import "govuk_publishing_components/components/layout-super-navigation-header";
 @import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/skip-link";
 

--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -24,7 +24,9 @@ class RootController < ApplicationController
     504
     campaign
     gem_layout
+    gem_layout_explore_header
     gem_layout_full_width
+    gem_layout_full_width_explore_header
     gem_layout_account
     scheduled_maintenance
     print

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: 'gem_base', locals: {
+  full_width: true,
+  show_explore_header: true,
+} %>


### PR DESCRIPTION
For the apps that are on the gem based public_layout template (currently Frontend and Collections) we need to be able to specify which header we want to show the user. Accompanying PR here for the Explore Super Menu being added to the gem is https://github.com/alphagov/govuk_publishing_components/pull/2179/

Trello https://trello.com/c/fYNA3mnu/390-prep-ab-test-for-frontend-and-collections