### PR TITLE
Add homepage_new template

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -30,6 +30,7 @@ class RootController < ApplicationController
     gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
     gem_layout_homepage
+    gem_layout_homepage_new
     gem_layout_no_emergency_banner
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -14,6 +14,7 @@
   footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
   homepage ||= false
+  homepage_blue_navbar ||= false
 
   @emergency_banner = !omit_emergency_banner && emergency_banner_notification
 
@@ -43,6 +44,7 @@
   emergency_banner: emergency_banner.presence,
   full_width: full_width,
   global_bar: global_bar,
+  homepage: homepage_blue_navbar,
   logo_link: logo_link,
   navigation_items: [ # Remember to update the links in _base.html.erb as well.
     {

--- a/app/views/root/gem_layout_homepage_new.html.erb
+++ b/app/views/root/gem_layout_homepage_new.html.erb
@@ -1,0 +1,5 @@
+<%= render partial: "gem_base", locals: {
+	full_width: true,
+	homepage: true,
+	homepage_blue_navbar: true,
+} %>


### PR DESCRIPTION
## What

Add new `gem_layout_homepage_new.html.erb` template. Add new `homepage_blue_navbar` attribute to `_gem_base.html.erb`.

## Why

We are rolling out a new design for the homepage on GOV.UK. To make launching the changes easier, we want to gradually deploy the changes behind a query string so that they can all be released at the same time. This new template and attribute triggers the new navbar that will only appear on the new homepage design. 

`homepage` is currently passed to the `layout_for_public` template (it is used to turn off the blue border underneath the navbar) so we need `homepage_blue_navbar` to specifically trigger the navbar.

## Screenshot

![Screenshot 2023-10-05 at 15 02 21](https://github.com/alphagov/static/assets/3727504/ea5426a6-0fc2-4e80-b6d7-91d8408a29e3)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

[Relevant Trello Card](https://trello.com/c/qTmNgPwV/2019-look-and-feel-homepage-top-menu-navigation-header-l)

