### PR TITLE
Add missing textarea styles for the feedback component

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/components/layout-super-navigation-header";
 @import "govuk_publishing_components/components/search";
 @import "govuk_publishing_components/components/skip-link";
+@import "govuk_publishing_components/components/textarea";
 
 @import "components/emergency-banner";
 @import "components/global-bar";


### PR DESCRIPTION
Missed in https://github.com/alphagov/static/pull/2680

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td valign="top">

<img width="1120" alt="Screenshot 2022-01-07 at 11 31 55" src="https://user-images.githubusercontent.com/788096/148538315-301d301c-42fe-4f35-905e-c387cbff96ed.png">


</td><td valign="top">

<img width="1019" alt="Screenshot 2022-01-07 at 11 34 44" src="https://user-images.githubusercontent.com/788096/148538431-4da61991-458f-48a2-a1e1-389db0e53170.png">


</td></tr>
</table