### PR TITLE
Enable draft on public layout

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -18,3 +18,5 @@ $govuk-new-link-styles: true;
 @import "components/emergency-banner";
 @import "components/global-bar";
 @import "components/survey";
+
+@import "helpers/draft";

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -11,6 +11,7 @@
   show_explore_header ||= false
   show_account_layout ||= false
   account_nav_location ||= nil
+  drat_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
 
   if @emergency_banner
     emergency_banner = render "components/emergency_banner", {
@@ -63,5 +64,6 @@
   show_explore_header: show_explore_header,
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
   show_account_layout: show_account_layout,
-  account_nav_location: account_nav_location
+  account_nav_location: account_nav_location,
+  draft_watermark: drat_environment
 } %>


### PR DESCRIPTION
A `draft` class is used to apply a watermark when previewing documents in publishing applications. A smokey test is currently failing as this class is missing in applications using the new `gem_layout`.

- [x] Dependent on https://github.com/alphagov/govuk_publishing_components/pull/2276 to enable the `draft_watermak` feature in `layout_for_public`.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

![govuk-static-enable-dra-yqwopb herokuapp com_templates_gem_layout_no_footer_navigation html erb (1)](https://user-images.githubusercontent.com/788096/130221999-4ed5bb5c-cee3-4e97-816d-85b76f22c0e7.png)


</td><td valign="top">

![govuk-static-enable-dra-yqwopb herokuapp com_templates_gem_layout_no_footer_navigation html erb](https://user-images.githubusercontent.com/788096/130222006-4676fec4-39e4-4e13-868f-db14c05fbfd7.png)


</td></tr>
</table>
