### PR TITLE
Add new template for blue bar full width

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -27,6 +27,7 @@ class RootController < ApplicationController
     gem_layout_account_manager
     gem_layout_explore_header
     gem_layout_full_width
+    gem_layout_full_width_blue_bar
     gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
     gem_layout_no_emergency_banner

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -14,6 +14,7 @@
   account_nav_location ||= nil
   footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
+  blue_bar ||= false
 
   @emergency_banner = !omit_emergency_banner && emergency_banner_notification
 
@@ -34,6 +35,7 @@
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,
+  blue_bar: blue_bar,
   draft_watermark: draft_environment,
   emergency_banner: emergency_banner.presence,
   full_width: full_width,

--- a/app/views/root/gem_layout_full_width_blue_bar.html.erb
+++ b/app/views/root/gem_layout_full_width_blue_bar.html.erb
@@ -1,0 +1,1 @@
+<%= render partial: 'gem_base', locals: { full_width: true, blue_bar: true } %>


### PR DESCRIPTION
## What

Add a new template for Browse page headers on the collection application. Update the gem_base with new attributes that have been added to the public_layout.

## Why

There are instances of pages on collections that have a coloured background in the heading section. This meant that the the blue bar (which is rendered in the public_layout) had to be rendered by collections otherwise it would result in a gap between the blue bar and coloured section. This solution seemed fine until we had a recent deployment of the global bar. As the global bar includes a blue bar, it meant that the Browse pages had two blue bars. They therefore needed to be removed while the global bar was present and then added back again when the global bar was removed. 

To avoid this needing to happen the next time the bar is deployed, this new template has been implemented. It means that if a page has a coloured background heading it can be specified in the template and then it will be applied to the blue bar. This means the blue bar can be rendered in public_layout and so applications don't need to render the blue bar if they have a heading section with a background colour.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/pT7Sh8Yn/1793-update-layoutforpublic-template-so-that-global-bar-is-independent-of-requiring-changes-in-the-browse-template-l)