### PR TITLE
New Template with No Emergency Banner

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -29,6 +29,7 @@ class RootController < ApplicationController
     gem_layout_full_width
     gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
+    gem_layout_no_emergency_banner
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
     scheduled_maintenance

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,8 +1,8 @@
 <%
-  @emergency_banner = emergency_banner_notification
 
   logo_link ||= Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/"
   full_width ||= false
+  omit_emergency_banner ||= false
   omit_feedback_form ||= nil
   omit_footer_navigation ||= nil
   omit_footer_border ||= nil
@@ -14,6 +14,8 @@
   account_nav_location ||= nil
   footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
+
+  @emergency_banner = !omit_emergency_banner && emergency_banner_notification
 
   if @emergency_banner
     emergency_banner = render "components/emergency_banner", {

--- a/app/views/root/gem_layout_no_emergency_banner.html.erb
+++ b/app/views/root/gem_layout_no_emergency_banner.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "gem_base",
+  locals: {
+    omit_emergency_banner: true
+  }
+%>


### PR DESCRIPTION
## What

A new template which does not display the emergency banner, even when it is active.

## Why

For the Queen topical page, it was requested that the emergency be removed as it creates a circular journey and pushes content down. This is because the emergency banner has a link to the page that it appears on. The addition of this template will prevent this happening in the future.