### PR TITLE
Update to latest Capybara

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
       debug_inspector (>= 0.0.1)
     brakeman (5.2.3)
     builder (3.2.4)
-    capybara (3.37.1)
+    capybara (3.38.0)
       addressable
       matrix
       mini_mime (>= 0.1.3)


### PR DESCRIPTION
Capybara 3.38.0

This allows us to move to the latest version of Puma [1].

[1]: https://github.com/teamcapybara/capybara/pull/2530