### PR TITLE
Add account pages to global survey blocklist

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -317,14 +317,15 @@
     },
 
     pathInBlocklist: function () {
-      var blackList = new RegExp('^/(?:' +
+      var blockList = new RegExp('^/(?:' +
         /service-manual/.source +
         /|coronavirus/.source +
-        // add more blacklist paths in the form:
-        // + /|path-to\/blacklist/.source
+        /|account/.source +
+        // add more blockList paths in the form:
+        // + /|path-to\/blockList/.source
         ')(?:/|$)'
       )
-      return blackList.test(userSurveys.currentPath())
+      return blockList.test(userSurveys.currentPath())
     },
 
     userCompletedTransaction: function () {

--- a/spec/javascripts/surveys.spec.js
+++ b/spec/javascripts/surveys.spec.js
@@ -614,6 +614,18 @@ describe('Surveys', function () {
       expect(surveys.pathInBlocklist()).toBeFalsy()
     })
 
+    it('returns true if the path is /account', function () {
+      spyOn(surveys, 'currentPath').and.returnValues('/account', '/account/')
+      expect(surveys.pathInBlocklist()).toBeTruthy()
+      expect(surveys.pathInBlocklist()).toBeTruthy()
+    })
+
+    it('returns true if the path is a sub-folder under /account', function () {
+      spyOn(surveys, 'currentPath').and.returnValues('/account/home', '/account/home/')
+      expect(surveys.pathInBlocklist()).toBeTruthy()
+      expect(surveys.pathInBlocklist()).toBeTruthy()
+    })
+
     it('returns false otherwise', function () {
       spyOn(surveys, 'currentPath').and.returnValue('/')
       expect(surveys.pathInBlocklist()).toBeFalsy()


### PR DESCRIPTION
Disable the survey prompt for pages under `/account`. 

One reason for this is that there are already other prompts for feedback on all account pages. Having yet another one adds unnecessary noise. 

Another reason is to keep `gov.uk/account/home` (rendered by `frontend`) consistent with the other account pages which are currently still rendered with the `govuk-account-manager-prototype` app, and do not use the user satisfaction survey.