### PR TITLE
Revert "Bump govuk_publishing_components from 27.10.2 to 27.10.3"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
     govuk_personalisation (0.9.0)
       plek (>= 1.9.0)
       rails (~> 6)
-    govuk_publishing_components (27.10.3)
+    govuk_publishing_components (27.10.2)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
Reverts alphagov/static#2639

Reverting to a version that doesn't use `em` units in the header.