### PR TITLE
Conditionally add GA4 code from gem

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -1,5 +1,9 @@
 //= require govuk_publishing_components/analytics
 
+<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+  //= require govuk_publishing_components/analytics-ga4
+<% end %>
+
 var linkedDomains = [
   'access.service.gov.uk',
   'access.tax.service.gov.uk',


### PR DESCRIPTION
## What
Include new Google Tag Manager code from the gem. Note that this PR will need a new version of the gem with [this change](https://github.com/alphagov/govuk_publishing_components/pull/2760).

- if the environment variables are set (should only be set on integration) then pull in the new Google Tag Manager code from the gem
- this will allow us to test click tracking on some elements

## Why
We want to start testing this.

## Visual changes
None.

Trello card: https://trello.com/c/V0RFrSMK/43-test-technical-approach-to-tracking-on-tabs-and-accordions