### PR TITLE
Make `emergency_banner` rake task more robust

### DIFF
--- a/lib/emergency_banner/deploy.rb
+++ b/lib/emergency_banner/deploy.rb
@@ -1,6 +1,13 @@
+require "uri"
+
 module EmergencyBanner
   class Deploy
     def run(campaign_class, heading, short_description = "", link = "", link_text = "")
+      if link != ""
+        uri = URI.parse(link)
+        raise ArgumentError, "Invalid URL provided: #{link}" unless uri.is_a?(URI::HTTP) && !uri.host.nil?
+      end
+
       redis = Redis.new
       redis.hmset(
         :emergency_banner,

--- a/lib/emergency_banner/deploy.rb
+++ b/lib/emergency_banner/deploy.rb
@@ -3,6 +3,10 @@ require "uri"
 module EmergencyBanner
   class Deploy
     def run(campaign_class, heading, short_description = "", link = "", link_text = "")
+      unless %w[notable-death national-emergency local-emergency].include?(campaign_class)
+        raise ArgumentError, "Invalid campaign_class provided: #{campaign_class}"
+      end
+
       if link != ""
         uri = URI.parse(link)
         raise ArgumentError, "Invalid URL provided: #{link}" unless uri.is_a?(URI::HTTP) && !uri.host.nil?

--- a/lib/tasks/emergency_banner.rake
+++ b/lib/tasks/emergency_banner.rake
@@ -3,11 +3,13 @@ require_relative "../emergency_banner/remove"
 
 namespace :emergency_banner do
   desc "Deploy the emergency banner"
-  task :deploy, %i[campaign_class heading short_description link link_text] => :environment do |_, args|
-    raise ArgumentError unless args.campaign_class
-    raise ArgumentError unless args.heading
+  task :deploy, [] => :environment do |_, args|
+    campaign_class, heading, short_description, link, link_text = args.extras
+    raise ArgumentError unless campaign_class
+    raise ArgumentError unless heading
+    raise ArgumentError, "Expected up to 5 arguments. #{args.extras.count} were provided" if args.extras.count > 5
 
-    EmergencyBanner::Deploy.new.run(args.campaign_class, args.heading, args.short_description, args.link, args.link_text)
+    EmergencyBanner::Deploy.new.run(campaign_class, heading, short_description, link, link_text)
   end
 
   desc "Remove the emergency banner"

--- a/test/tasks/emergency_banner_test.rb
+++ b/test/tasks/emergency_banner_test.rb
@@ -37,6 +37,13 @@ describe "emergency_banner:deploy" do
 
     Rake::Task["emergency_banner:deploy"].invoke("campaign class", "heading", "short description", "link", "link_text")
   end
+
+  should "raise an exception if unexpected arguments are passed" do
+    exception = assert_raises ArgumentError do
+      Rake::Task["emergency_banner:deploy"].invoke("campaign class", "heading", "short description", "link", "link_text", "something else")
+    end
+    assert_equal("Expected up to 5 arguments. 6 were provided", exception.message)
+  end
 end
 
 describe "emergency_banner:remove" do

--- a/test/unit/emergency_banner/deploy_test.rb
+++ b/test/unit/emergency_banner/deploy_test.rb
@@ -21,6 +21,16 @@ describe "Emergency Banner::Deploy" do
       EmergencyBanner::Deploy.new.run("notable-death", "A title")
     end
 
+    should "raise an exception if the campaign_class is invalid" do
+      exception = assert_raises ArgumentError do
+        EmergencyBanner::Deploy.new.run(
+          "notable-deathh", # spot the deliberate error!
+          "A title",
+        )
+      end
+      assert_equal("Invalid campaign_class provided: notable-deathh", exception.message)
+    end
+
     should "create an emergency_banner with a campaign_class, heading and short_description" do
       Redis.any_instance.expects(:hmset).with(
         :emergency_banner,

--- a/test/unit/emergency_banner/deploy_test.rb
+++ b/test/unit/emergency_banner/deploy_test.rb
@@ -92,5 +92,18 @@ describe "Emergency Banner::Deploy" do
 
       EmergencyBanner::Deploy.new.run("notable-death", "A title", "A short description of the event", "https://www.gov.uk", "Text for hyperlink")
     end
+
+    should "raise an exception if the input for the link doesn't pass validation" do
+      exception = assert_raises ArgumentError do
+        EmergencyBanner::Deploy.new.run(
+          "notable-death",
+          "A title",
+          "A short description of the event",
+          "https:/www.gov.uk", # spot the deliberate error!
+          "Text for hyperlink",
+        )
+      end
+      assert_equal("Invalid URL provided: https:/www.gov.uk", exception.message)
+    end
   end
 end


### PR DESCRIPTION
## What

The rake task will now fail fast if:

- Too many arguments are provided
- The `campaign_class` argument has an unrecognised value
- The `link` argument is not a valid URI

## Why

Previously, inputting a typo would make Origin return 500 errors! By running the rake task with an unescaped comma in the input, as below:

```
kubectl -n apps exec deploy/static -- rake "emergency_banner:deploy['notable-death','Henry Fielding dies','English novelist and dramatist known for his earthy humour and satire dies, age 47','https://en.wikipedia.org/wiki/Henry_Fielding','More information']"
```

The bad use of comma would give the following incorrect entry in redis:

```
irb(main):001:0> Redis.new.hgetall("emergency_banner")
=>
{"short_description"=>
  "'English novelist and dramatist known for his earthy humour and satire dies",
 "heading"=>"'Henry Fielding dies'",
 "campaign_class"=>"'notable-death'",
 "link"=>"age 47'",
```

This resulted in an "access denied" error for https://assets.staging.publishing.service.gov.uk/templates/gem_layout_homepage.html.erb, and subsequently a 500 error for all pages on Origin (e.g. https://www-origin.staging.publishing.service.gov.uk/). The immediate user impact would be minimal, as our CDN automatically falls back to the mirrors, but even so - that's not a good thing!

Therefore we decided to add some safeguards to make it harder for a developer to accidentally break the site.

Trello: https://trello.com/c/ocrS67MT/3222-make-emergency-banner-rake-task-more-robust