### PR TITLE
Add Puma via govuk_app_config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 ARG base_image=ruby:2.7.2
 FROM ${base_image}
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential nodejs && apt-get clean
-RUN gem install foreman
 
 # This image is only intended to be able to run this app in a production RAILS_ENV
 ENV RAILS_ENV production
@@ -24,4 +23,4 @@ ADD . $APP_HOME
 
 RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bundle exec rails assets:precompile
 
-CMD foreman run web
+CMD bundle exec puma

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,8 +124,9 @@ GEM
       activesupport (>= 5.0)
     govuk-content-schema-test-helpers (1.6.1)
       json-schema (~> 2.8.0)
-    govuk_app_config (4.0.1)
+    govuk_app_config (4.1.0)
       logstasher (>= 1.2.2, < 2.2.0)
+      puma (~> 5.0)
       sentry-rails (~> 4.5.0)
       sentry-ruby (~> 4.5.0)
       statsd-ruby (~> 1.5.0)
@@ -221,7 +222,7 @@ GEM
     public_suffix (4.0.6)
     puma (5.3.2)
       nio4r (~> 2.0)
-    racc (1.5.2)
+    racc (1.6.0)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -358,7 +359,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,0 +1,2 @@
+require "govuk_app_config/govuk_puma"
+GovukPuma.configure_rails(self)


### PR DESCRIPTION
This PR adds `Puma` via govuk_app_config. Puma was previously installed indirectly through the dependency on `govuk_test` as part of the `dev` and `test` groups; given that we want to run Puma in production, we are instead configuring it via govuk_app_config.

**This PR is reliant on [changes to govuk_app_config](https://github.com/alphagov/govuk_app_config/pull/214)**

[Trello card](https://trello.com/c/irrbEFMV/668)