### PR TITLE
Get components gem version

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -152,6 +152,7 @@ if (gtm_id || gtag_id) {
   if (typeof window.GOVUK.analyticsGA4.init !== 'undefined') {
     window.GOVUK.analyticsGA4 = window.GOVUK.analyticsGA4 || {}
     window.GOVUK.analyticsGA4.vars = window.GOVUK.analyticsGA4.vars || {}
+    window.GOVUK.analyticsGA4.vars.gem_version = '<%= GovukPublishingComponents::VERSION %>'
 
     if (gtag_id) {
       window.GOVUK.analyticsGA4.vars.gtag_id = gtag_id


### PR DESCRIPTION
## What
Get the version of the components gem and store it in the `window.GOVUK.analyticsGA4.vars` object, for later reference in the analytics code in the components gem.

- needed for the GA4 analytics code
- this was being created in the components gem, but that meant including a .js.erb file there, which we're trying to move away from
- instead, include it here, so we reduce the number of .js.erb files and deal with this later

Related change: https://github.com/alphagov/govuk_publishing_components/pull/2984

## Why
Using `.js.erb` files is apparently deprecated, so we're trying to avoid using them. This removes the `.js.erb` file in the gem (well, renames it back to `.js`) and moves the code here, so at least it's all in one place and we can come up with a single solution to this later.

## Visual changes
None.

Trello card: https://trello.com/c/Yu6Fw4ob/220-tech-debt-to-be-addressed