### PR TITLE
Edit gem_layout_no_footer_navigation to not show Explore header

### DIFF
--- a/app/views/root/gem_layout_no_footer_navigation.html.erb
+++ b/app/views/root/gem_layout_no_footer_navigation.html.erb
@@ -1,1 +1,6 @@
-<%= render partial: "gem_base", locals: { omit_footer_navigation: true } %>
+<%= render partial: "gem_base",
+  locals: {
+    omit_footer_navigation: true,
+    show_explore_header: false
+  }
+%>


### PR DESCRIPTION
## What / Why

As this is affecting Service Manual, which shouldn't be showing the Super Header.

(The Service Manual is the only app using the `gem_layout_no_footer_navigation` template)

[Trello card](https://trello.com/c/7xbAX1Uk/711-bug-fix-service-manual-header)

## Related PRs

* https://github.com/alphagov/service-manual-frontend/pull/1021
* https://github.com/alphagov/govuk_publishing_components/pull/2521

## Before

![www gov uk_service-manual](https://user-images.githubusercontent.com/424772/146182250-b303b566-e211-483f-a988-5a454129d7c6.png)

## After

![service-manual-frontend dev gov uk_service-manual](https://user-images.githubusercontent.com/424772/146182343-f768c35d-7bd9-4f42-a13b-c8dff651db8e.png)


