### PR TITLE
Update to use new Minideb Ruby base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-ARG base_image=ruby:2.7.6-slim-buster
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:2.7.6
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:2.7.6
 
-FROM $base_image AS builder
+FROM $builder_image AS builder
 
-ENV RAILS_ENV=production GOVUK_APP_NAME=static
-
-RUN apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get install -y build-essential nodejs && \
-    apt-get clean
+ENV GOVUK_APP_NAME=static
 
 RUN mkdir /app
 
@@ -15,30 +11,22 @@ WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
 
-RUN bundle config set deployment 'true' && \
-    bundle config set without 'development test' && \
-    bundle install --jobs 4 --retry=2
+RUN bundle install
 
 COPY . /app
 
-RUN GOVUK_WEBSITE_ROOT=https://www.gov.uk GOVUK_APP_DOMAIN=www.gov.uk bundle exec rails assets:precompile
+RUN bundle exec rails assets:precompile && rm -fr /app/log
+
 
 FROM $base_image
 
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=static
-
-RUN apt-get update -qy && \
-    apt-get upgrade -y && \
-    apt-get install -y nodejs
-
-RUN groupadd -g 1001 appuser && \
-    useradd appuser -u 1001 -g 1001 --home /app
+ENV GOVUK_APP_NAME=static
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app
 RUN mkdir -p /app/public/templates && chown -R 1001:1001 /app/public/templates
 
-USER appuser
+USER app
 WORKDIR /app
 
 CMD bundle exec puma


### PR DESCRIPTION
Updating base image to use a new base and builder image. 

New Images are based on Ruby built from source on top of [Minideb](https://github.com/bitnami/minideb)


Base image repo, for more info:
https://github.com/alphagov/govuk-ruby-images

Further details:
https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles