### PR TITLE
Set GOOGLE_TAG_MANAGER_ID for image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM $builder_image AS builder
 
 ENV GOVUK_APP_NAME=static
 
+# GOOGLE_TAG_MANAGER_ID is set to ensure assets are precompiled with GTM
+# module enabled. Value is set to the real GTM ID during deployment.
+ENV GOOGLE_TAG_MANAGER_ID=true
+
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/


### PR DESCRIPTION
GOOGLE_TAG_MANAGER_ID is set to ensure assets are precompiled with GTM module enabled. Value is set to the real GTM ID during deployment. This fixes an issue where assets for Static in the image differed from our old deployments of Static on EC2.

https://github.com/alphagov/static/blob/fb01c7415a419766b15c4e95b9ef0e0452e66ad6/app/assets/javascripts/analytics.js.erb#L3
