### PR TITLE
Use a wider div to wrap banner text

### DIFF
--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -1,7 +1,7 @@
 <div class="emergency-banner emergency-banner--<%= campaign_class %> dont-print" role="banner" data-nosnippet>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
-      <div class="govuk-grid-column-two-thirds">
+      <div class="govuk-grid-column-full">
         <h2 class="emergency-banner__heading"><%= heading %></h2>
         <% if short_description %>
           <p class="emergency-banner__description"><%= short_description %></p>


### PR DESCRIPTION
Currently, `govuk-grid-column-two-thirds` knocks the 'II' onto a second line for the Queens death emergency banner. Using three thirds keeps all the text on a single line for larger screens.

## Before 

<img width="1573" alt="Screenshot 2022-09-08 at 19 41 05" src="https://user-images.githubusercontent.com/24479188/189200729-1dc40d6c-67b3-4cb1-9235-9e2c0a34ec7f.png">

## After

<img width="1626" alt="Screenshot 2022-09-08 at 19 40 43" src="https://user-images.githubusercontent.com/24479188/189200914-5be3f59d-fe62-4484-adf8-1a4a4187a96a.png">
<img width="503" alt="Screenshot 2022-09-08 at 19 40 52" src="https://user-images.githubusercontent.com/24479188/189200937-6c560076-3584-411e-89ab-3a97c3d6177a.png">
