### PR TITLE
Convert the search button to be a link by default

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -15,7 +15,7 @@
 <% content_for :show_explore_header, local_assigns[:show_explore_header] %>
 
 <% content_for :inside_header do %>
-  <button class="search-toggle js-header-toggle" data-search-toggle-for="search">Show or hide search</button>
+  <a class="search-toggle js-header-toggle" data-search-toggle-for="search" data-button-text="Show or hide search" href="/search">Search on GOV.UK</a>
   <%
     # The /search page redirects to a finder if keywords are included. Be
     # careful about changing this, as the redirect adds some parameters to the


### PR DESCRIPTION
## What
Convert the search button seen on menu's with navigation on gov.uk ([example](https://www.gov.uk/government/publications/school-inspections-a-guide-for-parents)) to an `a` tag by default.

## Why
Currently, when js is turned off for pages with this menu, the search button doesn't do anything. This ensures that it's default state is a link, making it interactable regardless of js.

Cannot be merged until https://github.com/alphagov/govuk_publishing_components/pull/2235 has been merged and deployed.

No visual changes

[Card](https://trello.com/c/8unZtntm/341-fix-the-search-link-in-the-no-js-mobile-version-of-the-old-menu-bar)