### PR TITLE
Add templates with old style header

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -24,9 +24,11 @@ class RootController < ApplicationController
     504
     campaign
     gem_layout
+    gem_layout_old_header
     gem_layout_account_manager
     gem_layout_explore_header
     gem_layout_full_width
+    gem_layout_full_width_old_header
     gem_layout_full_width_explore_header
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -5,5 +5,6 @@
   omit_global_banner: true,
   omit_user_satisfaction_survey: true,
   show_account_layout: true,
-  account_nav_location: "your-account"
+  account_nav_location: "your-account",
+  show_explore_header: false,
 } %>

--- a/app/views/root/gem_layout_full_width_old_header.html.erb
+++ b/app/views/root/gem_layout_full_width_old_header.html.erb
@@ -1,0 +1,4 @@
+<%= render partial: 'gem_base', locals: {
+  full_width: true,
+  show_explore_header: false,
+} %>

--- a/app/views/root/gem_layout_old_header.html.erb
+++ b/app/views/root/gem_layout_old_header.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: "gem_base", locals: { show_explore_header: false } %>

--- a/app/views/root/header_footer_only_old_header.html.erb
+++ b/app/views/root/header_footer_only_old_header.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: 'base', locals: {
+  css_file: 'header-footer-only',
+  js_file: 'header-footer-only',
+  show_explore_header: false,
+} %>


### PR DESCRIPTION
These are being added as an interim step before we set the Explore Super Menu Header to be the default. We need the old header to ensure we keep Account links in place.