### PR TITLE
Avoid 2 banner roles on the same page

### DIFF
--- a/app/views/components/_emergency_banner.html.erb
+++ b/app/views/components/_emergency_banner.html.erb
@@ -1,8 +1,8 @@
-<div class="emergency-banner emergency-banner--<%= campaign_class %> dont-print" role="banner" data-nosnippet>
+<section class="emergency-banner emergency-banner--<%= campaign_class %> dont-print" aria-labelledby="emergency-banner-heading" data-nosnippet>
   <div class="govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-full">
-        <h2 class="emergency-banner__heading"><%= heading %></h2>
+        <h2 class="emergency-banner__heading" id="emergency-banner-heading"><%= heading %></h2>
         <% if short_description %>
           <p class="emergency-banner__description"><%= short_description %></p>
         <% end %>
@@ -12,4 +12,4 @@
       </div>
     </div>
   </div>
-</div>
+</section>


### PR DESCRIPTION
The top banner also has role=banner, so we're
marking this one with an aria-labelled-by attribute instead
and using `section`, which has the same semantics as `<div role="region">`
