### PR TITLE
Add account "no nav" layout template variation

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -25,6 +25,7 @@ class RootController < ApplicationController
     campaign
     gem_layout
     gem_layout_account_manager
+    gem_layout_account_manager_no_nav
     gem_layout_explore_header
     gem_layout_full_width
     gem_layout_full_width_explore_header

--- a/app/views/root/_account.html.erb
+++ b/app/views/root/_account.html.erb
@@ -1,0 +1,13 @@
+<% omit_account_navigation ||= nil %>
+
+<%= render partial: "gem_base", locals: {
+  account_nav_location: "your-account",
+  logo_link: GovukPersonalisation::Urls.your_account,
+  omit_feedback_form: true,
+  omit_global_banner: true,
+  omit_user_satisfaction_survey: true,
+  product_name: "Account",
+  show_account_layout: true,
+  show_explore_header: false,
+  omit_account_navigation: omit_account_navigation,
+} %>

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -7,6 +7,7 @@
   omit_footer_navigation ||= nil
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
+  omit_account_navigation ||= nil
   product_name ||= nil
   show_explore_header = show_explore_header === false ? false : true
   show_account_layout ||= false
@@ -64,6 +65,7 @@
   ],
   omit_feedback_form: omit_feedback_form,
   omit_footer_navigation: omit_footer_navigation,
+  omit_account_navigation: omit_account_navigation,
   product_name: product_name,
   show_account_layout: show_account_layout,
   show_explore_header: show_explore_header,

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -1,10 +1,1 @@
-<%= render partial: "gem_base", locals: {
-  account_nav_location: "your-account",
-  logo_link: GovukPersonalisation::Urls.your_account,
-  omit_feedback_form: true,
-  omit_global_banner: true,
-  omit_user_satisfaction_survey: true,
-  product_name: "Account",
-  show_account_layout: true,
-  show_explore_header: false,
-} %>
+<%= render partial: "account" %>

--- a/app/views/root/gem_layout_account_manager_no_nav.html.erb
+++ b/app/views/root/gem_layout_account_manager_no_nav.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: "account", locals: {
+  omit_account_navigation: true,
+} %>

--- a/docs/slimmer_templates.md
+++ b/docs/slimmer_templates.md
@@ -19,6 +19,11 @@ This layout omits the default feedback component for GOVUK as the account pages 
 This also includes the Account product name in the layout header and changes the logo link to the account homepage link.
 
 
+## `gem_layout_account_manager_no_nav`
+
+Same as the `gem_layout_account_manager`, but displays without the account nav component.
+
+
 ## `core_layout` (default)
 
 This template contains styles for the black header bar, the footer and core layout classes. By default it will centre your content to the same width as the GOV.UK header. It provides classes for grid layouts using the column mixins from the frontend toolkit.


### PR DESCRIPTION
With the migration to DI, we are moving some pages from the account
manager prototype app to `frontend`. Some of these interstitial pages
(such as the "Control how we use information about you page") should
have the account elements, such as the account header and footer and
account phase banner, but should not include the account side navigation
component.

The `gem_layout_account_manager_no_nav` template has been created with
this purpose.

The only difference between `gem_layout_account_manager` and `gem_layout_account_manager_no_nav` should be:
- `gem_layout_account_manager` uses the  [with_account_layout_enabled](https://components.publishing.service.gov.uk/component-guide/layout_for_public/with_account_layout_enabled/preview) variant of the layout component.
- `gem_layout_account_manager_no_nav` uses the  [with_account_layout_but_without_account_navigation](https://components.publishing.service.gov.uk/component-guide/layout_for_public/with_account_layout_but_without_account_navigation/preview) variant of the layout component.

It is likely that the side nav will eventually be removed from account manager pages completely but in the meanwhile it seems like there is still a need to maintain an account layout with a side nav, and a separate one without.


-------


https://trello.com/c/vIjbnGSj/1087-account-pages-tidy-up-for-launch