### PR TITLE
Remove redundant JavaScript import

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,7 +1,6 @@
 //= require govuk_publishing_components/dependencies
 
 //= require govuk_publishing_components/lib/cookie-functions
-//= require govuk_publishing_components/lib/header-navigation
 
 //= require analytics
 


### PR DESCRIPTION
### What
Remove redundant `govuk_publishing_components/lib/header-navigation` import

### Why
`header-navigation` is already required and executed by all public-facing applications as part of `govuk_publishing_components/lib`. Given `header-navigation` is not an actual module, but a IIFE relict from `govuk_template`, this duplication results in two toggle-like events being attached to the same button, which causes the search button to open and close itself in one click

Note

- [ ] requires [`frontend` to be brought in line with the other apps](https://github.com/alphagov/frontend/pull/2901) using the `gem_layout` (namely `collections`, `email-alert-frontend`, `feedback`, `info-frontend`, `licence-finder` and `smart-answers`).