### PR TITLE
Change behaviour so that `user_satisfaction_survey` is disabled by default in `gem_base` template

### DIFF
--- a/app/views/root/_account.html.erb
+++ b/app/views/root/_account.html.erb
@@ -9,7 +9,6 @@
   omit_feedback_form: true,
   omit_footer_border: true,
   omit_global_banner: true,
-  omit_user_satisfaction_survey: true,
   omit_footer_navigation: true,
   show_account_layout: true,
   show_explore_header: false,

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -7,7 +7,6 @@
   omit_footer_navigation ||= nil
   omit_footer_border ||= nil
   omit_global_banner ||= nil
-  omit_user_satisfaction_survey ||= nil
   omit_account_navigation ||= nil
   product_name ||= nil
   show_explore_header = show_explore_header === false ? false : true
@@ -28,7 +27,6 @@
 
   global_bar = ''
   global_banner = render "components/global_bar" unless omit_global_banner
-  global_bar << '<div id="user-satisfaction-survey-container"></div>' unless omit_user_satisfaction_survey
   global_bar << global_banner if global_banner
 %>
 


### PR DESCRIPTION
This change makes it so that by default user_satisfaction_survey is **not** enabled in gem_base. Request was made that the user satisfaction survey be disabled for now as it was clashing with intervention banner and some of our new templates. After some exploring, I found that it has been set to appear on gem_base.html.erb by default. As a several apps use gem_layout.html.erb which uses the gem_base partial, I thought the least disruptive way to implement this change would be to change the default behaviour from always on to always off.  It will likely return in a redesigned form at some point in the future at which point this default behaviour can be changed back (or if is desired it could be only enabled on specific frontend apps instead of all frontend apps).

[Relevant Trello Card With Request](https://trello.com/c/m9cB3s9M/931-switch-off-the-sitewide-survey-banner)