### PR TITLE
Lint: use list syntax for Dockerfile CMD.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,4 @@ RUN mkdir -p /app/public/templates && chown -R 1001:1001 /app/public/templates
 USER app
 WORKDIR /app
 
-CMD bundle exec puma
+CMD ["bundle", "exec", "puma"]


### PR DESCRIPTION
Generated with `gsed -i 's/^CMD bundle exec puma$/CMD [bundle, exec, puma]/'`