### PR TITLE
Footer tweaks for DI migration

### DIFF
--- a/app/views/root/_account.html.erb
+++ b/app/views/root/_account.html.erb
@@ -1,12 +1,38 @@
-<% omit_account_navigation ||= nil %>
+<%
+  omit_account_navigation ||= nil
+  di_location = "https://signin.account.gov.uk"
+%>
 
 <%= render partial: "gem_base", locals: {
   account_nav_location: "your-account",
   omit_feedback_form: true,
+  omit_footer_border: true,
   omit_global_banner: true,
   omit_user_satisfaction_survey: true,
   omit_footer_navigation: true,
   show_account_layout: true,
   show_explore_header: false,
   omit_account_navigation: omit_account_navigation,
+  footer_meta: { items: [
+    {
+      href: "#{di_location}/accessibility-statement",
+      text: "Accessibility statement"
+    },
+    {
+      href: "/help/cookies",
+      text: "Cookies"
+    },
+    {
+      href: "#{di_location}/terms-and-conditions",
+      text: "Terms and conditions"
+    },
+    {
+      href: "#{di_location}/privacy-statement",
+      text: "Privacy notice"
+    },
+    {
+      href: "#{di_location}/support",
+      text: "Support"
+    },
+  ]}
 } %>

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -5,6 +5,7 @@
   full_width ||= false
   omit_feedback_form ||= nil
   omit_footer_navigation ||= nil
+  omit_footer_border ||= nil
   omit_global_banner ||= nil
   omit_user_satisfaction_survey ||= nil
   omit_account_navigation ||= nil
@@ -12,6 +13,7 @@
   show_explore_header = show_explore_header === false ? false : true
   show_account_layout ||= false
   account_nav_location ||= nil
+  footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
 
   if @emergency_banner
@@ -66,8 +68,10 @@
   omit_feedback_form: omit_feedback_form,
   omit_footer_navigation: omit_footer_navigation,
   omit_account_navigation: omit_account_navigation,
+  omit_footer_border: omit_footer_border,
   product_name: product_name,
   show_account_layout: show_account_layout,
   show_explore_header: show_explore_header,
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
+  footer_meta: footer_meta,
 } %>


### PR DESCRIPTION
Change footer links to match DI footer. 
Display footer without the blue border.

The footer border update depends on https://github.com/alphagov/govuk_publishing_components/pull/2393 

----

https://trello.com/c/vIjbnGSj/1087-account-pages-tidy-up-for-launch