### PR TITLE
Clean up: unused templates

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -30,11 +30,8 @@ class RootController < ApplicationController
     gem_layout_explore_header
     gem_layout_full_width
     gem_layout_full_width_explore_header
-    gem_layout_full_width_old_header
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
-    gem_layout_old_header
-    gem_layout_old_header_full_width
     scheduled_maintenance
     print
     proposition_menu

--- a/app/views/root/gem_layout_full_width_old_header.html.erb
+++ b/app/views/root/gem_layout_full_width_old_header.html.erb
@@ -1,4 +1,0 @@
-<%= render partial: 'gem_base', locals: {
-  full_width: true,
-  show_explore_header: false,
-} %>

--- a/app/views/root/gem_layout_old_header.html.erb
+++ b/app/views/root/gem_layout_old_header.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: "gem_base", locals: { show_explore_header: false } %>

--- a/app/views/root/gem_layout_old_header_full_width.html.erb
+++ b/app/views/root/gem_layout_old_header_full_width.html.erb
@@ -1,4 +1,0 @@
-<%= render partial: "gem_base", locals: {
-  full_width: true,
-  show_explore_header: false,
-}%>


### PR DESCRIPTION
It seems that these templates were introduced solely for pages which
still used the old layout header while the explore nav was being rolled
out to the rest of the site.
There no longer are any references to these templates so I believe they
can safely be removed.

https://trello.com/c/buf41APG/24-tidy-up-layout-templates-in-static