### PR TITLE
Spike: show a banner warning when page is rendered via mirror

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -18,6 +18,13 @@
   title_classes << "govuk-link" if title_href
 -%>
 
+<div id="mirror-banner" class="govuk-width-container govuk-!-margin-top-4">
+  <%= render "govuk_publishing_components/components/notice", {
+    title: "This content may be out of date",
+    description: sanitize("<p class=\"govuk-body\">This page was served from the GOV.UK mirror and may not work properly.</p>"),
+  } %>
+</div>
+
 <% if show_global_bar %>
   <!--[if gt IE 7]><!-->
   <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>


### PR DESCRIPTION
If the user views a mirrored page, there is no indication that it is a mirrored page (except by accident, e.g. looking broken). The page content may be out of date, depending on when it was mirrored. Additionally, dynamic content won't work, so if Origin is down and we're serving mirrored content, if the user performs a "Search", for example, they'll get a 503 error.

I've used the [Notice component][] as there is precedent for using it to indicate content warnings, e.g.
https://components.publishing.service.gov.uk/component-guide/notice/with_locale.

The wording and styling are of course subject to change.

> ![](https://user-images.githubusercontent.com/5111927/192025177-3eaa4c7b-c239-4f0d-83d8-d8019f287019.png)

Trello: https://trello.com/c/OuKvzs4L/2741-write-rfc-to-be-transparent-about-mirrored-content

[Notice component]: https://components.publishing.service.gov.uk/component-guide/notice
