### PR TITLE
Add print stylesheet for navigation header

### DIFF
--- a/app/assets/stylesheets/application-print.scss
+++ b/app/assets/stylesheets/application-print.scss
@@ -5,5 +5,6 @@ $is-print: true;
 @import "govuk_publishing_components/component_support";
 
 @import "govuk_publishing_components/components/print/button";
+@import "govuk_publishing_components/components/print/layout-super-navigation-header";
 
 @import "helpers/print-base";


### PR DESCRIPTION
## What

Adds the print stylesheet for the navigation header

## Why

The navigation header has a print stylesheet, so it should be used. Currently  the print stylesheet stops the navigation header from being printed as it takes up too much space and isn't that useful.

## Visual differences

| Browser | Before | After |
| - | ------ | ----- 
| Firefox | <img width="823" alt="" src="https://user-images.githubusercontent.com/1732331/141108960-b0737723-ebfc-4be6-b054-e493c7aae006.png"> | <img width="825" alt="" src="https://user-images.githubusercontent.com/1732331/141108957-310a36e1-f0b0-4db6-86a6-718789190eca.png"> |
| Chrome | <img width="582" alt="" src="https://user-images.githubusercontent.com/1732331/141109322-50a352e8-ba07-4e4f-bc16-c2f2610b034e.png"> | <img width="584" alt="" src="https://user-images.githubusercontent.com/1732331/141109317-709a0c03-803a-4985-bd53-fce564628308.png"> | 
| Safari | <img width="631" alt="" src="https://user-images.githubusercontent.com/1732331/141109660-ef466415-5b72-4fb1-9431-89000eb3b1a5.png"> | <img width="636" alt="" src="https://user-images.githubusercontent.com/1732331/141109670-c52d87d6-19e6-4999-ae1e-dab9066a3977.png"> |
| Internet Explorer 11 | <img width="586" alt="Screenshot 2021-11-10 at 12 05 30" src="https://user-images.githubusercontent.com/1732331/141110076-87c3f75c-8330-40af-8d2c-cb42f9e07dfa.png"> | <img width="597" alt="Screenshot 2021-11-10 at 12 05 03" src="https://user-images.githubusercontent.com/1732331/141110069-7cb71825-bd6e-4e8d-be86-c9a4c5e18d15.png"> | 