### PR TITLE
Add button component JavaScript

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -9,6 +9,7 @@
 // check the component auditing before removing any of them
 // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
 
+//= require govuk_publishing_components/components/button
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/layout-header


### PR DESCRIPTION
## What

Add the button component's JavaScript into the `application.js` file served by `static`.

## Why

The button CSS is in the Static served stylesheet, so the button component's JavaScript should also be in the Static served JavaScript file. At the moment the CSS is coming from `static`, but the JavaScript is coming from the rendering application.

## Visual changes

None.
