### PR TITLE
Add GA4 form tracker and section value to survey banner

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -327,7 +327,8 @@
       // The module is then started - the module will send data-ga4-auto object to the dataLayer.
       // Doing it this way prevents us from calling and having to maintaining GA4 JS/cookie consent in this repo.
       var emailSurveyHeading = document.getElementById('survey-title').textContent.trim()
-      var emailSurveyText = error ? document.getElementById('email-survey-post-failure') : document.getElementById('#email-survey-post-success')
+
+      var emailSurveyText = error ? document.getElementById('email-survey-post-failure') : document.getElementById('email-survey-post-success')
       emailSurveyText = emailSurveyText.textContent.trim()
       var span = document.createElement('span')
       span.setAttribute('data-module', 'ga4-auto-tracker')

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -28,7 +28,7 @@
             '\'>Close</a>' +
       '    <h2 class="survey-title" id="survey-title">{{title}}</h2>' +
           '<div data-module="ga4-link-tracker" data-ga4-track-links-only ' +
-                'data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1 }) + '\'>' +
+                'data-ga4-link=\'' + JSON.stringify({ event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1, section: '{{title}}' }) + '\'>' +
             children +
           '</div>' +
       '  </div>' +

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -24,7 +24,7 @@
               'id="user-survey-cancel" ' +
               'role="button" ' +
               'data-module="ga4-event-tracker" ' +
-              'data-ga4-event=\'' + JSON.stringify({ event_name: 'select_content', type: 'survey banner', action: 'closed' }) +
+              'data-ga4-event=\'' + JSON.stringify({ event_name: 'select_content', type: 'survey banner', action: 'closed', section: '{{title}}' }) +
             '\'>Close</a>' +
       '    <h2 class="survey-title" id="survey-title">{{title}}</h2>' +
           '<div data-module="ga4-link-tracker" data-ga4-track-links-only ' +
@@ -49,7 +49,7 @@
     '    {{surveyCta}}' +
     '  </a>' +
     '</div>' +
-    '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true">' +
+    '<form id="email-survey-form" action="/contact/govuk/email-survey-signup" method="post" class="js-hidden" aria-hidden="true" data-module="ga4-form-tracker" data-ga4-form=\'' + JSON.stringify({ event_name: 'form_submit', type: 'survey banner', action: 'submit', section: '{{title}}', text: '{{surveyFormCta}}', tool_name: '{{title}}' }) + '\'>' +
     '  <div class="survey-inner-wrapper">' +
     '    <div id="survey-form-description" class="survey-form-description">{{surveyFormDescription}}' +
     '      <br> {{surveyFormCtaPostscript}}' +

--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -308,8 +308,10 @@
           xhr.onreadystatechange = function () {
             if (xhr.readyState === 4 && xhr.status === 200) {
               successCallback()
+              userSurveys.attachGa4FormCompleteElement($emailSurveyForm, false)
             } else {
               errorCallback()
+              userSurveys.attachGa4FormCompleteElement($emailSurveyForm, true)
             }
           }
 
@@ -318,6 +320,27 @@
           e.preventDefault()
         })
       }
+    },
+
+    attachGa4FormCompleteElement: function (emailSurveyElement, error) {
+      // When the email survey form is submitted, this attaches a HTML element with our GA4 auto tracker to the DOM.
+      // The module is then started - the module will send data-ga4-auto object to the dataLayer.
+      // Doing it this way prevents us from calling and having to maintaining GA4 JS/cookie consent in this repo.
+      var emailSurveyHeading = document.getElementById('survey-title').textContent.trim()
+      var emailSurveyText = error ? document.getElementById('email-survey-post-failure') : document.getElementById('#email-survey-post-success')
+      emailSurveyText = emailSurveyText.textContent.trim()
+      var span = document.createElement('span')
+      span.setAttribute('data-module', 'ga4-auto-tracker')
+      span.setAttribute('data-ga4-auto', JSON.stringify({
+        event_name: 'form_complete',
+        action: 'complete',
+        type: 'survey banner',
+        text: emailSurveyText,
+        section: emailSurveyHeading,
+        tool_name: emailSurveyHeading
+      }))
+      emailSurveyElement.appendChild(span)
+      window.GOVUK.modules.start(emailSurveyElement)
     },
 
     setURLSurveyEventHandlers: function (survey) {

--- a/spec/javascripts/surveys.spec.js
+++ b/spec/javascripts/surveys.spec.js
@@ -104,7 +104,7 @@ describe('Surveys', function () {
 
         var expectedGa4Auto = { event_data: { event_name: 'element_visible', type: 'survey banner' } }
         var expectedGa4Event = { event_name: 'select_content', type: 'survey banner', action: 'closed', section: 'Tell us what you think of GOV.UK' }
-        var expectedGa4Link = { event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1 }
+        var expectedGa4Link = { event_name: 'navigation', type: 'survey banner', index: 1, index_total: 1, section: 'Tell us what you think of GOV.UK' }
         var expectedGa4Form = {
           event_name: 'form_submit',
           type: 'survey banner',


### PR DESCRIPTION
## What
- Adds the `section` value to the GA4 object for the survey banner events, with the value of `section` being the survey's heading text.
- Adds the GA4 form tracker to the email survey banner to track submitting the form.
- Adds a `form_complete` event using `Ga4AutoTracker` when the survey is sent to the user. This adds a `<span>` to the DOM with GA4 auto on it, rather than adding GA4 code to `surveys.js`. I thought this would be better as it prevents us adding a bunch of GA4 code in static which checks if GA4 modules exists, if cookie consent exists, and then more code to push the event. Instead we add a `<span>` with the auto tracker on it, then run `window.GOVUK.Modules.start()`.

## Why
- I missed out some tracking requirements in https://trello.com/c/udF07C9O/662-banners-survey-banner-element-visibility-navigation-close-user-interaction-and-form-events

## How to test

- Run a local version of static with this branch checked out
- In `surveys.js` go to the function `isSurveyToBeDisplayed` and set it to just return true, e.g.:
```JavaScript
 isSurveyToBeDisplayed: function (survey) { return true }
```
- In `gem_base.html.erb`, add the HTML element somewhere: 
```HTML
<div id="user-satisfaction-survey-container"></div>
```