### PR TITLE
Add new template for blue bar full width

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -27,6 +27,7 @@ class RootController < ApplicationController
     gem_layout_account_manager
     gem_layout_explore_header
     gem_layout_full_width
+    gem_layout_full_width_blue_bar
     gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
     gem_layout_no_emergency_banner

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -14,6 +14,7 @@
   account_nav_location ||= nil
   footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
+  blue_bar ||= false
 
   @emergency_banner = !omit_emergency_banner && emergency_banner_notification
 
@@ -34,6 +35,7 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,
+  blue_bar: blue_bar,
   draft_watermark: draft_environment,
   emergency_banner: emergency_banner.presence,
   full_width: full_width,

--- a/app/views/root/gem_layout_full_width_blue_bar.html.erb
+++ b/app/views/root/gem_layout_full_width_blue_bar.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'gem_base', locals: { full_width: true, blue_bar: true } %>


### PR DESCRIPTION
This adds a new template that allows a blue bar to be added to full width templates. Adding this template avoids having to implement the bar within the collections application itself, which was causing styling differences to the blue bar that appears on regular width layouts when browsing collections pages.

https://github.com/alphagov/govuk_publishing_components/pull/3002 needs to be merged first.