### PR TITLE
Set the timezone to London

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -39,5 +39,7 @@ module Static
 
     # Use temporary directory for page cache if filesystem is read-only
     config.action_controller.page_cache_directory = File.join(ENV["TMPDIR"], "page_cache") if ENV.fetch("USE_TMPDIR_PAGE_CACHE", "false") == "true"
+
+    config.time_zone = "London"
   end
 end


### PR DESCRIPTION
This setting has been available for 7 years.
See commit in government-frontend:
https://github.com/alphagov/government-frontend/commit/737211f87e9a9dbf4bcbb3b518a91fec317df50a

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

