### PR TITLE
Update header links href to new account manager home

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -46,7 +46,7 @@
       navigation_items: [ # Remember to update the links in _gem_base.html.erb as well.
       {
         text: "Account",
-        href: Plek.new.find("account-manager"),
+        href: Plek.new.website_root + "/account/home",
         data: {
           module: "explicit-cross-domain-links",
           link_for: "accounts-signed-in",

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -29,7 +29,7 @@
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
   {
     text: "Account",
-    href: Plek.new.find("account-manager"),
+    href: Plek.new.website_root + "/account/home",
     data: {
       module: "explicit-cross-domain-links",
       link_for: "accounts-signed-in",

--- a/app/views/root/gem_layout_account.html.erb
+++ b/app/views/root/gem_layout_account.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: "gem_base", locals: {
   product_name: "Account",
-  logo_link: Plek.find('account-manager'),
+  logo_link: Plek.new.website_root + "/account/home",
   omit_feedback_form: true,
 } %>


### PR DESCRIPTION
We are moving the account homepage to `gov.uk/account/home`. 

This updates the `href` for the header nav links which used to point to `account.publishing.service.gov.uk`, to now point to `gov.uk/account/home` instead.