### PR TITLE
Remove ECR publish on PR

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,6 @@ on:
       - "Jenkinsfile"
       - ".git**"
 
-  pull_request:
-    paths-ignore:
-      - "Jenkinsfile"
-      - ".git**"
-
 jobs:
   publish:
     name: Build


### PR DESCRIPTION
After some discussion within the team, we have decided that its not necessary to have Github actions CI run on PR's for now.

What should happen on PR's is something we will visit again at a later date.