### PR TITLE
Add GA4 tracking to global bar

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -16,15 +16,22 @@
   title_classes = %w(global-bar-title)
   title_classes << "js-call-to-action" if title_href
   title_classes << "govuk-link" if title_href
+
+  ga4_data = {
+    event_name: "navigation",
+    type: "global bar",
+    section: title,
+  }.to_json
+
 -%>
 
 <% if show_global_bar %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
+  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-ga4-global-bar data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
     <p class="global-bar-message govuk-width-container">
       <% if title %>
         <% if title_href %>
-          <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>"><%= title %></a>
+          <a class="<%= title_classes.join(' ') %>" href="<%= title_href %>" data-module="ga4-link-tracker" data-ga4-link="<%= ga4_data %>"><%= title %></a>
         <% else %>
           <span class="<%= title_classes.join(' ') %>"><%= title %></span>
         <% end %>
@@ -37,7 +44,11 @@
             link_text,
             link_href,
             rel: "external noreferrer",
-            class: "govuk-link js-call-to-action"
+            class: "govuk-link js-call-to-action",
+            data: {
+              module: "ga4-link-tracker",
+              ga4_link: ga4_data,
+            },
           ) %>
         <% else %>
           <%= link_text %>


### PR DESCRIPTION
## What / Why
- Adds basic GA4 tracking to the global bar
- This tracking was missed in our GA4 team implementation work, most likely because this banner isn't documented in our component guide lists
- If you're unfamiliar with GA4:
    - We add a `data-ga4-link` JSON to links we want to track with some data we want tracked
    - We also initialise a `ga4-link-tracker` JavaScript module on these links
    - When the link is clicked, the `ga4-link-tracker` JS will use the JSON values, as well as create it's own values, which are then sent to GA4. Therefore we only need to add a small amount of templating data to get these links tracked.
    - We also add a `data-ga4-global-bar` attribute, which can be used in a future `govuk_publishing_components` gem release to track every time the banner is rendered
- Trello card: https://trello.com/b/rm8pjAAk/ga4-gtm-implementation-ga4-team-user-experience-govuk

