### PR TITLE
Bump to latest components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_publishing_components (24.20.0)
+    govuk_publishing_components (24.21.0)
       govuk_app_config
       kramdown
       plek


### PR DESCRIPTION
Dependabot seems to have failed on this one. We need the latest gem to get some scroll tracking updates.