### PR TITLE
Make navigation header the default header

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,49 +1,33 @@
-<%
-  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : true
-%>
-
-<% if show_super_navigation_header %>
-  <%= render "govuk_publishing_components/components/layout_super_navigation_header" %>
+<% if @show_account_navigation %>
+  <%= render "govuk_publishing_components/components/layout_header", {
+    remove_bottom_border: true,
+    navigation_items: [ # Remember to update the links in _gem_base.html.erb as well.
+      {
+        text: "Account",
+        href: GovukPersonalisation::Urls.your_account,
+        data: {
+          module: "explicit-cross-domain-links",
+          link_for: "accounts-signed-in",
+        },
+      },
+      {
+        text: "Sign out",
+        href: GovukPersonalisation::Urls.sign_out,
+        data: {
+          module: "explicit-cross-domain-links",
+          link_for: "accounts-signed-in",
+        },
+      },
+      {
+        text: "Sign in",
+        href: GovukPersonalisation::Urls.sign_in,
+        data: {
+          module: "explicit-cross-domain-links",
+          link_for: "accounts-signed-out",
+        },
+      },
+    ],
+  } %>
 <% else %>
-  <header role="banner" id="global-header" class="<%= yield(:header_class) %>">
-    <div class="header-wrapper">
-      <div class="header-global">
-        <div class="header-logo">
-          <a href="<%= content_for?(:homepage_url) ? yield(:homepage_url) : "https://www.gov.uk/" %>"
-              title="<%= content_for?(:logo_link_title) ? yield(:logo_link_title) : "Go to the GOV.UK homepage" %>"
-              class="content govuk-header__link govuk-header__link--homepage"
-              id="logo"
-              data-module="gem-track-click"
-              data-track-category="homeLinkClicked"
-              data-track-action="homeHeader">
-            <span class="govuk-header__logotype">
-              <svg aria-hidden="true"
-                    focusable="false"
-                    class="govuk-header__logotype-crown"
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 132 97"
-                    height="30"
-                    width="36">
-                <path fill="currentColor"
-                      fill-rule="evenodd"
-                      d="M25 30.2c3.5 1.5 7.7-.2 9.1-3.7 1.5-3.6-.2-7.8-3.9-9.2-3.6-1.4-7.6.3-9.1 3.9-1.4 3.5.3 7.5 3.9 9zM9 39.5c3.6 1.5 7.8-.2 9.2-3.7 1.5-3.6-.2-7.8-3.9-9.1-3.6-1.5-7.6.2-9.1 3.8-1.4 3.5.3 7.5 3.8 9zM4.4 57.2c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.5-1.5-7.6.3-9.1 3.8-1.4 3.5.3 7.6 3.9 9.1zm38.3-21.4c3.5 1.5 7.7-.2 9.1-3.8 1.5-3.6-.2-7.7-3.9-9.1-3.6-1.5-7.6.3-9.1 3.8-1.3 3.6.4 7.7 3.9 9.1zm64.4-5.6c-3.6 1.5-7.8-.2-9.1-3.7-1.5-3.6.2-7.8 3.8-9.2 3.6-1.4 7.7.3 9.2 3.9 1.3 3.5-.4 7.5-3.9 9zm15.9 9.3c-3.6 1.5-7.7-.2-9.1-3.7-1.5-3.6.2-7.8 3.7-9.1 3.6-1.5 7.7.2 9.2 3.8 1.5 3.5-.3 7.5-3.8 9zm4.7 17.7c-3.6 1.5-7.8-.2-9.2-3.8-1.5-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.3 3.5-.4 7.6-3.9 9.1zM89.3 35.8c-3.6 1.5-7.8-.2-9.2-3.8-1.4-3.6.2-7.7 3.9-9.1 3.6-1.5 7.7.3 9.2 3.8 1.4 3.6-.3 7.7-3.9 9.1zM69.7 17.7l8.9 4.7V9.3l-8.9 2.8c-.2-.3-.5-.6-.9-.9L72.4 0H59.6l3.5 11.2c-.3.3-.6.5-.9.9l-8.8-2.8v13.1l8.8-4.7c.3.3.6.7.9.9l-5 15.4v.1c-.2.8-.4 1.6-.4 2.4 0 4.1 3.1 7.5 7 8.1h.2c.3 0 .7.1 1 .1.4 0 .7 0 1-.1h.2c4-.6 7.1-4.1 7.1-8.1 0-.8-.1-1.7-.4-2.4V34l-5.1-15.4c.4-.2.7-.6 1-.9zM66 92.8c16.9 0 32.8 1.1 47.1 3.2 4-16.9 8.9-26.7 14-33.5l-9.6-3.4c1 4.9 1.1 7.2 0 10.2-1.5-1.4-3-4.3-4.2-8.7L108.6 76c2.8-2 5-3.2 7.5-3.3-4.4 9.4-10 11.9-13.6 11.2-4.3-.8-6.3-4.6-5.6-7.9 1-4.7 5.7-5.9 8-.5 4.3-8.7-3-11.4-7.6-8.8 7.1-7.2 7.9-13.5 2.1-21.1-8 6.1-8.1 12.3-4.5 20.8-4.7-5.4-12.1-2.5-9.5 6.2 3.4-5.2 7.9-2 7.2 3.1-.6 4.3-6.4 7.8-13.5 7.2-10.3-.9-10.9-8-11.2-13.8 2.5-.5 7.1 1.8 11 7.3L80.2 60c-4.1 4.4-8 5.3-12.3 5.4 1.4-4.4 8-11.6 8-11.6H55.5s6.4 7.2 7.9 11.6c-4.2-.1-8-1-12.3-5.4l1.4 16.4c3.9-5.5 8.5-7.7 10.9-7.3-.3 5.8-.9 12.8-11.1 13.8-7.2.6-12.9-2.9-13.5-7.2-.7-5 3.8-8.3 7.1-3.1 2.7-8.7-4.6-11.6-9.4-6.2 3.7-8.5 3.6-14.7-4.6-20.8-5.8 7.6-5 13.9 2.2 21.1-4.7-2.6-11.9.1-7.7 8.8 2.3-5.5 7.1-4.2 8.1.5.7 3.3-1.3 7.1-5.7 7.9-3.5.7-9-1.8-13.5-11.2 2.5.1 4.7 1.3 7.5 3.3l-4.7-15.4c-1.2 4.4-2.7 7.2-4.3 8.7-1.1-3-.9-5.3 0-10.2l-9.5 3.4c5 6.9 9.9 16.7 14 33.5 14.8-2.1 30.8-3.2 47.7-3.2z">
-                </path>
-                <image src="<%= asset_path 'gov.uk_logotype_crown_invert_trans.png' %>"
-                        xlink:href=""
-                        class="govuk-header__logotype-crown-fallback-image"
-                        width="36"
-                        height="32">
-                </image>
-              </svg>
-              <span class="govuk-header__logotype-text">
-                <%= content_for?(:global_header_text) ? yield(:global_header_text) : "GOV.UK" %>
-              </span>
-            </span>
-          </a>
-        </div>
-        <%= yield :inside_header %>
-      </div>
-      <%= yield :proposition_header %>
-    </div>
-  </header>
+  <%= render "govuk_publishing_components/components/layout_super_navigation_header" %>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : false
+  show_super_navigation_header = content_for?(:show_explore_header) ? yield(:show_explore_header) : true
 %>
 
 <% if show_super_navigation_header %>

--- a/app/views/root/_base.html.erb
+++ b/app/views/root/_base.html.erb
@@ -1,8 +1,7 @@
-<% hide_account_navigation ||= false %>
-
 <% content_for :homepage_url, Plek.new.website_root %>
 <% content_for :page_title, content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information" %>
 <% @emergency_banner = emergency_banner_notification %>
+<% @show_account_navigation = defined?(show_account_navigation) && show_account_navigation.present? ? show_account_navigation : false %>
 
 <% if ENV["DRAFT_ENVIRONMENT"].present? %>
   <% content_for :body_classes, "draft" %>
@@ -40,36 +39,6 @@
 <% end %>
 
 <% content_for :after_header do %>
-  <% unless hide_account_navigation %>
-    <%= render "govuk_publishing_components/components/layout_header", {
-      remove_bottom_border: true,
-      navigation_items: [ # Remember to update the links in _gem_base.html.erb as well.
-      {
-        text: "Account",
-        href: GovukPersonalisation::Urls.your_account,
-        data: {
-          module: "explicit-cross-domain-links",
-          link_for: "accounts-signed-in",
-        },
-      },
-      {
-        text: "Sign out",
-        href: GovukPersonalisation::Urls.sign_out,
-        data: {
-          module: "explicit-cross-domain-links",
-          link_for: "accounts-signed-in",
-        },
-      },
-      {
-        text: "Sign in",
-        href: GovukPersonalisation::Urls.sign_in,
-        data: {
-          module: "explicit-cross-domain-links",
-          link_for: "accounts-signed-out",
-        },
-      }],
-    } %>
-  <% end %>
   <div id="user-satisfaction-survey-container"></div>
   <% if @emergency_banner %>
     <%= render "components/emergency_banner", {

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -8,7 +8,7 @@
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
   product_name ||= nil
-  show_explore_header ||= false
+  show_explore_header = show_explore_header === false ? false : true
   show_account_layout ||= false
   account_nav_location ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?

--- a/app/views/root/gem_layout_explore_header.html.erb
+++ b/app/views/root/gem_layout_explore_header.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: "gem_base", locals: { show_explore_header: true } %>
+<%= render partial: "gem_base" %>

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: 'gem_base', locals: { full_width: true, show_explore_header: true, } %>
+<%= render partial: 'gem_base', locals: { full_width: true } %>

--- a/app/views/root/header_footer_only_old_header.html.erb
+++ b/app/views/root/header_footer_only_old_header.html.erb
@@ -1,5 +1,5 @@
-<%= render partial: 'base', locals: {
-  css_file: 'header-footer-only',
-  js_file: 'header-footer-only',
-  show_explore_header: false,
+<%= render partial: "base", locals: {
+  css_file: "header-footer-only",
+  js_file: "header-footer-only",
+  show_account_navigation: true,
 } %>

--- a/test/integration/templates/header_footer_only_test.rb
+++ b/test/integration/templates/header_footer_only_test.rb
@@ -11,7 +11,7 @@ class HeaderFooterOnlyTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header#global-header" do
+      within "header.gem-c-layout-super-navigation-header" do
         assert page.has_selector?("form#search")
       end
 


### PR DESCRIPTION
## What

Turns the [navigation header][nh] on for all visitors; updates the logic so that pages that need the GOV.UK Accounts links won't see the navigation header ([gov.uk/brexit][1], [gov.uk/transition-check/questions][2]).

Also reverts alphagov/static#2598

Replaces https://github.com/alphagov/static/pull/2601

Dependent on:
 - https://github.com/alphagov/government-frontend/pull/2231
 - https://github.com/alphagov/whitehall/pull/6307
 - https://github.com/alphagov/finder-frontend/pull/2641
 - https://github.com/alphagov/govuk-search-relevance-tool/pull/87

## Why

The navigation header was A/B tested, and found to be an improvement on the existing headers - so it should be turned on for all users.

[1]: https://www.gov.uk/brexit
[2]: https://www.gov.uk/transition-check/questions
[nh]: https://components.publishing.service.gov.uk/component-guide/layout_super_navigation_header
