### PR TITLE
Deploy Global Banner for Emergency Alerts Test

### DIFF
--- a/app/assets/stylesheets/components/_global-bar.scss
+++ b/app/assets/stylesheets/components/_global-bar.scss
@@ -8,7 +8,7 @@ $covid-grey: #262828;
 
 .global-bar {
   @include govuk-font(19);
-  background-color: govuk-colour("black");
+  background-color: #d9e7f2;
   border-top: govuk-spacing(2) solid govuk-colour("blue");
   border-bottom: 1px solid govuk-colour("white");
   display: none;
@@ -19,10 +19,10 @@ $covid-grey: #262828;
 
   .govuk-link,
   .govuk-link:link {
-    color: govuk-colour("white");
+    color: govuk-colour("black");
 
     &:visited {
-      color: govuk-colour("white");
+      color: govuk-colour("black");
     }
 
     &:focus {
@@ -49,7 +49,7 @@ $covid-grey: #262828;
 
 .global-bar-title,
 .global-bar-text {
-  color: govuk-colour("white");
+  color: govuk-colour("black");
 }
 
 .global-bar-title__nowrap {

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,5 +1,5 @@
 <%
-  show_global_bar ||= false # Toggles the appearance of the global bar
+  show_global_bar ||= true # Toggles the appearance of the global bar
 
   title = false
   title_href = false

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -21,7 +21,7 @@
 <% if show_global_bar %>
   <!--[if gt IE 7]><!-->
   <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
-    <div class="global-bar-message govuk-width-container">
+    <p class="global-bar-message govuk-width-container">
       <% if title %>
         <% if title_href %>
           <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= title %></a>
@@ -31,7 +31,7 @@
       <% end %>
 
       <% if link_text %>
-        <p class="global-bar-text">
+        <span class="global-bar-text">
         <% if link_href %>
           <%= link_to(
             link_text,
@@ -42,9 +42,9 @@
         <% else %>
           <%= link_text %>
         <% end %>
-        </p>
+        </span>
       <% end %>
-    </div>
+    </p>
   </div>
   <!--<![endif]-->
 <% end %>

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,9 +1,9 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
 
-  title = false
-  title_href = false
-  link_text = false
+  title = "Emergency Alerts"
+  title_href = "/alerts"
+  link_text = "Test on Sunday 23 April, 3pm"
   link_href = false
 
   # Toggles banner being permanently visible


### PR DESCRIPTION
## What

Show the global bar with a message about upcoming Emergency Alerts test. Change the Emergency Bar background colour to light blue (so as not to confuse it with the black Emergency Banner). Inline the message text so the bar does not take two lines and push content to far down the page.

## Why

In advance of the Emergency Alerts test, we want to raise awareness of them happening. This will be removed after the Emergency Alerts test takes place.

![Screenshot 2023-04-14 at 13 23 25](https://user-images.githubusercontent.com/3727504/232042447-2009d552-0b1f-407a-8b74-e2952e08d391.png)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/WtRR3aGm/1775-urgent-emergency-alerts-site-wide-banner-m)

