### PR TITLE
Include trigger event script from gem

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require govuk_publishing_components/dependencies
 
+//= require govuk_publishing_components/lib/trigger-event
 //= require govuk_publishing_components/lib/cookie-functions
 
 //= require analytics


### PR DESCRIPTION
## What
Fix the analytics pageviews not firing on GOV.UK's 404 page, by including the `trigger-event.js` script in `static`, from the components gem.

- this script is called by the cookie banner code in `setCookieConsent`, which is included in static as part of the cookies/analytics code for GOV.UK
- without it, cookie consent doesn't appear to be set correctly, resulting in a console error complaining about the trigger event script missing if you try to consent to cookies on the 404 page (which comes from static)
- oddly, once you have consented to cookies no further errors appear, but the analytics pageview for the 404 page doesn't appear to work
- adding the trigger event script like this should fix analytics on the 404 page, which are currently not working properly

Without the script, this is what happens:

![Screenshot 2022-02-11 at 10 30 35](https://user-images.githubusercontent.com/861310/153576416-40499961-be34-4018-94f2-014f2a81e72d.png)
