### PR TITLE
Heed the `GA_*_ID` env vars at runtime.

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -136,9 +136,7 @@ var linkedDomains = [
 ]
 
 window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {}
-window.GOVUK.analyticsVars.gaProperty = '<%= Rails.application.config.ga_universal_id %>'
 window.GOVUK.analyticsVars.primaryLinkedDomains = ['account.gov.uk']
-window.GOVUK.analyticsVars.gaPropertyCrossDomain = '<%= Rails.application.config.ga_secondary_id %>'
 window.GOVUK.analyticsVars.linkedDomains = linkedDomains
 
 if (typeof window.GOVUK.analyticsInit !== 'undefined') {

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -31,6 +31,12 @@
 %>
 
 <% content_for :head do %>
+  <script>
+    window.GOVUK = window.GOVUK || {};
+    window.GOVUK.analyticsVars = window.GOVUK.analyticsVars || {};
+    window.GOVUK.analyticsVars.gaProperty = '<%= Rails.application.config.ga_universal_id %>';
+    window.GOVUK.analyticsVars.gaPropertyCrossDomain = '<%= Rails.application.config.ga_secondary_id %>';
+  </script>
   <% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
      <%= render "govuk_publishing_components/components/google_tag_manager_script", {
        gtm_id: ENV["GOOGLE_TAG_MANAGER_ID"],


### PR DESCRIPTION
The Google Analytics IDs were being burned into the `analytics.js` Rails asset at build time (i.e. `rails assets:precompile`), which was causing all environments to use the same property IDs when deployed as containers. In the containerised world we want to compile the assets once, at build time, and upload them to a central service for serving static files (Amazon S3).

While the account number is the same (UA-26179049), each environment has a distinct property number (integration=22, staging=20, prod=1).

Avoid substituting environment variables into JavaScript files via ERB at build time. Instead, move these up into HTML templates so that changes to `GA_*_ID` take effect at container startup rather than requiring a rebuild.

#### Testing

Deployed to the integration EKS cluster and observed GA collect requests are now being sent with the expected web property ID (`UA-26179049-22`) for integration, instead of `UA-26179049-1` as before.

`POST | https://www.google-analytics.com/j/collect?v=1&_v=j96&aip=1&a=1642051629&t=pageview&_s=1&dl=https://www.eks.integration.govuk.digital/&dp=/&ul=en-gb&de=UTF-8&dt=Welcome to GOV.UK&sd=30-bit&sr=1920x1200&vp=1145x767&je=0&_u=SCEACAABBAAAAC~&cid=1100976322.1652793698&tid=UA-26179049-22&_gid=1606836569.1660302003&_slc=1&cd15=200&cd16=unknown&cd95=1100976322.1652793698&cd11=1&cd2=homepage&cd3=other&cd4=f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a&cd9=<OT1056>&cd12=not withdrawn&cd17=homepage&cd20=frontend&cd30=none&cd31=none&cd32=none&cd56=other&cd57=other&cd58=other&cd59=other&cd39=false&cd89=frontend&cd26=0&cd27=0&cd23=unknown&cd38=false&cd100=true&z=739931572`

Didn't see any new errors in the JS console. Only tested on latest Firefox, Safari and Edge (all macOS). Can't easily inspect the GA collection requests on Chrome because it does some strange internal redirect, but there were no errors there either.