### PR TITLE
"Omit account navigation" should be true on the account layout templates

### DIFF
--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -1,5 +1,4 @@
 <%
-  omit_account_navigation ||= nil
   account_nav_location ||= "your-account"
   di_location = "https://signin.account.gov.uk"
 %>
@@ -12,7 +11,7 @@
   omit_footer_navigation: true,
   show_account_layout: true,
   show_explore_header: false,
-  omit_account_navigation: omit_account_navigation,
+  omit_account_navigation: true,
   footer_meta: { items: [
     {
       href: "#{di_location}/accessibility-statement",

--- a/app/views/root/gem_layout_account_manager_no_nav.html.erb
+++ b/app/views/root/gem_layout_account_manager_no_nav.html.erb
@@ -1,5 +1,4 @@
 <%
-  omit_account_navigation ||= nil
   account_nav_location ||= "your-account"
   di_location = "https://signin.account.gov.uk"
 %>
@@ -12,7 +11,7 @@
   omit_footer_navigation: true,
   show_account_layout: true,
   show_explore_header: false,
-  omit_account_navigation: omit_account_navigation,
+  omit_account_navigation: true,
   footer_meta: { items: [
     {
       href: "#{di_location}/accessibility-statement",


### PR DESCRIPTION
https://github.com/alphagov/static/pull/2808 accidentally reintroduced the left hand side account nav on Manage your GOVUK email subscriptions 🤦🏻‍♀️