### PR TITLE
Manually bump the components gem to v29

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,14 +122,14 @@ GEM
     govuk_personalisation (0.11.2)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (28.9.2)
+    govuk_publishing_components (29.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
       plek
       rails (>= 6)
       rouge
-      sprockets (< 4)
+      sprockets (>= 3)
     govuk_test (3.0.0)
       brakeman (>= 5.0.2)
       capybara
@@ -161,7 +161,7 @@ GEM
     json-schema (2.8.1)
       addressable (>= 2.4)
     kgio (2.11.4)
-    kramdown (2.3.1)
+    kramdown (2.3.2)
       rexml
     link_header (0.0.8)
     listen (3.2.1)


### PR DESCRIPTION
- breaking release, removes jQuery