### PR TITLE
Add data-toggle-name to old buttons

### DIFF
--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -15,7 +15,7 @@
 <% content_for :show_explore_header, local_assigns[:show_explore_header] %>
 
 <% content_for :inside_header do %>
-  <a class="search-toggle js-header-toggle" data-search-toggle-for="search" data-button-text="Show or hide search" href="/search">Search on GOV.UK</a>
+  <a class="search-toggle js-header-toggle" data-button-name="search" data-search-toggle-for="search" data-button-text="Show or hide search" href="/search">Search on GOV.UK</a>
   <%
     # The /search page redirects to a finder if keywords are included. Be
     # careful about changing this, as the redirect adds some parameters to the

--- a/app/views/root/proposition_menu.html.erb
+++ b/app/views/root/proposition_menu.html.erb
@@ -1,5 +1,5 @@
 <div class="header-proposition">
   <div class="content">
-    <button data-search-toggle-for="proposition-links" class="js-header-toggle mobile-menu-toggle">Menu</button>
+    <button data-button-name="menu" data-search-toggle-for="proposition-links" class="js-header-toggle mobile-menu-toggle">Menu</button>
   </div>
 </div>


### PR DESCRIPTION
The Search and Menu buttons in mobile view for the older "proposition" menu used in government-frontend for Whitehall style templates needs this attribute for tracking.

https://trello.com/c/2Jv5BrTu