### PR TITLE
Test that gem_layout renders feedback component

### DIFF
--- a/test/integration/templates/gem_layout_test.rb
+++ b/test/integration/templates/gem_layout_test.rb
@@ -1,0 +1,34 @@
+require "integration_test_helper"
+
+class GemLayoutTest < ActionDispatch::IntegrationTest
+  setup do
+    Capybara.current_driver = Capybara.javascript_driver
+    visit "/templates/gem_layout.html.erb"
+  end
+
+  should "allow user to report a problem with the page" do
+    click_on "Report a problem with this page"
+    assert page.has_content?("Help us improve GOV.UK")
+    assert page.has_field?("What went wrong?")
+
+    # Regression test for scenario where wrong URL is set
+    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    assert_equal page.current_url, url_input.value
+  end
+
+  should "allow user to report that the page is not useful" do
+    click_on "No" # No, this page is not useful
+    assert page.has_content?("Help us improve GOV.UK")
+    assert page.has_field?("Email address")
+
+    # Regression test for scenario where wrong URL is set
+    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    full_path = URI(page.current_url).request_uri
+    assert_equal full_path, url_input.value
+  end
+
+  should "allow user to report that the page is useful" do
+    click_on "Yes" # Yes, this page is useful
+    assert page.has_content?("Thank you for your feedback")
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/XDLC291t/2948-write-test-for-static-to-go-hand-in-hand-with-smokey-3)

This imports a test from Smokey[^1][^2] that confirms that the feedback component is present & functional.

The Smokey test does not currently meet the eligibility criteria for inclusion in the repository[^3], but by adding this test to Static we can meet the "Second critical functional check" criterion.

n.b. I'm new to GDS, so please do look over it critically and let me know if I've made any mistakes 🙏

[^1]: https://github.com/alphagov/smokey/blob/main/features/apps/static.feature
[^2]: https://github.com/alphagov/smokey/blob/main/features/step_definitions/feedback_steps.rb
[^3]: https://github.com/alphagov/smokey/blob/main/docs/writing-tests.md