### PR TITLE
Remove unused gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,6 @@ end
 
 group :test do
   gem "climate_control"
-  gem "govuk-content-schema-test-helpers"
   gem "minitest"
   gem "minitest-capybara"
   gem "mocha", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,8 +112,6 @@ GEM
       rest-client (~> 2.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (4.9.0)
       logstasher (~> 2.1)
       plek (~> 4)
@@ -155,8 +153,6 @@ GEM
     image_size (3.0.2)
     in_threads (1.6.0)
     json (2.6.2)
-    json-schema (2.8.1)
-      addressable (>= 2.4)
     kgio (2.11.4)
     kramdown (2.4.0)
       rexml
@@ -360,7 +356,6 @@ DEPENDENCIES
   binding_of_caller
   climate_control
   gds-api-adapters
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_personalisation
   govuk_publishing_components


### PR DESCRIPTION
Doesn't look as though this gem is currently used, so very minor change!

https://trello.com/c/b9PRFqgU/231-applications-use-govuk-content-schema-test-helpers-which-is-an-archived-gem