### PR TITLE
Use Terser instead of Uglifier

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem "nokogiri"
 gem "plek"
 gem "redis"
 gem "sprockets-rails"
-gem "uglifier"
+gem "terser"
 
 group :development do
   gem "better_errors"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     domain_name (0.6.20240107)
     drb (2.2.1)
     erubi (1.12.0)
-    execjs (2.8.1)
+    execjs (2.9.1)
     ffi (1.16.3)
     gds-api-adapters (95.1.0)
       addressable
@@ -572,12 +572,12 @@ GEM
       sprockets (>= 3.0.0)
     statsd-ruby (1.5.0)
     stringio (3.1.0)
+    terser (1.2.0)
+      execjs (>= 0.3.0, < 3)
     thor (1.3.1)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    uglifier (4.2.0)
-      execjs (>= 0.3.0, < 3)
     unicode-display_width (2.5.0)
     webmock (3.23.0)
       addressable (>= 2.8.0)
@@ -620,7 +620,7 @@ DEPENDENCIES
   shoulda-context
   simplecov
   sprockets-rails
-  uglifier
+  terser
   webmock
 
 RUBY VERSION

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,7 +25,7 @@ Rails.application.configure do
   config.public_file_server.enabled = ENV["RAILS_SERVE_STATIC_FILES"].present?
 
   # Compress JS using a preprocessor.
-  config.assets.js_compressor = :uglifier
+  config.assets.js_compressor = :terser
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
## What

Use Terser instead of Uglifier to compile JavaScript.

## Why

This change is preparation for upgrading to V5 of govuk-frontend in the govuk-publishing-components gem.

govuk-frontend v5 now targets browsers that support ES6. This means that the UMD modules used in govuk_publsihing_components from govuk-frontend use features of ES6 and so it means that Uglifier can't be used anymore because it only supports ES5.

[Trello card](https://trello.com/c/lnPFryyC/2562-prep-for-51-move-fe-applications-from-uglifier-to-terser-l)

## Further info

### JS Size

| minifier | file | minified JS | minified JS (gzip) |
| --- | --- | --- | --- |
| uglifer |  static/application.js | 81.2KB | 16.6KB |
| terser | static/application.js | 81.3KB | 16.6KB |

### Browser testing

I've tested the changes on Integration using the browsers below, functionality works as expected without any console errors.

- [x] Chrome
- [x] Firefox
- [x] Safari
- [x] IE11