### PR TITLE
Add `gem_layout` variations

### DIFF
--- a/app/views/root/gem_layout_no_feedback_form.html.erb
+++ b/app/views/root/gem_layout_no_feedback_form.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "gem_base", locals: { omit_feedback_form: true } %>

--- a/app/views/root/gem_layout_no_footer_navigation.html.erb
+++ b/app/views/root/gem_layout_no_footer_navigation.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "gem_base", locals: { omit_footer_links: true } %>


### PR DESCRIPTION
 - Add `gem_layout_no_feedback_form` template [for `feedback` to use the new layout](alphagov/feedback#1266)
 - Add `gem_layout_no_footer_navigation` template [for `service-manual-frontend` to use the new layout](https://github.com/alphagov/service-manual-frontend/pull/960) (in a subsequent PR `without_footer_links` template will be removed)

### Note
This PR currently fails tests as it awaits for https://github.com/alphagov/govuk_publishing_components/pull/2218 to be released.