### PR TITLE
Remove setting of default cookie consent cookie

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -17,9 +17,6 @@ var globalBarInit = {
   },
 
   getLatestCookie: function () {
-    if (!window.GOVUK.cookie('cookies_policy')) {
-      window.GOVUK.setDefaultConsentCookie()
-    }
     var currentCookie = window.GOVUK.getCookie(GLOBAL_BAR_SEEN_COOKIE)
 
     return currentCookie


### PR DESCRIPTION
## What
Remove default setting of consent cookie.

- global bar calls `setDefaultConsentCookie` on page load, which sets the default cookie consent to reject all
- this occurs first before any of the cookie banner code runs
- however the cookie banner also calls this, if it hasn't been called already

## Why
This is a bit of a duplication, and we're making fairly big changes to the cookie code in the gem and having this here is complicating things, so removing.

## Visual changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api
