### PR TITLE
Explicitly allow redirects to other hosts within gov.uk domain

### DIFF
--- a/app/controllers/icon_redirects_controller.rb
+++ b/app/controllers/icon_redirects_controller.rb
@@ -2,10 +2,14 @@ class IconRedirectsController < ApplicationController
   before_action { expires_in(1.day, public: true) }
 
   def show
-    redirect_to view_context.asset_path(request.path.to_s[1..]), status: :moved_permanently
+    redirect_to(view_context.asset_path(request.path.to_s[1..]),
+                status: :moved_permanently,
+                allow_other_host: true)
   end
 
   def apple_old_size_icon
-    redirect_to view_context.asset_path("apple-touch-icon.png"), status: :moved_permanently
+    redirect_to(view_context.asset_path("apple-touch-icon.png"),
+                status: :moved_permanently,
+                allow_other_host: true)
   end
 end


### PR DESCRIPTION
In rails 7 redirects to other hosts are no longer permitted by default
and ActionController::Redirecting::UnsafeRedirectError was raised.

However in all those cases we are redirect to other GOV.UK domains such as
assets.gov.uk


Tested in staging