### PR TITLE
Make GA4 analytics page views work on error pages

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -11,6 +11,16 @@
   global_bar = render "components/global_bar"
 %>
 
+<% content_for :head do %>
+  <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+     <%= render "govuk_publishing_components/components/google_tag_manager_script", {
+       gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],
+       gtm_auth: ENV["GOOGLE_TAG_MANAGER_AUTH"],
+       gtm_preview: ENV["GOOGLE_TAG_MANAGER_PREVIEW"]
+     } %>
+  <% end %>
+<% end %>
+
 <%= render "govuk_publishing_components/components/layout_for_public", {
   emergency_banner: emergency_banner,
   full_width: false,


### PR DESCRIPTION
## What
Make page views for the new analytics code work on the error pages (404, 500, etc.)

- error pages use a different template from the rest of the site, GTM code wasn't included here so wasn't working
- note that this will be a temporary measure for GTM init until we've integrated it into the cookie consent

## Why
Really important to know when people hit error pages.

## Visual changes
None.

Trello card: https://trello.com/c/5forgWxL/338-page-views-dont-work-on-error-pages