### PR TITLE
Coronavirus banner to no longer reference "rules"

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -9,7 +9,7 @@
   show_coronavirus_link = true
   coronavirus_title = "Coronavirus (COVID-19)"
   coronavirus_href = "/coronavirus"
-  coronavirus_subtext = "Rules, guidance and support"
+  coronavirus_subtext = "Guidance and support"
 
   show_transition_link = false
   transition_title = "Brexit"


### PR DESCRIPTION
Trello: https://trello.com/c/R2SasXMA/503-govuk-sitewide-banner-text-change

Not to be deployed until the government guidance changes on the 19th July

Before:

![Screenshot 2021-07-16 at 12 09 16](https://user-images.githubusercontent.com/282717/125938781-dfc7f7ba-1e58-46ca-8299-ee52d7265a4b.png)

After:

![Screenshot 2021-07-16 at 12 08 51](https://user-images.githubusercontent.com/282717/125938742-bd72d976-dbe0-4541-8309-31a13026bb5c.png)

