### PR TITLE
Rename Licence reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,6 @@ How to's:
 - [How to: deploy the Emergency Banner](docs/emergency-banner.md)
 - [How to: update `humans.txt`](docs/humans.md)
 
-## License
+## Licence
 
 [MIT License](LICENCE)


### PR DESCRIPTION
We want to make the reference to the licence in the README consistent with the GDS Way.

Trello card: https://trello.com/c/P0DpFcwW/260-standardise-all-license-files-names-to-licence

