### PR TITLE
update default survey to url

### DIFF
--- a/app/assets/javascripts/surveys.js
+++ b/app/assets/javascripts/surveys.js
@@ -81,7 +81,7 @@
       url: 'https://www.smartsurvey.co.uk/s/gov_uk?c={{currentPath}}',
       identifier: 'user_satisfaction_survey',
       frequency: 6,
-      surveyType: 'email'
+      surveyType: 'url'
     },
     smallSurveys: [],
 


### PR DESCRIPTION
Make the default survey a URL type rather than an email type.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

