### PR TITLE
Look for gtag env var

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -145,14 +145,22 @@ if (typeof window.GOVUK.analyticsInit !== 'undefined') {
   window.GOVUK.analyticsInit()
 }
 
-<% if ENV["GOOGLE_TAG_MANAGER_ID"] %>
+var gtm_id = '<%= ENV["GOOGLE_TAG_MANAGER_ID"] %>' || null
+var gtag_id = '<%= ENV["GTAG_ID"] %>' || null
+
+if (gtm_id || gtag_id) {
   if (typeof window.GOVUK.analyticsGA4.init !== 'undefined') {
     window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {}
     window.GOVUK.analyticsGA4.vars = window.GOVUK.analyticsGA4.vars || {}
-    window.GOVUK.analyticsGA4.vars.id = '<%= ENV["GOOGLE_TAG_MANAGER_ID"] %>'
-    window.GOVUK.analyticsGA4.vars.auth = '<%= ENV["GOOGLE_TAG_MANAGER_AUTH"] %>'
-    window.GOVUK.analyticsGA4.vars.preview = '<%= ENV["GOOGLE_TAG_MANAGER_PREVIEW"] %>'
+
+    if (gtag_id) {
+      window.GOVUK.analyticsGA4.vars.gtag_id = gtag_id
+    } else {
+      window.GOVUK.analyticsGA4.vars.id = gtm_id
+      window.GOVUK.analyticsGA4.vars.auth = '<%= ENV["GOOGLE_TAG_MANAGER_AUTH"] %>'
+      window.GOVUK.analyticsGA4.vars.preview = '<%= ENV["GOOGLE_TAG_MANAGER_PREVIEW"] %>'
+    }
 
     window.GOVUK.analyticsGA4.init()
   }
-<% end %>
+}


### PR DESCRIPTION
## What
Allow the use of Google Tag in place of Google Tag Manager.

- modify the GA4 code to check for the existence of a gtag environment variable alongside the existing code to check for a GTM env var
- if the gtag env var is found, this will be used in preference to GTM by the code called in the components gem from window.GOVUK.analyticsGA4.init()
- otherwise will default back to GTM for all environments, or simply do nothing if no GTM or gtag env vars are found

## Why
We want to test Gtag on integration and this allows us to do it without breaking things on other environments. Related to: https://github.com/alphagov/govuk_publishing_components/pull/2979

## Visual changes
None.

Trello card: https://trello.com/c/Oo0T8ZCa/178-spike-into-back-out-plan-from-gtm-to-gtag