### PR TITLE
[DO NOT MERGE] Test branch for absolute header/footer links and global search/feedback form

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_personalisation"
-gem "govuk_publishing_components"
+gem "govuk_publishing_components", git: "https://github.com/alphagov/govuk_publishing_components.git", branch: "fix-assets-header-footer-links"
 gem "nokogiri"
 gem "plek"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/alphagov/govuk_publishing_components.git
+  revision: 73bb3b5f2c6b094b9ccb69eb64545201d9b465f5
+  branch: fix-assets-header-footer-links
+  specs:
+    govuk_publishing_components (37.1.0)
+      govuk_app_config
+      govuk_personalisation (>= 0.7.0)
+      kramdown
+      plek
+      rails (>= 6)
+      rouge
+      sprockets (>= 3)
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,15 +159,6 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.1.0)
-      govuk_app_config
-      govuk_personalisation (>= 0.7.0)
-      kramdown
-      plek
-      rails (>= 6)
-      rouge
-      sprockets (>= 3)
-      sprockets-rails
     govuk_test (4.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -596,7 +602,7 @@ DEPENDENCIES
   gds-api-adapters
   govuk_app_config
   govuk_personalisation
-  govuk_publishing_components
+  govuk_publishing_components!
   govuk_test
   listen
   minitest

--- a/test/integration/templates/gem_layout_test.rb
+++ b/test/integration/templates/gem_layout_test.rb
@@ -12,7 +12,7 @@ class GemLayoutTest < ActionDispatch::IntegrationTest
     assert page.has_field?("What went wrong?")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    url_input = page.find("form[action='http://www.dev.gov.uk/contact/govuk/problem_reports'] input[name=url]", visible: false)
     assert_equal page.current_url, url_input.value
   end
 
@@ -20,9 +20,9 @@ class GemLayoutTest < ActionDispatch::IntegrationTest
     click_on "No" # No, this page is not useful
     assert page.has_content?("Help us improve GOV.UK")
     assert page.has_field?("Email address")
-
+    puts page.html
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    url_input = page.find("form[action='http://www.dev.gov.uk/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
     full_path = URI(page.current_url).request_uri
     assert_equal full_path, url_input.value
   end


### PR DESCRIPTION
Testing the header links, footer links, feedback form action links, and search action links with the changes to make the links absolute.

This branch is also rebased off the lib/dart sass branch as tests were failing when based off of main

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

