### PR TITLE
Add support for "Manage your account" active in the account nav

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -25,6 +25,7 @@ class RootController < ApplicationController
     campaign
     gem_layout
     gem_layout_account_manager
+    gem_layout_account_manager_manage_your_account_active
     gem_layout_account_manager_no_nav
     gem_layout_explore_header
     gem_layout_full_width

--- a/app/views/root/_account.html.erb
+++ b/app/views/root/_account.html.erb
@@ -1,10 +1,11 @@
 <%
   omit_account_navigation ||= nil
+  account_nav_location ||= "your-account"
   di_location = "https://signin.account.gov.uk"
 %>
 
 <%= render partial: "gem_base", locals: {
-  account_nav_location: "your-account",
+  account_nav_location: account_nav_location,
   omit_feedback_form: true,
   omit_footer_border: true,
   omit_global_banner: true,

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -47,6 +47,7 @@
         module: "explicit-cross-domain-links",
         link_for: "accounts-signed-in",
       },
+      active: show_account_layout,
     },
     {
       text: "Sign out",

--- a/app/views/root/gem_layout_account_manager_manage_your_account_active.html.erb
+++ b/app/views/root/gem_layout_account_manager_manage_your_account_active.html.erb
@@ -1,0 +1,3 @@
+<%= render partial: "account", locals: {
+  account_nav_location: "manage",
+} %>

--- a/docs/slimmer_templates.md
+++ b/docs/slimmer_templates.md
@@ -20,6 +20,9 @@ This layout omits the default feedback component for GOVUK as the account pages 
 
 Same as the `gem_layout_account_manager`, but displays without the account nav component.
 
+## `gem_layout_account_manager_manage_your_account_active`
+
+Same as the `gem_layout_account_manager`, but displays "Manage your account" as active in the [account navigation element](https://components.publishing.service.gov.uk/component-guide/layout_for_public/with_current_account_navigation/preview).
 
 ## `core_layout` (default)
 


### PR DESCRIPTION
When the account layout template renders with a nav, the "Your account" nav option is selected by default.

Some pages which use the account layout belong under "Manage your account" instead of "Your account".

This allows us the option to render the account layout with "Manage your account" selected/active in the account nav, instead of the default "Your account".

### gem_layout_account_manager template
<img width="1032" alt="Screenshot 2021-11-29 at 17 11 21" src="https://user-images.githubusercontent.com/7116819/143915857-2615fe01-23cd-44d5-a490-c25669594144.png">

### gem_layout_account_manager_manage_your_account_active template
<img width="1008" alt="Screenshot 2021-11-29 at 17 12 30" src="https://user-images.githubusercontent.com/7116819/143915862-4fdd8145-85e0-47cf-b389-8d020880b325.png">


This also ensures the **Account** link in the site header nav appears with the correct **active** blue colour (currently there is no visual difference between the **Account** link and the **Sign out** one)

------

https://trello.com/c/uDkZ90GE