### PR TITLE
Clear the template caches every 5 minutes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem "rack_strip_client_ip"
 gem "redis"
 gem "sassc-rails"
 gem "uglifier"
+gem "whenever"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crack (0.4.4)
@@ -356,6 +357,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     zeitwerk (2.5.1)
@@ -395,6 +398,7 @@ DEPENDENCIES
   uglifier
   webdrivers
   webmock
+  whenever
 
 BUNDLED WITH
    2.1.4

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ module Static
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
+    config.eager_load_paths += %W[#{config.root}/lib]
+
     # Using a sass css compressor causes a scss file to be processed twice
     # (once to build, once to compress) which breaks the usage of "unquote"
     # to use CSS that has same function names as SCSS such as max.

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,29 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+set :output, error: "log/cron.error.log", standard: "log/cron.log"
+
+bundler_prefix = ENV.fetch("BUNDLER_PREFIX", "/usr/local/bin/govuk_setenv static")
+job_type :rake, "cd :path && #{bundler_prefix} bundle exec rake :task :output"
+
+every "*/5 * * * *" do
+  rake "templates_cache:clear"
+end
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever

--- a/lib/services/clear_template_cache.rb
+++ b/lib/services/clear_template_cache.rb
@@ -1,0 +1,7 @@
+class Services::ClearTemplateCache
+  def self.run!
+    RootController::TEMPLATES.each do |template|
+      ActionController::Base.expire_page("templates/#{template}.html.erb")
+    end
+  end
+end

--- a/lib/tasks/templates_cache.rake
+++ b/lib/tasks/templates_cache.rake
@@ -1,0 +1,6 @@
+namespace :templates_cache do
+  desc "Clear the templates cache - should be run on a schedule"
+  task clear: :environment do
+    Services::ClearTemplateCache.run!
+  end
+end

--- a/test/tasks/templates_cache_test.rb
+++ b/test/tasks/templates_cache_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+describe "templates_cache:clear" do
+  before do
+    Rake::Task["templates_cache:clear"].reenable
+  end
+
+  should "run the process to purge the template cache" do
+    Services::ClearTemplateCache.expects(:run!)
+    Rake::Task["templates_cache:clear"].invoke
+  end
+end

--- a/test/unit/services/clear_template_cache_test.rb
+++ b/test/unit/services/clear_template_cache_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+
+describe Services::ClearTemplateCache do
+  context "#run!" do
+    before do
+      RootController::TEMPLATES.each do |template|
+        ActionController::Base.stubs(:expire_page)
+          .with("templates/#{template}.html.erb")
+          .returns(nil)
+      end
+    end
+
+    should "not raise an error" do
+      Services::ClearTemplateCache.run!
+    end
+  end
+end


### PR DESCRIPTION
Rather than requiring a separate [script][1] run by Jenkins to clear the caches, Static can clear its own cache using
the same ActionPack page caching [API](https://github.com/rails/actionpack-page_caching).

This ensures that this process is tested (as compared to the Jenkins script, which is hard to test).

It also ensures that the template caches expire - this design is similar to the 'sweepers' recommended in the ActionPack page cache docs.

We may still need to cycle all Static pods when the emergency banner is added/removed once we are running Static in Kubernetes. We could run a sidecar container that clears Static caches, but that's out of scope for this work.

Longer term we probably want to look at replacing Static or at least making the serving less dynamic - there's no need for a Ruby webserver to be involved since it's Nginx that mostly is serving these files.

A corresponding change to run `bundle exec whenever` in govuk-app-deployment is required to update the crontab.

[1]: https://github.com/alphagov/govuk-puppet/blob/178ff3c0d1b024a5e0c81f384b07d0dfb65f418d/modules/govuk_jenkins/templates/jobs/clear_template_cache.yaml.erb#L18

To be merged once https://github.com/alphagov/govuk-rfcs/pull/144 is approved.