### PR TITLE
Remove `em()` mixin import

### DIFF
--- a/app/assets/stylesheets/header-footer-only.scss
+++ b/app/assets/stylesheets/header-footer-only.scss
@@ -2,8 +2,6 @@ $govuk-compatibility-govuktemplate: true;
 $govuk-use-legacy-palette: false;
 
 @import "govuk_publishing_components/govuk_frontend_support";
-// The search component requires this helper mixin to render height #PR-2380
-@import "govuk_publishing_components/components/helpers/px-to-em";
 @import "govuk_publishing_components/components/cookie-banner";
 // collections uses the action-link component and relies upon this line, see
 // https://github.com/alphagov/collections/pull/1754


### PR DESCRIPTION
The search component use to make use of this mixin, but it was [later updated to use `govuk-em()`](https://github.com/alphagov/govuk_publishing_components/pull/2034) via `govuk-frontend` so it's no longer needed by `static`.