### PR TITLE
Temporarily turn super navigation off

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : true
+  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : false
 %>
 
 <% if show_super_navigation_header %>

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -8,7 +8,7 @@
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
   product_name ||= nil
-  show_explore_header = show_explore_header === false ? false : true
+  show_explore_header ||= false
   show_account_layout ||= false
   account_nav_location ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?

--- a/app/views/root/gem_layout_explore_header.html.erb
+++ b/app/views/root/gem_layout_explore_header.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "gem_base" %>
+<%= render partial: "gem_base", locals: { show_explore_header: true } %>

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'gem_base', locals: { full_width: true } %>
+<%= render partial: 'gem_base', locals: { full_width: true, show_explore_header: true, } %>

--- a/test/integration/templates/header_footer_only_test.rb
+++ b/test/integration/templates/header_footer_only_test.rb
@@ -11,7 +11,7 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header.gem-c-layout-super-navigation-header" do
+      within "header#global-header" do
         assert page.has_selector?("form#search")
       end
 


### PR DESCRIPTION
Temporarily turn the new menu bar header off (back to it's previous A/B configuration) as it was deployed ahead of schedule and broke a high profile page https://www.gov.uk/transition-check/questions