### PR TITLE
Add GOOGLE_TAG_MANAGER_ID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
-ENV GOVUK_APP_NAME=static
+ENV GOVUK_APP_NAME=static \
+    GOOGLE_TAG_MANAGER_ID=GTM-MG7HG5W
 
 WORKDIR /app
 


### PR DESCRIPTION
GOOGLE_TAG_MANAGER_ID added with ID, this should  ensure assets are precompiled with correct `gtm_id`

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

