### PR TITLE
Small Dockerfile fixes for Replatforming.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,10 @@
 .git
 .gitignore
 Jenkinsfile
+Procfile
 README.md
+docs
+log
+spec
+test
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,12 +5,9 @@ FROM $builder_image AS builder
 
 ENV GOVUK_APP_NAME=static
 
-RUN mkdir /app
-
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/
-
 RUN bundle install
 
 COPY . /app


### PR DESCRIPTION
Remove an unnecessary mkdir /app from the Dockerfile, since this will be incompatible with an upcoming version of govuk-ruby-base.

Also remove some unneeded paths from the image.