### PR TITLE
Make app base image configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ruby:2.7.2
+ARG base_image=ruby:2.7.2
+FROM ${base_image}
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
 RUN gem install foreman
 


### PR DESCRIPTION
This PR adds a new `base_image` arg which can be used to specify the base image for building the app image, as used in the `FROM` command. Adding `base_image` allows for our `build-images` pipeline to specify `govuk-ruby-X.Y.Z` when packaging for production, pulling this base image from a private ECR repository; for local development, the base image will remain unchanged from the default as the `base_image` arg will not be overridden.

Trello: https://trello.com/c/dZQwFSKK