### PR TITLE
Account layout template adjustments

### DIFF
--- a/app/views/root/_account.html.erb
+++ b/app/views/root/_account.html.erb
@@ -2,11 +2,10 @@
 
 <%= render partial: "gem_base", locals: {
   account_nav_location: "your-account",
-  logo_link: GovukPersonalisation::Urls.your_account,
   omit_feedback_form: true,
   omit_global_banner: true,
   omit_user_satisfaction_survey: true,
-  product_name: "Account",
+  omit_footer_navigation: true,
   show_account_layout: true,
   show_explore_header: false,
   omit_account_navigation: omit_account_navigation,

--- a/docs/slimmer_templates.md
+++ b/docs/slimmer_templates.md
@@ -14,10 +14,7 @@ Use this layout if you want to have full width content - such as the blue welcom
 
 This is intended as a skeleton wrapper for account pages. It is intended to be used when we need a page rendered by another frontend app to look like a page from `govuk-account-manager-prototype`.
 
-This layout omits the default feedback component for GOVUK as the account pages use a different one from the rest of GOV.UK. Instead it introduces an account-specific phase banner, account feedback prompt, and an account nav component. It also purposefully omits the global bar and user satisfaction survey bar.
-
-This also includes the Account product name in the layout header and changes the logo link to the account homepage link.
-
+This layout omits the default feedback component for GOVUK as the account pages use a different one from the rest of GOV.UK. Instead it introduces an account-specific phase banner, and an account nav component. It also purposefully omits the global bar and user satisfaction survey bar.
 
 ## `gem_layout_account_manager_no_nav`
 


### PR DESCRIPTION
Implement some adjustments to the layout template for accounts to ensure
a smooth transition to DI auth.

Remove the Account product name from the header, and ensure the GOVUK
link leads back to the GOVUK homepage so users don't get stuck in the
account zone.

Remove footer navigation links in favour or the more stripped down
version of the footer. We want the footer to match what DI have
implemented (it could look weird if the footer dramatically changes when
someone navigates from one account page to another)

https://trello.com/c/vIjbnGSj/1087-account-pages-tidy-up-for-launch

Related PR which implements similar minor changes to the account layout in the components gem: https://github.com/alphagov/govuk_publishing_components/pull/2380