### PR TITLE
Add GA4 tracking to survey banner

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -15,10 +15,22 @@
   var templateBase = function (children) {
     return (
       '<section id="user-satisfaction-survey" class="visible" aria-hidden="false">' +
-      '  <div class="survey-wrapper govuk-width-container">' +
-      '    <a class="govuk-link survey-close-button" href="#user-survey-cancel" aria-labelledby="survey-title user-survey-cancel" id="user-survey-cancel" role="button">Close</a>' +
+      '  <div class="survey-wrapper govuk-width-container" data-module="ga4-auto-tracker" ' +
+              'data-ga4-auto=\'' + JSON.stringify({ event_data: { event_name: 'element_visible', type: 'survey banner' } }) +
+              '\'>' +
+      '    <a class="govuk-link survey-close-button" ' +
+              'href="#user-survey-cancel" ' +
+              'aria-labelledby="survey-title user-survey-cancel" ' +
+              'id="user-survey-cancel" ' +
+              'role="button" ' +
+              'data-module="ga4-event-tracker" ' +
+              'data-ga4-event=\'' + JSON.stringify({ event_name: 'select_content', type: 'survey banner', action: 'closed' }) +
+            '\'>Close</a>' +
       '    <h2 class="survey-title" id="survey-title">{{title}}</h2>' +
-           children +
+          '<div data-module="ga4-link-tracker" data-ga4-track-links-only ' +
+                'data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1 }) + '\'>' +
+            children +
+          '</div>' +
       '  </div>' +
       '</section>'
     )
@@ -197,12 +209,14 @@
     displayURLSurvey: function (survey, surveyContainer) {
       var urlSurveyTemplate = userSurveys.getUrlSurveyTemplate()
       surveyContainer.innerHTML = urlSurveyTemplate.render(survey)
+      window.GOVUK.modules.start(surveyContainer) // Initialises our GA4 modules
       userSurveys.setURLSurveyEventHandlers(survey)
     },
 
     displayEmailSurvey: function (survey, surveyContainer) {
       var emailSurveyTemplate = userSurveys.getEmailSurveyTemplate()
       surveyContainer.innerHTML = emailSurveyTemplate.render(survey)
+      window.GOVUK.modules.start(surveyContainer) // Initialises our GA4 modules
       userSurveys.setEmailSurveyEventHandlers(survey)
     },
 

--- a/spec/javascripts/surveys.spec.js
+++ b/spec/javascripts/surveys.spec.js
@@ -90,6 +90,30 @@ describe('Surveys', function () {
       expect($('#user-satisfaction-survey').attr('aria-hidden')).toBe('false')
     })
 
+    it('displays the survey with GA4 attributes', function () {
+      var surveyTypes = [defaultSurvey, smallSurvey, urlSurvey, emailSurvey]
+
+      for (var i = 0; i < surveyTypes.length; i++) {
+        var survey = surveyTypes[i]
+        surveys.displaySurvey(survey)
+        var surveyParent = document.querySelector('#user-satisfaction-survey')
+
+        var ga4AutoElement = surveyParent.querySelector('.survey-wrapper')
+        var ga4EventElement = surveyParent.querySelector('.survey-close-button')
+        var ga4LinkElement = surveyParent.querySelector('.survey-title + div')
+
+        var expectedGa4Auto = { event_data: { event_name: 'element_visible', type: 'survey banner' } }
+        var expectedGa4Event = { event_name: 'select_content', type: 'survey banner', action: 'closed' }
+        var expectedGa4Link = { event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1 }
+
+        expect(JSON.parse(ga4AutoElement.getAttribute('data-ga4-auto'))).toEqual(expectedGa4Auto)
+        expect(JSON.parse(ga4EventElement.getAttribute('data-ga4-event'))).toEqual(expectedGa4Event)
+        expect(JSON.parse(ga4LinkElement.getAttribute('data-ga4-link'))).toEqual(expectedGa4Link)
+
+        expect(ga4LinkElement.hasAttribute('data-ga4-track-links-only')).toEqual(true)
+      }
+    })
+
     it('increments the survey seen cookie counter', function () {
       GOVUK.cookie(surveys.surveySeenCookieName(defaultSurvey), null)
       surveys.displaySurvey(defaultSurvey)


### PR DESCRIPTION
## What

- Adds GA4 tracking to the survey banner. More specifically, it adds a `data-ga4-auto` to send the presence of the banner, `data-ga4-event` for the 'Close' button, and `data-ga4-link` for the survey link.
- As the survey is inserted into the DOM after the modules.js code runs, we can't simply add data-module= to the elements. Instead we manually initialise the GA4 tracking on each element. As JavaScript inserts the banner HTML, we only need to add the tracking attributes here and not in any HTML templates.
- The survey banner is inserted after the GA4 pageview runs, which is why we are using `data-ga4-auto` instead.

## Why

https://trello.com/c/udF07C9O/662-banners-survey-banner-element-visibility-navigation-close-user-interaction-and-form-events

## How to test

- Run a local version of static with this branch checked out
- In `surveys.js` go to the function `isSurveyToBeDisplayed` and set it to just return true, e.g.:
```JavaScript
 isSurveyToBeDisplayed: function (survey) { return true }
```
- In `gem_base.html.erb`, add the HTML element somewhere: 
```HTML
<div id="user-satisfaction-survey-container"></div>
```
 

