### PR TITLE
Pass homepage to layout_for_public

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -39,6 +39,7 @@
   emergency_banner: emergency_banner.presence,
   full_width: full_width,
   global_bar: global_bar,
+  homepage: homepage
   logo_link: logo_link,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
     {


### PR DESCRIPTION
## What

Pass the `homepage` parameter to `layout_for_public`.  

## Why

So that homepage specific styles can be triggered in `layout_for_public`.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

