### PR TITLE
Revert #2034

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -43,33 +43,6 @@ var globalBarInit = {
     return new RegExp(paths.join('|')).test(window.location.pathname)
   },
 
-  checkDuplicateCookie: function () {
-    var cookies = document.cookie.split(';')
-    var matches = 0
-    var i
-
-    for (i = 0; i < cookies.length; i++) {
-      if (cookies[i] && cookies[i].indexOf('global_bar_seen') !== -1) {
-        matches++
-      }
-    }
-
-    if (matches > 1) {
-      var possiblePaths = window.location.pathname.split('/')
-      var pathString = ''
-
-      // The duplicate cookie will have a path set to something other than "/".
-      // The cookie will only surface on that path or it's sub-paths
-      // As there isn't a way of directly finding out the path, we need to try cookie deletion with all path combinations possible on the current URL.
-      for (i = 0; i < possiblePaths.length; i++) {
-        if (possiblePaths[i] !== '') {
-          pathString = pathString + '/' + possiblePaths[i]
-          document.cookie = 'global_bar_seen=; expires=Thu, 01 Jan 1970 00:00:01 GMT;path=' + pathString
-        }
-      }
-    }
-  },
-
   setBannerCookie: function () {
     var cookieCategory = window.GOVUK.getCookieCategory(GLOBAL_BAR_SEEN_COOKIE)
     var cookieConsent = GOVUK.getConsentCookie()
@@ -95,11 +68,6 @@ var globalBarInit = {
     var currentCookieVersion
 
     if (!globalBarInit.urlBlockList()) {
-      // We had a bug which meant that the global_bar_seen cookie was sometimes set more than once.
-      // This bug has now been fixed, but some users will be left with these duplicate cookies and therefore will continue to see the issue.
-      // We need to check for duplicate cookies so we can delete them
-      globalBarInit.checkDuplicateCookie()
-
       if (globalBarInit.getLatestCookie() === null) {
         globalBarInit.setBannerCookie()
         globalBarInit.makeBannerVisible()


### PR DESCRIPTION
Checking for duplicated cookie is no longer needed as the old `global_bar_seen` cookie has expired. Fixes #2036