### PR TITLE
Bump govuk_publishing_components

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_publishing_components (25.3.1)
+    govuk_publishing_components (25.4.0)
       govuk_app_config
       kramdown
       plek


### PR DESCRIPTION
Trello: https://trello.com/c/pATsfsuD/524-convert-finder-frontend-module-initialisers-in-livesearchjs-to-not-use-jquery

I've expedited this release because https://github.com/alphagov/finder-frontend/pull/2617 requires this change and I'd forgotten static needs to be also updated.