### PR TITLE
Remove emergency alerts banner

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,9 +1,9 @@
 <%
-  show_global_bar ||= true # Toggles the appearance of the global bar
+  show_global_bar ||= false # Toggles the appearance of the global bar
 
-  title = "Emergency Alerts"
-  title_href = "/alerts"
-  link_text = "Test on Sunday 23 April, 3pm"
+  title = false
+  title_href = false
+  link_text = false
   link_href = false
 
   # Toggles banner being permanently visible


### PR DESCRIPTION
Removes banner added in https://github.com/alphagov/static/pull/3039
Leaves the updated styling, but hides the banner and resets the banner text.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

