### PR TITLE
[DO NOT MERGE] Enable the single consent API

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,3 +19,4 @@
 
 //= require global-bar-init
 //= require surveys
+window.GOVUK.useSingleConsentApi = true


### PR DESCRIPTION
## What / why

- this turns on the code in `govuk_publishing_components` so that the single consent API is enabled
- it is being used in this branch for testing purposes only

## Visual changes
None.

Trello card: https://trello.com/c/dmlTAzKB/140-implement-single-consent-api