### PR TITLE
[DO NOT MERGE] Test branch for absolute global link changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "bootsnap", require: false
 gem "gds-api-adapters"
 gem "govuk_app_config"
 gem "govuk_personalisation"
-gem "govuk_publishing_components"
+gem "govuk_publishing_components", git: "https://github.com/alphagov/govuk_publishing_components.git", branch: "fix-assets-header-footer-links"
 gem "nokogiri"
 gem "plek"
 gem "redis"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,18 @@
+GIT
+  remote: https://github.com/alphagov/govuk_publishing_components.git
+  revision: 6a7343077326e07f44530a733ebe0e78f29626e2
+  branch: fix-assets-header-footer-links
+  specs:
+    govuk_publishing_components (37.1.0)
+      govuk_app_config
+      govuk_personalisation (>= 0.7.0)
+      kramdown
+      plek
+      rails (>= 6)
+      rouge
+      sprockets (>= 3)
+      sprockets-rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -144,15 +159,6 @@ GEM
     govuk_personalisation (0.15.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (37.1.0)
-      govuk_app_config
-      govuk_personalisation (>= 0.7.0)
-      kramdown
-      plek
-      rails (>= 6)
-      rouge
-      sprockets (>= 3)
-      sprockets-rails
     govuk_test (4.0.1)
       brakeman (>= 5.0.2)
       capybara (>= 3.36)
@@ -596,7 +602,7 @@ DEPENDENCIES
   gds-api-adapters
   govuk_app_config
   govuk_personalisation
-  govuk_publishing_components
+  govuk_publishing_components!
   govuk_test
   listen
   minitest

--- a/test/integration/templates/gem_layout_test.rb
+++ b/test/integration/templates/gem_layout_test.rb
@@ -12,7 +12,7 @@ class GemLayoutTest < ActionDispatch::IntegrationTest
     assert page.has_field?("What went wrong?")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/problem_reports'] input[name=url]", visible: false)
+    url_input = page.find("form[action='http://www.dev.gov.uk/contact/govuk/problem_reports'] input[name=url]", visible: false)
     assert_equal page.current_url, url_input.value
   end
 
@@ -22,7 +22,7 @@ class GemLayoutTest < ActionDispatch::IntegrationTest
     assert page.has_field?("Email address")
 
     # Regression test for scenario where wrong URL is set
-    url_input = page.find("form[action='/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
+    url_input = page.find("form[action='http://www.dev.gov.uk/contact/govuk/email-survey-signup'] input[name='email_survey_signup[survey_source]']", visible: false)
     full_path = URI(page.current_url).request_uri
     assert_equal full_path, url_input.value
   end


### PR DESCRIPTION
Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Test branch for absolute global link changes - makes header links, footer links, search form, and feedback form use absolute links instead of relative ones

Recreated the PR as I was having issues with the build after I amended commits in my previous PRs

