### PR TITLE
Enable GA4 tracking on the emergency banner

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -5,6 +5,7 @@
       link: @emergency_banner.link,
       link_text: @emergency_banner.link_text,
       short_description: @emergency_banner.short_description,
+      ga4_tracking: true,
     }
   end
   user_satisfaction_survey = '<div id="user-satisfaction-survey-container"></div>'

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -25,6 +25,7 @@
       link_text: @emergency_banner.link_text,
       short_description: @emergency_banner.short_description,
       homepage: homepage,
+      ga4_tracking: true,
     }
   end
 


### PR DESCRIPTION
Adds `ga4_tracking: true` to the emergency banner.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

