### PR TITLE
GUA-222 Update text for the account link in the header

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -49,7 +49,7 @@
   logo_link: logo_link,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
     {
-      text: "Account",
+      text: "Your GOV.UK account",
       href: GovukPersonalisation::Urls.your_account,
       data: {
         module: "explicit-cross-domain-links",


### PR DESCRIPTION
The account team are changing some details about how you navigate between the account and services, ahead of onboarding the LITE service.

**Don't merge this one yet** as it has to go out at the same time as some changes on DI AUTH side.


https://govukverify.atlassian.net/browse/GUA-224