### PR TITLE
Add helpforhouseholds.campaign.gov.uk to linkedDomains

### DIFF
--- a/app/assets/javascripts/analytics.js.erb
+++ b/app/assets/javascripts/analytics.js.erb
@@ -68,6 +68,7 @@ var linkedDomains = [
   'get-fishing-licence.service.gov.uk',
   'get-information-schools.service.gov.uk',
   'gro.gov.uk',
+  'helpforhouseholds.campaign.gov.uk',
   'helpwithcourtfees.service.gov.uk',
   'help-with-prison-visits.service.gov.uk',
   'identity.company-information.service.gov.uk',


### PR DESCRIPTION
Enable cross-domain Google Analytics tracking for the helpforhouseholds.campaign.gov.uk domain