### PR TITLE
Remove coronavirus banner

### DIFF
--- a/app/assets/stylesheets/components/_global-bar.scss
+++ b/app/assets/stylesheets/components/_global-bar.scss
@@ -50,10 +50,6 @@ $covid-grey: #262828;
 .global-bar-title,
 .global-bar-text {
   color: govuk-colour("white");
-
-  & + .global-bar-covid-wrapper {
-    margin-top: govuk-spacing(2);
-  }
 }
 
 .global-bar-title__nowrap {

--- a/app/assets/stylesheets/components/_global-bar.scss
+++ b/app/assets/stylesheets/components/_global-bar.scss
@@ -81,25 +81,3 @@ $covid-grey: #262828;
 .global-bar__list {
   margin-top: 0;
 }
-
-.global-bar-additional {
-  display: none;
-  padding: govuk-spacing(4) 0;
-  background-color: $covid-grey;
-}
-
-.global-bar-additional__text {
-  position: relative;
-
-  p:last-child {
-    margin-bottom: 0;
-  }
-}
-
-.global-bar-additional__text-govspeak {
-  color: govuk-colour("white");
-}
-
-.global-bar-additional--show {
-  display: block;
-}

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_global_bar ||= true # Toggles the appearance of the global bar
+  show_global_bar ||= false # Toggles the appearance of the global bar
 
   title = false
   title_href = false

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -11,16 +11,11 @@
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
 
-  show_additional_banner = false
-
   global_bar_classes = %w(global-bar dont-print)
 
   title_classes = %w(global-bar-title)
   title_classes << "js-call-to-action" if title_href
   title_classes << "govuk-link" if title_href
-
-  dismiss_classes = %w(global-bar__dismiss global-bar__dismiss--show dismiss)
-  dismiss_classes << "govuk-link"
 -%>
 
 <% if show_global_bar %>
@@ -50,27 +45,6 @@
         </p>
       <% end %>
     </div>
-
-    <% if show_additional_banner %>
-      <div class="global-bar-additional global-bar-additional--show">
-        <div class="govuk-width-container govuk-grid-row">
-          <%= render "govuk_publishing_components/components/govspeak", {
-          } do %>
-            <div class="global-bar-additional__text-govspeak govuk-grid-column-two-thirds govuk-!-padding-0">
-              <p class="govuk-!-margin-bottom-1">Coronavirus guidance is being updated.</p>
-              <p class="govuk-!-margin-top-0">Read <a href="/government/speeches/prime-ministers-statement-to-the-house-on-covid-19-23-june-2020" class="govuk-link">the Prime Minister’s statement</a> for the latest information.</p>
-            </div>
-          <% end %>
-        </div>
-
-        <div class="govuk-width-container global-bar-dismiss-wrapper">
-          <a href="#hide-message"
-            class="<%= dismiss_classes.join(' ') %>"
-            role="button"
-            aria-controls="global-bar">Hide message</a>
-        </div>
-      </div>
-    <% end %>
   </div>
   <!--<![endif]-->
 <% end %>

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -6,11 +6,6 @@
   link_text = false
   link_href = false
 
-  show_coronavirus_link = true
-  coronavirus_title = "Coronavirus (COVID-19)"
-  coronavirus_href = "/coronavirus"
-  coronavirus_subtext = "Latest updates and guidance"
-
   # Toggles banner being permanently visible
   # If true, banner is always_visible & does not disappear automatically after 3 pageviews
   # Regardless of value, banner is always manually dismissable by users
@@ -53,20 +48,6 @@
           <%= link_text %>
         <% end %>
         </p>
-      <% end %>
-
-      <% if show_coronavirus_link %>
-        <div class="global-bar-covid-wrapper">
-          <%= render "govuk_publishing_components/components/action_link", {
-            text: coronavirus_title,
-            href: coronavirus_href,
-            subtext: coronavirus_subtext,
-            classes: "js-call-to-action",
-            light_text: true,
-            simple_light: true,
-          }
-         %>
-        </div>
       <% end %>
     </div>
 


### PR DESCRIPTION
Trello: https://trello.com/c/BpOxInF5

# What's changed and why?

Investigate how much work is required to remove the coronavirus banner.

# Findings

1. As there are no other banners, `show_global_bar` needs to be set to `false` otherwise a black bar is displayed after the GOV.UK header:

|show_global_bar = true|show_global_bar = false|
|:-----------------------|:-----------------------|
|<img width="1128" alt="global_banner_left_on" src="https://user-images.githubusercontent.com/5793815/156581069-fe5993c1-8808-4c25-9457-277f995ef98e.png">|<img width="1128" alt="global_banner_turned_off" src="https://user-images.githubusercontent.com/5793815/156581101-5dd4e3af-440c-455a-af04-5c15a599e9ae.png">|

2. After the global banner is turned off, the "Tell us what you think" survey sometimes makes a reappearance:

|Before|After|
|:------|:----|
|<img width="1126" alt="Screenshot 2022-03-03 at 14 00 16" src="https://user-images.githubusercontent.com/5793815/156581636-2d9e94b1-a465-4a3e-a0d6-16d944092ceb.png">|<img width="1128" alt="Screenshot 2022-03-03 at 13 59 40" src="https://user-images.githubusercontent.com/5793815/156581316-30bd929e-b218-4e1d-96ab-b51c92bcf5c8.png"><img width="1128" alt="global_banner_turned_off" src="https://user-images.githubusercontent.com/5793815/156581101-5dd4e3af-440c-455a-af04-5c15a599e9ae.png">|




