### PR TITLE
Configure static to work with dartsass in govuk-docker

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,2 @@
+web: bin/rails server -p 3000
+css: bin/rails dartsass:build && bin/rails dartsass:watch

--- a/bin/dev
+++ b/bin/dev
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+if !(gem list foreman -i --silent); then
+  echo "Installing foreman..."
+  gem install foreman
+fi
+rm -rd ./public/assets/static
+exec foreman start -f Procfile.dev "$@"

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -42,9 +42,6 @@ Rails.application.configure do
   # Tell Active Support which deprecation messages to disallow.
   config.active_support.disallowed_deprecation_warnings = []
 
-  # Suppress logger output for asset requests.
-  config.assets.quiet = true
-
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 


### PR DESCRIPTION
## What

- Adds code to support `dartsass` compilation in `govuk-docker`, based off of https://github.com/alphagov/whitehall/pull/8812
- One thing to mention is docker didn't like the execution of `bin/dev` so I had to run `chmod +x bin/dev` on my machine. Not sure if this will be an issue for others?

## Why
- `static` has not been updating its SASS/CSS properly when `govuk_publishing_components` is updated. This is due to the migration to dartsass.

## How to test
- Checkout this branch
- Change your `govuk-docker/static/docker-compose.yml` to use `command: bin/dev` instead of `command: bin/rails s --restart` (or just checkout this branch of `govuk-docker`: https://github.com/alphagov/govuk-docker/pull/721)
- Change `static` to use your local `govuk_publishing_components` then `make static` / run static
- When you change SASS in `govuk_publishing_components`, it should update instantly in static