### PR TITLE
Clear the template caches when the emergency banner is updated

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module Static
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.eager_load_paths += %W[#{config.root}/lib]
+
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.

--- a/lib/services/clear_template_cache.rb
+++ b/lib/services/clear_template_cache.rb
@@ -1,0 +1,7 @@
+class Services::ClearTemplateCache
+  def self.run!
+    RootController::TEMPLATES.each do |template|
+      ActionController::Base.expire_page("templates/#{template}.html.erb")
+    end
+  end
+end

--- a/lib/tasks/emergency_banner.rake
+++ b/lib/tasks/emergency_banner.rake
@@ -8,10 +8,12 @@ namespace :emergency_banner do
     raise ArgumentError unless args.heading
 
     EmergencyBanner::Deploy.new.run(args.campaign_class, args.heading, args.short_description, args.link, args.link_text)
+    Services::ClearTemplateCache.run!
   end
 
   desc "Remove the emergency banner"
   task remove: :environment do
     EmergencyBanner::Remove.new.run
+    Services::ClearTemplateCache.run!
   end
 end

--- a/test/tasks/emergency_banner_test.rb
+++ b/test/tasks/emergency_banner_test.rb
@@ -9,7 +9,7 @@ describe "emergency_banner:deploy" do
 
   should "run the process to deploy the emergency banner" do
     EmergencyBanner::Deploy.any_instance.expects(:run)
-
+    Services::ClearTemplateCache.expects(:run!)
     Rake::Task["emergency_banner:deploy"].invoke("campaign class", "heading")
   end
 
@@ -41,7 +41,7 @@ end
 describe "emergency_banner:remove" do
   should "run the process to remove the emergency banner" do
     EmergencyBanner::Remove.any_instance.expects(:run)
-
+    Services::ClearTemplateCache.expects(:run!)
     Rake::Task["emergency_banner:remove"].invoke
   end
 end

--- a/test/unit/services/clear_template_cache_test.rb
+++ b/test/unit/services/clear_template_cache_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+require "services/clear_template_cache"
+
+describe Services::ClearTemplateCache do
+  context "#run!" do
+    before do
+      RootController::TEMPLATES.each do |template|
+        ActionController::Base.stubs(:expire_page)
+          .with("templates/#{template}.html.erb")
+          .returns(nil)
+      end
+    end
+
+    should "not raise an error" do
+      Services::ClearTemplateCache.run!
+    end
+  end
+end


### PR DESCRIPTION
Rather than requiring a separate [script](https://github.com/alphagov/govuk-puppet/blob/178ff3c0d1b024a5e0c81f384b07d0dfb65f418d/modules/govuk_jenkins/templates/jobs/clear_template_cache.yaml.erb#L18) run by Jenkins to clear the caches, Static can clear it's own cache using the same [ActionPack page caching API](https://github.com/rails/actionpack-page_caching): 

This ensures that this process is somewhat tested (as compared to the Jenkins script, which is hard to test).