### PR TITLE
Remove all Coronavirus links on 4xx and 5xx error pages

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -31,7 +31,6 @@
         margin_top: 0,
       } %>
       <%= raw intro %>
-      <p class="govuk-body">You can <a class="govuk-link" href="/coronavirus">find coronavirus information</a> on GOV.UK.</p>
       <pre class="govuk-!-margin-top-8">Status code: <%= status_code %></pre>
     </div>
   </div>

--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -15,6 +15,7 @@ class Error4XXTest < ActionDispatch::IntegrationTest
 
       within "#content" do
         assert page.has_selector?("h1", text: "Page not found")
+        assert page.has_no_selector?("p", text: "find coronavirus information")
         assert page.has_selector?("pre", text: "Status code: 404", visible: :all)
       end
 

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -15,6 +15,7 @@ class Error5XXTest < ActionDispatch::IntegrationTest
 
       within "#content" do
         assert page.has_selector?("h1", text: "Sorry, we’re experiencing technical difficulties")
+        assert page.has_no_selector?("p", text: "find coronavirus information")
         assert page.has_selector?("pre", text: "Status code: 500", visible: :all)
       end
 


### PR DESCRIPTION
## What

Remove the Coronavirus link on all 4xx and 5xx error pages.

## Why

We are removing all signposting to Coronavirus across GOV.UK.

## Screenshots

| Before | After |
|---|---|
|![Screenshot 2022-03-29 at 17 09 19](https://user-images.githubusercontent.com/44037625/160656978-a9863412-9ec5-4859-b401-73217e7c5c33.png)|![Screenshot 2022-03-29 at 17 08 51](https://user-images.githubusercontent.com/44037625/160657043-5667aae7-bce8-401c-a423-81c70c2cf8b3.png)|

[Trello](https://trello.com/c/jbSGY1lk/798-placeholder-remove-coronavirus-link-on-404-message-due-4th-april)