### PR TITLE
Remove jQuery from globalbar

### DIFF
--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -13,8 +13,12 @@
 
   Modules.GlobalBar = function () {
     this.start = function ($el) {
+      this.$module = $el[0]
       var GLOBAL_BAR_SEEN_COOKIE = 'global_bar_seen'
-      var alwaysOn = $el.data('global-bar-permanent')
+      var alwaysOn = this.$module.getAttribute('data-global-bar-permanent')
+      if (alwaysOn === 'false') {
+        alwaysOn = false // in this situation we need to convert string to boolean
+      }
       var cookieCategory = GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE)
       var cookieConsent = GOVUK.getConsentCookie()[cookieCategory]
 
@@ -29,18 +33,24 @@
         var count = viewCount()
       }
 
-      $el.on('click', '.dismiss', hide)
-      $el.on('click', '.js-call-to-action', handleCallToActionClick)
+      this.$module.addEventListener('click', function (e) {
+        var target = e.target
+        if (target.classList.contains('dismiss')) {
+          hide(e)
+        } else if (target.classList.contains('js-call-to-action')) {
+          handleCallToActionClick(target)
+        }
+      })
 
-      if ($el.is(':visible')) {
+      // if the element is visible
+      if (this.$module.offsetParent !== null) {
         if (!alwaysOn) {
           incrementViewCount(count)
         }
       }
 
-      function handleCallToActionClick () {
-        var $link = $(this)
-        var url = $link.attr('href')
+      function handleCallToActionClick (target) {
+        var url = target.getAttribute('href')
         track(url)
       }
 
@@ -54,8 +64,14 @@
 
         var cookieValue = JSON.stringify({ count: 999, version: cookieVersion })
         GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookieValue, { days: 84 })
-        $('.global-bar-additional').removeClass('global-bar-additional--show')
-        $('.global-bar__dismiss').removeClass('global-bar__dismiss--show')
+        var additional = document.querySelector('.global-bar-additional')
+        if (additional) {
+          additional.classList.remove('global-bar-additional--show')
+        }
+        var dismiss = document.querySelector('.global-bar__dismiss')
+        if (dismiss) {
+          dismiss.classList.remove('global-bar__dismiss--show')
+        }
         track('Manually dismissed')
         evt.preventDefault()
       }

--- a/app/assets/javascripts/modules/global-bar.js
+++ b/app/assets/javascripts/modules/global-bar.js
@@ -8,100 +8,102 @@
   Manages count of how many times a global bar has been seen
   using cookies.
 */
+window.GOVUK = window.GOVUK || {}
+window.GOVUK.Modules = window.GOVUK.Modules || {};
+
 (function (Modules) {
-  'use strict'
+  function GlobalBar ($module) {
+    this.$module = $module
+  }
 
-  Modules.GlobalBar = function () {
-    this.start = function ($el) {
-      this.$module = $el[0]
-      var GLOBAL_BAR_SEEN_COOKIE = 'global_bar_seen'
-      var alwaysOn = this.$module.getAttribute('data-global-bar-permanent')
-      if (alwaysOn === 'false') {
-        alwaysOn = false // in this situation we need to convert string to boolean
-      }
-      var cookieCategory = GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE)
-      var cookieConsent = GOVUK.getConsentCookie()[cookieCategory]
+  GlobalBar.prototype.init = function () {
+    var GLOBAL_BAR_SEEN_COOKIE = 'global_bar_seen'
+    var alwaysOn = this.$module.getAttribute('data-global-bar-permanent')
+    if (alwaysOn === 'false') {
+      alwaysOn = false // in this situation we need to convert string to boolean
+    }
+    var cookieCategory = GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE)
+    var cookieConsent = GOVUK.getConsentCookie()[cookieCategory]
 
-      if (cookieConsent) {
-        // If the cookie is not set, let's set a basic one
-        if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)).count === undefined) {
-          GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 0, version: 0 }), { days: 84 })
-        }
-
-        var currentCookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))
-        var currentCookieVersion = currentCookie.version
-        var count = viewCount()
+    if (cookieConsent) {
+      // If the cookie is not set, let's set a basic one
+      if (GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE) === null || parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)).count === undefined) {
+        GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 0, version: 0 }), { days: 84 })
       }
 
-      this.$module.addEventListener('click', function (e) {
-        var target = e.target
-        if (target.classList.contains('dismiss')) {
-          hide(e)
-        } else if (target.classList.contains('js-call-to-action')) {
-          handleCallToActionClick(target)
-        }
-      })
+      var currentCookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))
+      var currentCookieVersion = currentCookie.version
+      var count = viewCount()
+    }
 
-      // if the element is visible
-      if (this.$module.offsetParent !== null) {
-        if (!alwaysOn) {
-          incrementViewCount(count)
-        }
+    this.$module.addEventListener('click', function (e) {
+      var target = e.target
+      if (target.classList.contains('dismiss')) {
+        hide(e)
+      } else if (target.classList.contains('js-call-to-action')) {
+        handleCallToActionClick(target)
+      }
+    })
+
+    // if the element is visible
+    if (this.$module.offsetParent !== null && !alwaysOn) {
+      incrementViewCount(count)
+    }
+
+    function handleCallToActionClick (target) {
+      var url = target.getAttribute('href')
+      track(url)
+    }
+
+    function hide (event) {
+      var currentCookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))
+      var cookieVersion = currentCookieVersion
+
+      if (currentCookie) {
+        cookieVersion = currentCookie.version
       }
 
-      function handleCallToActionClick (target) {
-        var url = target.getAttribute('href')
-        track(url)
+      var cookieValue = JSON.stringify({ count: 999, version: cookieVersion })
+      GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookieValue, { days: 84 })
+      var additional = document.querySelector('.global-bar-additional')
+      if (additional) {
+        additional.classList.remove('global-bar-additional--show')
+      }
+      var dismiss = document.querySelector('.global-bar__dismiss')
+      if (dismiss) {
+        dismiss.classList.remove('global-bar__dismiss--show')
+      }
+      track('Manually dismissed')
+      event.preventDefault()
+    }
+
+    function incrementViewCount (count) {
+      count = count + 1
+      var cookieValue = JSON.stringify({ count: count, version: currentCookieVersion })
+      GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookieValue, { days: 84 })
+
+      if (count === 2) {
+        track('Automatically dismissed')
+      }
+    }
+
+    function viewCount () {
+      var viewCountCookie = GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)
+      var viewCount = parseInt(parseCookie(viewCountCookie).count, 10)
+
+      if (isNaN(viewCount)) {
+        viewCount = 0
       }
 
-      function hide (evt) {
-        var currentCookie = parseCookie(GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE))
-        var cookieVersion = currentCookieVersion
+      return viewCount
+    }
 
-        if (currentCookie) {
-          cookieVersion = currentCookie.version
-        }
-
-        var cookieValue = JSON.stringify({ count: 999, version: cookieVersion })
-        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookieValue, { days: 84 })
-        var additional = document.querySelector('.global-bar-additional')
-        if (additional) {
-          additional.classList.remove('global-bar-additional--show')
-        }
-        var dismiss = document.querySelector('.global-bar__dismiss')
-        if (dismiss) {
-          dismiss.classList.remove('global-bar__dismiss--show')
-        }
-        track('Manually dismissed')
-        evt.preventDefault()
-      }
-
-      function incrementViewCount (count) {
-        count = count + 1
-        var cookieValue = JSON.stringify({ count: count, version: currentCookieVersion })
-        GOVUK.setCookie(GLOBAL_BAR_SEEN_COOKIE, cookieValue, { days: 84 })
-
-        if (count === 2) {
-          track('Automatically dismissed')
-        }
-      }
-
-      function viewCount () {
-        var viewCountCookie = GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)
-        var viewCount = parseInt(parseCookie(viewCountCookie).count, 10)
-
-        if (isNaN(viewCount)) {
-          viewCount = 0
-        }
-
-        return viewCount
-      }
-
-      function track (action) {
-        if (GOVUK.analytics && typeof GOVUK.analytics.trackEvent === 'function') {
-          GOVUK.analytics.trackEvent('Global bar', action, { nonInteraction: 1 })
-        }
+    function track (action) {
+      if (GOVUK.analytics && typeof GOVUK.analytics.trackEvent === 'function') {
+        GOVUK.analytics.trackEvent('Global bar', action, { nonInteraction: 1 })
       }
     }
   }
+
+  Modules.GlobalBar = GlobalBar
 })(window.GOVUK.Modules)

--- a/spec/javascripts/modules/global-bar.spec.js
+++ b/spec/javascripts/modules/global-bar.spec.js
@@ -6,8 +6,6 @@ describe('Global bar module', function () {
   var element
 
   beforeEach(function () {
-    globalBar = new GOVUK.Modules.GlobalBar()
-
     document.cookie = 'global_bar_seen=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;'
   })
 
@@ -31,7 +29,8 @@ describe('Global bar module', function () {
     it('sets basic global_bar_seen cookie if not already set', function () {
       expect(GOVUK.getCookie('global_bar_seen')).toBeNull()
 
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
@@ -40,7 +39,8 @@ describe('Global bar module', function () {
     it('sets basic global_bar_seen cookie if existing one is malformed', function () {
       GOVUK.setCookie('global_bar_seen', 1)
 
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
@@ -64,14 +64,16 @@ describe('Global bar module', function () {
     it('increments view count', function () {
       GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 1, version: 0 }))
 
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(2)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
     })
 
     it('hides additional information section when dismiss link is clicked', function () {
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       $(element).find('.dismiss')[0].click()
 
@@ -82,7 +84,8 @@ describe('Global bar module', function () {
     })
 
     it('hides dismiss link once dismiss link is clicked', function () {
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       $(element).find('.dismiss')[0].click()
 
@@ -111,7 +114,8 @@ describe('Global bar module', function () {
     })
 
     it('tracks when dismiss link is clicked', function () {
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       $(element).find('.dismiss')[0].click()
 
@@ -119,20 +123,21 @@ describe('Global bar module', function () {
     })
 
     it('tracks when clicking on a link marked with js-call-to-action', function () {
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       var link = $(element).find('.js-call-to-action')[0]
       link.addEventListener('click', function (e) {
         e.preventDefault()
       })
       link.click()
-      // $(element).find('.js-call-to-action')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Global bar', '/register-to-vote', { nonInteraction: 1 })
     })
 
     it('tracks when global bar is seen', function () {
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
       expect(GOVUK.CustomDimensions.getAndExtendDefaultTrackingOptions().dimension38.value).toBe('Global Banner viewed')
     })
   })
@@ -155,7 +160,8 @@ describe('Global bar module', function () {
 
       GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 2, version: 0 }))
 
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(2)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
@@ -173,7 +179,8 @@ describe('Global bar module', function () {
 
       GOVUK.setCookie('global_bar_seen', JSON.stringify({ count: 2, version: 0 }))
 
-      globalBar.start(element)
+      globalBar = new GOVUK.Modules.GlobalBar(element[0])
+      globalBar.init()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(3)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)

--- a/spec/javascripts/modules/global-bar.spec.js
+++ b/spec/javascripts/modules/global-bar.spec.js
@@ -11,6 +11,10 @@ describe('Global bar module', function () {
     document.cookie = 'global_bar_seen=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;'
   })
 
+  afterEach(function () {
+    $('#global-bar').remove()
+  })
+
   describe('global banner default', function () {
     beforeEach(function () {
       element = $(
@@ -69,7 +73,7 @@ describe('Global bar module', function () {
     it('hides additional information section when dismiss link is clicked', function () {
       globalBar.start(element)
 
-      $(element).find('.dismiss').click()
+      $(element).find('.dismiss')[0].click()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(999)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
@@ -80,7 +84,7 @@ describe('Global bar module', function () {
     it('hides dismiss link once dismiss link is clicked', function () {
       globalBar.start(element)
 
-      $(element).find('.dismiss').click()
+      $(element).find('.dismiss')[0].click()
 
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(999)
       expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(0)
@@ -109,7 +113,7 @@ describe('Global bar module', function () {
     it('tracks when dismiss link is clicked', function () {
       globalBar.start(element)
 
-      $(element).find('.dismiss').click()
+      $(element).find('.dismiss')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Global bar', 'Manually dismissed', { nonInteraction: 1 })
     })
@@ -117,7 +121,12 @@ describe('Global bar module', function () {
     it('tracks when clicking on a link marked with js-call-to-action', function () {
       globalBar.start(element)
 
-      $(element).find('.js-call-to-action').click()
+      var link = $(element).find('.js-call-to-action')[0]
+      link.addEventListener('click', function (e) {
+        e.preventDefault()
+      })
+      link.click()
+      // $(element).find('.js-call-to-action')[0].click()
 
       expect(GOVUK.analytics.trackEvent).toHaveBeenCalledWith('Global bar', '/register-to-vote', { nonInteraction: 1 })
     })


### PR DESCRIPTION
## What
Removes jQuery from the global bar script, and updates the code to use the GOVUK Frontend standard for module structure i.e. from a `start` to an `init` structure.

## Why
We're removing jQuery from GOV.UK.

## Visual changes
None.

Trello card: https://trello.com/c/SaxK0Gfc/523-remove-jquery-from-static

