### PR TITLE
Fix intermittent test failures in surveys

### DIFF
--- a/spec/javascripts/surveys.spec.js
+++ b/spec/javascripts/surveys.spec.js
@@ -52,6 +52,7 @@ describe('Surveys', function () {
       GOVUK.cookie(surveys.surveySeenCookieName(survey), null)
     })
     $block.remove()
+    $('#global-bar').remove()
   })
 
   describe('init', function () {
@@ -459,13 +460,23 @@ describe('Surveys', function () {
       expect(surveys.canShowAnySurvey()).toBeFalsy()
     })
 
-    xit('returns true otherwise', function () {
+    it('returns true otherwise', function () {
+      spyOn(surveys, 'otherNotificationVisible').and.returnValue(false)
+      spyOn(surveys, 'userCompletedTransaction').and.returnValue(false)
+      spyOn(surveys, 'pathInBlocklist').and.returnValue(false)
       expect(surveys.canShowAnySurvey()).toBeTruthy()
     })
   })
 
   describe('otherNotificationVisible', function () {
-    xit('returns true if the global cookie banner is visible', function () {
+    beforeEach(function () {
+      $('#global-cookie-message').css('display', 'none')
+      $('.emergency-banner').css('display', 'none')
+      $('#taxonomy-survey').css('display', 'none')
+      $('#global-bar').css('display', 'none')
+    })
+
+    it('returns true if the global cookie banner is visible', function () {
       $('#global-cookie-message').css('display', 'block')
 
       expect(surveys.canShowAnySurvey(defaultSurvey)).toBeTruthy()

--- a/spec/javascripts/surveys.spec.js
+++ b/spec/javascripts/surveys.spec.js
@@ -717,6 +717,7 @@ describe('Surveys', function () {
 
       it("records an event when clicking 'no thanks'", function () {
         spyOn(surveys, 'trackEvent')
+        emailSurvey.surveyExpanded = false
         $('#user-survey-cancel').trigger('click')
         expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'banner_no_thanks', 'No thanks clicked')
       })
@@ -830,6 +831,7 @@ describe('Surveys', function () {
 
         it("records an event when clicking 'no thanks'", function () {
           spyOn(surveys, 'trackEvent')
+          emailSurvey.surveyExpanded = true
           $('#user-survey-cancel').trigger('click')
           expect(surveys.trackEvent).toHaveBeenCalledWith(emailSurvey.identifier, 'email_survey_cancel', 'Email survey cancelled')
         })


### PR DESCRIPTION
## What
Fix two intermittently failing tests and re-enable and fix two disabled (and also intermittently failing) tests.

### Failures
Two of the survey JavaScript tests have been failing intermittently. This seems to have been caused by the state of the `surveyExpanded` attribute within the surveys code. This attribute is set correctly or incorrectly by other tests, so the failure would occur depending on the order the tests are run.

Specifically, this occurs in the `if` statement on line 244, where matching the `if` instead of the `else` can fire the wrong tracking event. The solution is to manually set this attribute to the expected value in the failing tests.

Issue noted in issue https://github.com/alphagov/govuk_publishing_components/issues/2524

### Disabled tests
Once enabled, these tests were also failing intermittently, again apparently due to race conditions caused by other tests. Explicitly setting the starting conditions for these tests seems to have solved the problem.

## Why
Test failures are bad. Also I want to remove jQuery from `static` and resolving them will make that easier.

## Visual changes
None.

Trello card: https://trello.com/c/SaxK0Gfc/523-remove-jquery-from-static