### PR TITLE
Prevent GOVUK_ASSET_HOST from setting the asset host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.assets.quiet = true
 
   # Allow overriding the asset host with an environment variable.
-  config.asset_host = ENV["ASSET_HOST"] || ENV["GOVUK_ASSET_ROOT"] || Plek.current.find("static")
+  config.asset_host = ENV["ASSET_HOST"] || Plek.current.find("static")
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,13 +82,13 @@ Rails.application.configure do
   end
 
   # Allow overriding the asset host with an environment variable.
-  config.action_controller.asset_host = ENV["ASSET_HOST"] || ENV["GOVUK_ASSET_ROOT"]
+  config.action_controller.asset_host = ENV["ASSET_HOST"]
 
   # Google Analytics ID
   config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-26179049-1")
   config.ga_secondary_id = ENV.fetch("GA_SECONDARY_ID", "UA-145652997-1")
 
-  # Set GOVUK_ASSET_ROOT & PLEK_SERVICE_STATIC_URI for heroku - for review
+  # Set ASSET_HOST & PLEK_SERVICE_STATIC_URI for heroku - for review
   # apps we have the hostname set at the time of the app being built so can't
   # be set up in the app.json
   if ENV["HEROKU_APP_NAME"]


### PR DESCRIPTION
This environment env var isn't being used in our infrastructure to set asset host as ASSET_HOST is always set and takes precedence. Neither is it used in our Heroku preview apps nor for local development (govuk-docker and ./startup.sh). This cleans up the codebase and removes confusion around which environment variables should be set.