### PR TITLE
Set the navigation header as default

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -24,14 +24,15 @@ class RootController < ApplicationController
     504
     campaign
     gem_layout
-    gem_layout_old_header
     gem_layout_account_manager
     gem_layout_explore_header
     gem_layout_full_width
-    gem_layout_full_width_old_header
     gem_layout_full_width_explore_header
+    gem_layout_full_width_old_header
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
+    gem_layout_old_header
+    gem_layout_old_header_full_width
     scheduled_maintenance
     print
     proposition_menu

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : false # will be shown or hidden by A/B Test variable
+  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : true
 %>
 
 <% if show_super_navigation_header %>

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -8,7 +8,7 @@
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
   product_name ||= nil
-  show_explore_header ||= true
+  show_explore_header = show_explore_header === false ? false : true
   show_account_layout ||= false
   account_nav_location ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
@@ -22,6 +22,7 @@
       short_description: @emergency_banner.short_description,
     }
   end
+
   global_bar = ''
   global_banner = render "components/global_bar" unless omit_global_banner
   global_bar << '<div id="user-satisfaction-survey-container"></div>' unless omit_user_satisfaction_survey

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -8,10 +8,10 @@
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
   product_name ||= nil
-  show_explore_header ||= false
+  show_explore_header ||= true
   show_account_layout ||= false
   account_nav_location ||= nil
-  drat_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
+  draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
 
   if @emergency_banner
     emergency_banner = render "components/emergency_banner", {
@@ -29,41 +29,42 @@
 %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
+  account_nav_location: account_nav_location,
+  draft_watermark: draft_environment,
   emergency_banner: emergency_banner.presence,
   full_width: full_width,
   global_bar: global_bar,
   logo_link: logo_link,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
-  {
-    text: "Account",
-    href: GovukPersonalisation::Urls.your_account,
-    data: {
-      module: "explicit-cross-domain-links",
-      link_for: "accounts-signed-in",
+    {
+      text: "Account",
+      href: GovukPersonalisation::Urls.your_account,
+      data: {
+        module: "explicit-cross-domain-links",
+        link_for: "accounts-signed-in",
+      },
     },
-  },
-  {
-    text: "Sign out",
-    href: GovukPersonalisation::Urls.sign_out,
-    data: {
-      module: "explicit-cross-domain-links",
-      link_for: "accounts-signed-in",
+    {
+      text: "Sign out",
+      href: GovukPersonalisation::Urls.sign_out,
+      data: {
+        module: "explicit-cross-domain-links",
+        link_for: "accounts-signed-in",
+      },
     },
-  },
-  {
-    text: "Sign in",
-    href: GovukPersonalisation::Urls.sign_in,
-    data: {
-      module: "explicit-cross-domain-links",
-      link_for: "accounts-signed-out",
-    },
-  }],
+    {
+      text: "Sign in",
+      href: GovukPersonalisation::Urls.sign_in,
+      data: {
+        module: "explicit-cross-domain-links",
+        link_for: "accounts-signed-out",
+      },
+    }
+  ],
   omit_feedback_form: omit_feedback_form,
   omit_footer_navigation: omit_footer_navigation,
   product_name: product_name,
+  show_account_layout: show_account_layout,
   show_explore_header: show_explore_header,
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
-  show_account_layout: show_account_layout,
-  account_nav_location: account_nav_location,
-  draft_watermark: drat_environment
 } %>

--- a/app/views/root/core_layout.html.erb
+++ b/app/views/root/core_layout.html.erb
@@ -1,6 +1,6 @@
 <%= render partial: 'base', locals: {
-  hide_nav: true, # no breadcrumbs, you can include them using components if
+  hide_nav: true, # no breadcrumbs, you can include them using components if
                   # you need them, rather than using slimmer
   css_file: 'core-layout',
-  js_file: 'header-footer-only'
+  js_file: 'header-footer-only',
 } %>

--- a/app/views/root/core_layout_explore_header.html.erb
+++ b/app/views/root/core_layout_explore_header.html.erb
@@ -1,7 +1,6 @@
 <%= render partial: 'base', locals: {
-  hide_nav: true, # no breadcrumbs, you can include them using components if
+  hide_nav: true, # no breadcrumbs, you can include them using components if
                   # you need them, rather than using slimmer
-  show_explore_header: true,
   css_file: 'core-layout',
-  js_file: 'header-footer-only'
+  js_file: 'header-footer-only',
 } %>

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -1,10 +1,10 @@
 <%= render partial: "gem_base", locals: {
-  product_name: "Account",
+  account_nav_location: "your-account",
   logo_link: GovukPersonalisation::Urls.your_account,
   omit_feedback_form: true,
   omit_global_banner: true,
   omit_user_satisfaction_survey: true,
+  product_name: "Account",
   show_account_layout: true,
-  account_nav_location: "your-account",
   show_explore_header: false,
 } %>

--- a/app/views/root/gem_layout_explore_header.html.erb
+++ b/app/views/root/gem_layout_explore_header.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "gem_base", locals: { show_explore_header: true } %>
+<%= render partial: "gem_base" %>

--- a/app/views/root/gem_layout_full_width.html.erb
+++ b/app/views/root/gem_layout_full_width.html.erb
@@ -1,3 +1,1 @@
-<%= render partial: 'gem_base', locals: {
-  full_width: true,
-} %>
+<%= render partial: 'gem_base', locals: { full_width: true } %>

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,3 +1,1 @@
-<%= render partial: 'gem_base', locals: {
-  full_width: true,
-} %>
+<%= render partial: 'gem_base', locals: { full_width: true } %>

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,4 +1,3 @@
 <%= render partial: 'gem_base', locals: {
   full_width: true,
-  show_explore_header: true,
 } %>

--- a/app/views/root/gem_layout_old_header_full_width.html.erb
+++ b/app/views/root/gem_layout_old_header_full_width.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: "gem_base", locals: {
+  full_width: true,
+  show_explore_header: false,
+}%>

--- a/test/integration/templates/header_footer_only_test.rb
+++ b/test/integration/templates/header_footer_only_test.rb
@@ -11,7 +11,7 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header#global-header" do
+      within "header.gem-c-layout-super-navigation-header" do
         assert page.has_selector?("form#search")
       end
 


### PR DESCRIPTION
## What

Updates both the gem layout and the core layout templates to use the new navigation header as the default.

Turns the navigation header off for the account manager template.

Adds a layout with the previous header.

Card: https://trello.com/c/3Vu0IPhG

## Why
...

## Visual differences

Gem layout:

| Before | After |
| - | - |
| ![image](https://user-images.githubusercontent.com/1732331/133446231-86f6f23c-881d-4ff1-acad-2e7678737141.png) | ![image](https://user-images.githubusercontent.com/1732331/133445795-f2a1d4a9-13e2-42a8-8d87-886a34a0fc58.png) |


Layout with previous header:
<img src="https://user-images.githubusercontent.com/1732331/133460305-7027fce9-fbb2-4afd-b294-c0e1610475c5.png" width="66%" />
