### PR TITLE
Conditionally add the GTM component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ group :development, :test do
 end
 
 group :test do
+  gem "climate_control"
   gem "govuk-content-schema-test-helpers"
   gem "jasmine-core"
   gem "minitest"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (3.0.0)
+    climate_control (1.0.1)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
     crack (0.4.4)
@@ -349,6 +350,7 @@ DEPENDENCIES
   actionpack-page_caching
   better_errors
   binding_of_caller
+  climate_control
   gds-api-adapters
   govuk-content-schema-test-helpers
   govuk_app_config

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -32,13 +32,15 @@
   global_bar << global_banner if global_banner
 %>
 
-<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
-   <%= render "govuk_publishing_components/components/google_tag_manager_script", {
-     gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
-     gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
-     gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
-   } %>
- <% end %>
+<% content_for :head do %>
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+       gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+     } %>
+  <% end %>
+<% end %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -32,6 +32,14 @@
   global_bar << global_banner if global_banner
 %>
 
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+   <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+     gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+     gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+     gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+   } %>
+ <% end %>
+
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,
   draft_watermark: draft_environment,

--- a/test/integration/google_tag_manager_component_test.rb
+++ b/test/integration/google_tag_manager_component_test.rb
@@ -1,0 +1,19 @@
+require "integration_test_helper"
+
+class GoogleTagManagerComponentTest < ActionDispatch::IntegrationTest
+  context "GTM environment variables are present" do
+    should "render the GTM component on the gem_base template" do
+      ClimateControl.modify GOOGLE_TAG_MANAGER_ID: "a-nice-id" do
+        visit "/templates/gem_layout.html.erb"
+        assert_match "https://www.googletagmanager.com/gtm.js", page.body
+      end
+    end
+  end
+
+  context "GTM environment variables are absent" do
+    should "not render the GTM component on the gem_base template" do
+      visit "/templates/gem_layout.html.erb"
+      assert_no_match "https://www.googletagmanager.com/gtm.js", page.body
+    end
+  end
+end


### PR DESCRIPTION
We want to test out our configuration of GTM and implementation of Ga4 tracking. We are going to do this in integration only at this stage. The env vars required to render the GTM component have been made available to government frontend on integration only, see https://github.com/alphagov/govuk-puppet/pull/11550

Trello: https://trello.com/c/0yzp3M2T/785-ga4-conditionally-add-the-gtm-component-to-static-templates