### PR TITLE
Pass domains to cross link on main GA property

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -132,6 +132,7 @@ var linkedDomains = [
 
 window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {}
 window.GOVUK.analyticsVars.gaProperty = '<%= Rails.application.config.ga_universal_id %>'
+window.GOVUK.analyticsVars.primaryLinkedDomains = ['account.gov.uk']
 window.GOVUK.analyticsVars.gaPropertyCrossDomain = '<%= Rails.application.config.ga_secondary_id %>'
 window.GOVUK.analyticsVars.linkedDomains = linkedDomains
 


### PR DESCRIPTION
**Requires a new version of the gem with this change to work properly, but safe to deploy without it: https://github.com/alphagov/govuk_publishing_components/pull/2378**

## What
Initialises cross domain linker on main GA property for GOV.UK by passing a list of domains.

## Why
See linked PR.

## Visual changes
None.

Trello card: https://trello.com/c/w3WVrDKm/149-add-cross-domain-tracking-to-main-govuk-tracker
