### PR TITLE
Migrate to govuk frontend 5.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,7 +148,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (39.2.5)
+    govuk_publishing_components (40.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,5 +1,6 @@
 //= link_tree ../images
 //= link application.js
+//= link es6-components.js
 //= link test-dependencies.js
 //= link modules/base-target.js
 //= link_tree ../builds

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -7,13 +7,14 @@
 // check the component auditing before removing any of them
 // https://github.com/alphagov/govuk_publishing_components/blob/main/docs/auditing.md
 
-//= require govuk_publishing_components/components/button
+// These modules from govuk_publishing_components don't
+// depend on any modules from govuk-frontend so can be
+// included here:
+//
 //= require govuk_publishing_components/components/cookie-banner
 //= require govuk_publishing_components/components/cross-service-header
 //= require govuk_publishing_components/components/feedback
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
-//= require govuk_publishing_components/components/skip-link
 
 //= require modules/global-bar
 

--- a/app/assets/javascripts/es6-components.js
+++ b/app/assets/javascripts/es6-components.js
@@ -1,0 +1,12 @@
+// These modules from govuk_publishing_components
+// depend on govuk-frontend modules. govuk-frontend
+// now targets browsers that support `type="module"`.
+//
+// To gracefully prevent execution of these scripts
+// on browsers that don't support ES6, this script
+// should be included in a `type="module"` script tag
+// which will ensure they are never loaded.
+
+//= require govuk_publishing_components/components/button
+//= require govuk_publishing_components/components/layout-header
+//= require govuk_publishing_components/components/skip-link

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,3 @@
-$govuk-new-link-styles: true;
-
 @import "govuk_publishing_components/govuk_frontend_support";
 @import "govuk_publishing_components/component_support";
 

--- a/config/initializers/govuk_publishing_components.rb
+++ b/config/initializers/govuk_publishing_components.rb
@@ -1,0 +1,3 @@
+GovukPublishingComponents.configure do |config|
+  config.use_es6_components = true
+end


### PR DESCRIPTION
## What

- Move components that rely on govuk-frontend modules to separate `es6-components.js` file
- Removed $govuk-new-link-styles

## Why

### Move components that rely on govuk-frontend modules to seperate `es6-components.js` file

In the event that a browser below the target for `govuk-frontend` loads a page with JS on it, attempting to parse the JS from `govuk-frontend` will cause an error. To avoid this from happening, JS that contains `govuk-frontend` JS has been moved to seperate file which will be loaded in a script tag with `type="module"`. This will prevent the JS from being parsed and so prevent the error

### Remove Sass variables

Removed $govuk-new-link-styles as the default value from v5 of govuk-frontend is true

The intention is for the PR to include the upgrade to the version of the publishing_components_gem as well, once released. This will also fix the failing test which relies on a new config option.

[Trello](https://trello.com/c/qJbcNljJ/2515-upgrade-static-to-run-on-v51-of-govuk-frontend)