### PR TITLE
Bump govuk_publishing_components to 27.9.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     govuk_personalisation (0.9.0)
       plek (>= 1.9.0)
       rails (~> 6)
-    govuk_publishing_components (27.8.2)
+    govuk_publishing_components (27.9.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
The e2e tests are failing with 27.9.1, so we think there may be a
problem with that version.