### PR TITLE
Add `gem_layout_header_navigation` template

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -28,6 +28,7 @@ class RootController < ApplicationController
     gem_layout_explore_header
     gem_layout_full_width
     gem_layout_full_width_explore_header
+    gem_layout_header_navigation
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
     scheduled_maintenance

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -11,6 +11,7 @@
   show_explore_header ||= false
   show_account_layout ||= false
   account_nav_location ||= nil
+  show_default_header_navigation_items ||= false
   drat_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
 
   if @emergency_banner
@@ -65,5 +66,6 @@
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
   show_account_layout: show_account_layout,
   account_nav_location: account_nav_location,
-  draft_watermark: drat_environment
+  draft_watermark: drat_environment,
+  show_default_header_navigation_items: show_default_header_navigation_items
 } %>

--- a/app/views/root/gem_layout_header_navigation.html.erb
+++ b/app/views/root/gem_layout_header_navigation.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "gem_base", locals: { show_default_header_navigation_items: true } %>


### PR DESCRIPTION
### What

Add `gem_layout_header_navigation` template

### Why

A set of applications [1][2][3] require a header navigation (sometimes referred to as 'proposition menu') which is only available in `core_layout` at the moment.

### Checklist

- [ ] Dependent on https://github.com/alphagov/govuk_publishing_components/pull/2292

[1] https://github.com/alphagov/whitehall/pull/6240
[2] https://github.com/alphagov/finder-frontend/pull/2616
[3] https://github.com/alphagov/government-frontend/pull/2206