### PR TITLE
[DO NOT MERGE] Remove time checks from global banner

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,15 +1,10 @@
 <%
   show_global_bar ||= true # Toggles the appearance of the global bar
 
-  if Time.zone.now.before?(Date.new(2024, 6, 19))
-    title = "Register to vote"
-    title_href = "/register-to-vote"
-    link_text = "Register by 18 June to vote in the General Election on 4 July."
-  else
-    title = "Bring photo ID to vote"
-    title_href = "/how-to-vote/photo-id-youll-need"
-    link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
-  end
+  title = "Bring photo ID to vote"
+  title_href = "/how-to-vote/photo-id-youll-need"
+  link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
+
 
   link_href = false
 


### PR DESCRIPTION
We added the time checks so that the global banner wouldn't have to be manually deployed at midnight. Those checks are no longer needed.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

