### PR TITLE
Add gem_layout_full_width_browse_header template

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -27,6 +27,7 @@ class RootController < ApplicationController
     gem_layout_account_manager
     gem_layout_explore_header
     gem_layout_full_width
+    gem_layout_full_width_browse_header
     gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
     gem_layout_homepage

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,4 +1,6 @@
 <%
+  blue_bar ||= true
+  blue_bar_background_colour ||= nil
   logo_link ||= Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/"
   full_width ||= false
   omit_emergency_banner ||= false
@@ -35,6 +37,8 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,
+  blue_bar: blue_bar,
+  blue_bar_background_colour: blue_bar_background_colour,
   draft_watermark: draft_environment,
   emergency_banner: emergency_banner.presence,
   full_width: full_width,

--- a/app/views/root/gem_layout_full_width_browse_header.html.erb
+++ b/app/views/root/gem_layout_full_width_browse_header.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'gem_base', locals: { full_width: true, blue_bar: true, blue_bar_background_colour: "browse" } %>


### PR DESCRIPTION
## What

Add a new template for Browse page headers on the collection application. Update the gem_base with new attributes that have been added to the public_layout.

## Why

There are instances of pages on collections that have a coloured background in the heading section. This meant that the the blue bar (which is rendered in the public_layout) had to be rendered by collections otherwise it would result in a gap between the blue bar and coloured section. This solution seemed fine until we had a recent deployment of the global bar. As the global bar includes a blue bar, it meant that the Browse pages had two blue bars. They therefore needed to be removed while the global bar was present and then added back again when the global bar was removed. 

To avoid this needing to happen the next time the bar is deployed, this new template has been implemented. It means that if a page has a coloured background heading it can be specified in the template and then it will be applied to the blue bar. This means the blue bar can be rendered in public_layout and so applications don't need to render the blue bar if they have a heading section with a background colour.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/pT7Sh8Yn/1793-update-layoutforpublic-template-so-that-global-bar-is-independent-of-requiring-changes-in-the-browse-template-l)