### PR TITLE
Remove 1px border bottom from global bar

### DIFF
--- a/app/assets/stylesheets/components/_global-bar.scss
+++ b/app/assets/stylesheets/components/_global-bar.scss
@@ -10,7 +10,6 @@ $covid-grey: #262828;
   @include govuk-font(19);
   background-color: #d9e7f2;
   border-top: govuk-spacing(2) solid govuk-colour("blue");
-  border-bottom: 1px solid govuk-colour("white");
   display: none;
 
   .show-global-bar & {


### PR DESCRIPTION
## What / Why
- Removes the 1px bottom from our non-emergency global bar
- https://trello.com/c/T4tonmaz/166-global-bar-border-issues