### PR TITLE
Migrate to Dart Sass from LibSass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 tmp/*
 log/*.log
 public/assets
+/app/assets/builds
+!/app/assets/builds/.keep
 
 # See https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored
 .yarn/cache/

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gem "rails", "7.1.2"
 
 gem "actionpack-page_caching"
 gem "bootsnap", require: false
+gem "dartsass-rails"
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_personalisation"
@@ -13,7 +14,6 @@ gem "govuk_publishing_components"
 gem "nokogiri"
 gem "plek"
 gem "redis"
-gem "sassc-rails"
 gem "sprockets-rails"
 gem "uglifier"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,6 +108,9 @@ GEM
     crack (0.4.5)
       rexml
     crass (1.0.6)
+    dartsass-rails (0.5.0)
+      railties (>= 6.0.0)
+      sass-embedded (~> 1.63)
     date (3.3.4)
     debug_inspector (1.1.0)
     docile (1.4.0)
@@ -527,14 +530,9 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sassc (2.4.0)
-      ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
+    sass-embedded (1.69.5)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     selenium-webdriver (4.14.0)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
@@ -561,7 +559,6 @@ GEM
     statsd-ruby (1.5.0)
     stringio (3.1.0)
     thor (1.3.0)
-    tilt (2.0.11)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -593,6 +590,7 @@ DEPENDENCIES
   binding_of_caller
   bootsnap
   climate_control
+  dartsass-rails
   gds-api-adapters
   govuk_app_config
   govuk_personalisation
@@ -608,7 +606,6 @@ DEPENDENCIES
   rails (= 7.1.2)
   redis
   rubocop-govuk
-  sassc-rails
   shoulda-context
   simplecov
   sprockets-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,9 +1,5 @@
 //= link_tree ../images
 //= link application.js
 //= link test-dependencies.js
-//= link application-ie8.css
-//= link application-print.css
-//= link application.css
-//= link guides-print.css
-//= link print.css
 //= link modules/base-target.js
+//= link_tree ../builds

--- a/app/assets/stylesheets/helpers/_draft.scss
+++ b/app/assets/stylesheets/helpers/_draft.scss
@@ -1,5 +1,5 @@
 .draft main {
-  background-image: image-url("draft-watermark.png");
+  background-image: url("draft-watermark.png");
   background-repeat: repeat-y;
   background-position: 50% 0;
   background-size: contain;

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -33,10 +33,6 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # Rather than use a CSS compressor, use the SASS style to perform compression.
-  config.sass.style = :compressed
-  config.sass.line_comments = false
-
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 

--- a/config/initializers/dartsass.rb
+++ b/config/initializers/dartsass.rb
@@ -1,0 +1,8 @@
+# config/initializers/dartsass.rb
+Rails.application.config.dartsass.builds = {
+  "application-ie8.scss" => "application-ie8.css",
+  "application-print.scss" => "application-print.css",
+  "application.scss" => "application.css",
+  "guides-print.scss" => "guides-print.css",
+  "print.scss" => "print.css",
+}


### PR DESCRIPTION
## What

Migrate to Dart Sass from LibSass.

## Why

- LibSass is now [deprecated](https://sass-lang.com/blog/libsass-is-deprecated/)
- Making changes ahead of Design System team dropping support for LibSass https://github.com/alphagov/govuk-frontend/discussions/2632.

## Visual Changes

None.

## How can I test these changes?

- run `yarn jasmine:prepare` (or run `bundle exec rake app:assets:clobber app:assets:precompile`)
- what should happen? The Sass files should be compiled. Keep an eye on the command line for warnings indicating the compilation process using Dart Sass
```
Deprecation Warning: Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.
Recommendation: math.div(300%, 4) or calc(300% / 4)
More info and automated migrator: https://sass-lang.com/d/slash-div
   │
26 │   three-quarters: (300% / 4),
   │                    ^^^^^^^^
   ...
```
- the `/builds` folder: `app/assets/builds` should now be populated with CSS files. Note, the 
- subsequently, all assets ought to be generated successfully within the `/public` directory
- no test failures to indicate the correct number of stylesheets are generated
- deploy to Integration. You'll notice that in the '**build and publish image**' task, the steps taken resemble those mentioned earlier, `dartsass-rails` is bundled and any Dart Sass warnings encountered during the compilation process are reported)
- inspect several pages, e.g. [contact GOV.UK](https://www.integration.publishing.service.gov.uk/contact/govuk), [cost of living support](https://www.integration.publishing.service.gov.uk/cost-of-living), [design and build government services](https://www.integration.publishing.service.gov.uk/service-toolkit) to ensure the absence of errors.

## Anything else

Once the PR gets the green light, any temporary commits and references to local gems e.g. `gem "govuk_publishing_components", path: "../govuk_publishing_components"` will be removed.

See:

- https://github.com/alphagov/collections/pull/3447
- https://github.com/alphagov/email-alert-frontend/pull/1655
- https://github.com/alphagov/govuk_publishing_components/pull/3726
- https://github.com/alphagov/govuk-developer-docs/pull/4216.