### PR TITLE
Remove configurable asset host

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -45,20 +45,15 @@ Rails.application.configure do
   # Suppress logger output for asset requests.
   config.assets.quiet = true
 
-  # Allow overriding the asset host with an environment variable.
-  config.asset_host = ENV["ASSET_HOST"] || Plek.new.find("static")
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 
-  # Allow access to the application using dev.gov.uk hostnames
-  config.hosts += %w[
-    draft-static.dev.gov.uk
-    static.dev.gov.uk
-  ]
+  # Allow requests for all domains e.g. <app>.dev.gov.uk
+  config.hosts.clear
+
   # Uncomment if you wish to allow Action Cable access from any origin.
   # config.action_cable.disable_request_forgery_protection = true
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,18 +81,14 @@ Rails.application.configure do
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end
 
-  # Allow overriding the asset host with an environment variable.
-  config.action_controller.asset_host = ENV["ASSET_HOST"]
-
   # Google Analytics ID
   config.ga_universal_id = ENV.fetch("GA_UNIVERSAL_ID", "UA-26179049-1")
   config.ga_secondary_id = ENV.fetch("GA_SECONDARY_ID", "UA-145652997-1")
 
-  # Set ASSET_HOST & PLEK_SERVICE_STATIC_URI for heroku - for review
+  # Set PLEK_SERVICE_STATIC_URI for heroku - for review
   # apps we have the hostname set at the time of the app being built so can't
   # be set up in the app.json
-  if ENV["HEROKU_APP_NAME"]
-    ENV["ASSET_HOST"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("ASSET_HOST")
-    ENV["PLEK_SERVICE_STATIC_URI"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com" unless ENV.include?("PLEK_SERVICE_STATIC_URI")
+  if ENV["HEROKU_APP_NAME"] && !ENV.include?("PLEK_SERVICE_STATIC_URI")
+    ENV["PLEK_SERVICE_STATIC_URI"] = "#{ENV['HEROKU_APP_NAME']}.herokuapp.com"
   end
 end


### PR DESCRIPTION
Trello: https://trello.com/c/lxxx5XLZ/178-govuk-has-a-half-implemented-content-security-policy-csp

Since the introduction of the [static proxy](https://github.com/alphagov/govuk_app_config/blob/7f060692720df50a27f6845f052b04eae2246226/lib/govuk_app_config/govuk_proxy/static_proxy.rb) there is no longer an essential need to use absolute asset URLs when using static and thus has become a niche feature.

As we don't use a host for static in production we can disallow the long list of allowed hostnames for assets in our Content Security Policy, which [we intend to do](https://github.com/alphagov/govuk_app_config/pull/274).

This PR removes the ability to configure the asset host, and pre-set defaults, so that developers won't fall into a situation where they configure it and then find it falls foul of the CSP.

This pairs with a corresponding [govuk-docker PR](https://github.com/alphagov/govuk-docker/pull/632) that set's the dev environment to always proxy static.

More info in the commits.