### PR TITLE
Remove unneeded instances of ga4_tracking: true

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -5,7 +5,6 @@
       link: @emergency_banner.link,
       link_text: @emergency_banner.link_text,
       short_description: @emergency_banner.short_description,
-      ga4_tracking: true,
     }
   end
   user_satisfaction_survey = '<div id="user-satisfaction-survey-container"></div>'

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -29,7 +29,6 @@
       link_text: @emergency_banner.link_text,
       short_description: @emergency_banner.short_description,
       homepage: homepage,
-      ga4_tracking: true,
     }
   end
 
@@ -41,9 +40,6 @@
 <%= render "govuk_publishing_components/components/layout_for_public", {
   account_nav_location: account_nav_location,
   **(defined?(blue_bar) ? {blue_bar: blue_bar,} : {}),
-  cookie_banner_data: {
-    ga4_tracking: true,
-  },
   draft_watermark: draft_environment,
   emergency_banner: emergency_banner.presence,
   full_width: full_width,


### PR DESCRIPTION
## What

Remove options passed to components for enabling GA4 tracking. All components referenced now have tracking enabled by default, and this option has been removed.

## Why
Unneeded code.

## Visual changes
None.

Trello card: https://trello.com/c/Xwp7dgJN/294-tracking-auditing-tracking-by-default
