### PR TITLE
Add template - "full_width" and "omit_footer_navigation"

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -30,6 +30,7 @@ class RootController < ApplicationController
     gem_layout_explore_header
     gem_layout_full_width
     gem_layout_full_width_explore_header
+    gem_layout_full_width_no_footer_navigation
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
     scheduled_maintenance

--- a/app/views/root/gem_layout_full_width_no_footer_navigation.html.erb
+++ b/app/views/root/gem_layout_full_width_no_footer_navigation.html.erb
@@ -1,0 +1,7 @@
+<%= render partial: "gem_base",
+  locals: {
+    full_width: true,
+    omit_footer_navigation: true,
+    show_explore_header: false
+  }
+%>


### PR DESCRIPTION
## What

Add a layout `gem_layout_full_width_no_footer_navigation ` to be used for both [The Service Manual](https://www.gov.uk/service-manual) and the [Service Toolkit](https://www.gov.uk/service-toolkit) pages.

## Why

A variation is needed to remove the blue border (`full_width: true`) but with the settings currently used for both The Service Manual and the Service Toolkit pages. No variation currently exists for the following configuration:
```
full_width: true,
omit_footer_navigation: true,
show_explore_header: false
```
## Anything else

https://github.com/alphagov/service-manual-frontend/pull/1080