### PR TITLE
Removes action link stylesheet

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,6 @@ $govuk-new-link-styles: true;
 // some applications may depend on these component asset imports
 // check the component auditing before removing any of them
 // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
-@import "govuk_publishing_components/components/action-link";
 @import "govuk_publishing_components/components/button";
 @import "govuk_publishing_components/components/cookie-banner";
 @import "govuk_publishing_components/components/feedback";


### PR DESCRIPTION
## What

Removes the action link stylesheet.

Partner to https://github.com/alphagov/collections/pull/2847.

## Why

The action link is now only being used in the collections app - so can be removed from static. This will prevent some unnecessary CSS from being served to users, as Static serves a stylesheet on every page across GOV.UK

## Visual differences

None.
