### PR TITLE
Turn on the navigation header for the error pages

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -21,6 +21,7 @@
   full_width: false,
   global_bar: user_satisfaction_survey + global_bar,
   logo_link: Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/",
+  show_explore_header: true,
   title: "#{heading} - GOV.UK",
 } do %>
   <div class="govuk-grid-row">
@@ -38,4 +39,3 @@
     window.httpStatusCode = '<%= status_code %>'
   </script>
 <% end %>
-

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -10,10 +10,6 @@ class Error4XXTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header.gem-c-layout-header.govuk-header" do
-        assert page.has_selector?("form#search")
-      end
-
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")
 

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -10,10 +10,6 @@ class Error5XXTest < ActionDispatch::IntegrationTest
     end
 
     within "body" do
-      within "header.gem-c-layout-header.govuk-header" do
-        assert page.has_selector?("form#search")
-      end
-
       assert page.has_selector?("#global-cookie-message")
       assert page.has_selector?("#user-satisfaction-survey-container")
 


### PR DESCRIPTION
## What
Updates the base error template to turn on the navigation header for all of the error pages.

## Why
The error pages still had the previous header layout - unlike the rest of `www.gov.uk` - so needed to be updated to be consistent.

## Visual differences

Before:
![image](https://user-images.githubusercontent.com/1732331/138905181-852d2862-0780-4b38-9fcd-566bdf9a16e0.png)


After:
![image](https://user-images.githubusercontent.com/1732331/138905127-5ab1eb6d-faa8-4c2f-b1df-300be1e102f0.png)

