### PR TITLE
Add `skip-link` script

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,9 +6,10 @@
 //= require analytics
 
 //= require govuk_publishing_components/components/cookie-banner
+//= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
-//= require govuk_publishing_components/components/feedback
+//= require govuk_publishing_components/components/skip-link
 
 //= require modules/global-bar
 //= require modules/cross-domain-tracking


### PR DESCRIPTION
### What
Add `skip-link` script

### Why
`govuk_publishing_components` v28.6 (https://github.com/alphagov/static/pull/2712) brings in a `skip-link` script that needs to be imported by `static`

From [govuk-frontend v4.0.0 release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.0.0):
> We've added JavaScript for the skip link component to set focus to the linked element, for example, the main content on the page. This helps screen readers read the linked content when users use the skip link component.