### PR TITLE
Remove Coronavirus error page tests

### DIFF
--- a/test/integration/templates/error_4xx_test.rb
+++ b/test/integration/templates/error_4xx_test.rb
@@ -15,7 +15,6 @@ class Error4XXTest < ActionDispatch::IntegrationTest
 
       within "#content" do
         assert page.has_selector?("h1", text: "Page not found")
-        assert page.has_no_selector?("p", text: "find coronavirus information")
         assert page.has_selector?("pre", text: "Status code: 404", visible: :all)
       end
 

--- a/test/integration/templates/error_5xx_test.rb
+++ b/test/integration/templates/error_5xx_test.rb
@@ -15,7 +15,6 @@ class Error5XXTest < ActionDispatch::IntegrationTest
 
       within "#content" do
         assert page.has_selector?("h1", text: "Sorry, we’re experiencing technical difficulties")
-        assert page.has_no_selector?("p", text: "find coronavirus information")
         assert page.has_selector?("pre", text: "Status code: 500", visible: :all)
       end
 


### PR DESCRIPTION
What

Tests were introduced as part of [this PR](https://github.com/alphagov/static/pull/2736) to ensure the Covonavirus link had been removed from the 4xx and 5xx error pages.

These should be removed.

Why

Once the above PR is merged and we are happy that these links are fully removed, we should remove these tests as they no longer add value.


[Trello](https://trello.com/c/MnEEQiWI/835-placeholder-remove-coronavirus-error-page-tests)