### PR TITLE
Add warnings

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -5,6 +5,10 @@
 
 //= require analytics
 
+// some applications may depend on these component asset imports
+// check the component auditing before removing any of them
+// https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
+
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/layout-header

--- a/app/assets/stylesheets/application-print.scss
+++ b/app/assets/stylesheets/application-print.scss
@@ -4,6 +4,9 @@ $is-print: true;
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 
+// some applications may depend on these component asset imports
+// check the component auditing before removing any of them
+// https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
 @import "govuk_publishing_components/components/print/button";
 @import "govuk_publishing_components/components/print/layout-super-navigation-header";
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,9 @@ $govuk-new-link-styles: true;
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 
+// some applications may depend on these component asset imports
+// check the component auditing before removing any of them
+// https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
 @import "govuk_publishing_components/components/action-link";
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/cookie-banner";


### PR DESCRIPTION
## What
Adds some warnings to the main stylesheet, print stylesheet and JS file.

## Why
To use a component in an application, the application must import any assets the component needs (stylesheet, print stylesheet, JavaScript). Anything `static` has is also included, so we don't need to duplicate assets between `static` and an application.

For example, the feedback component is included by `static` and depends upon the input component, so `static` needs to have the assets for both feedback and input. This means that any applications that use the input component don't need to include the assets for input, because they're already included by `static`.

In the future, if for some reason we removed the feedback component, and took the assets for feedback and input out of `static` without realising that other applications depend upon them, it would break the appearance and functionality of those applications.

All of this can be checked by running the component auditing: https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md

## Visual changes
None.