### PR TITLE
Revert "Set GOOGLE_TAG_MANAGER_ID for image build"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ FROM $builder_image AS builder
 
 ENV GOVUK_APP_NAME=static
 
-# GOOGLE_TAG_MANAGER_ID is set to ensure assets are precompiled with GTM
-# module enabled. Value is set to the real GTM ID during deployment.
-ENV GOOGLE_TAG_MANAGER_ID=true
-
 WORKDIR /app
 
 COPY Gemfile* .ruby-version /app/


### PR DESCRIPTION
Appears to have broken analytics on www domain - Reverts alphagov/static#2942