### PR TITLE
Timed updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,5 +36,6 @@ group :test do
   gem "mocha", require: false
   gem "shoulda-context"
   gem "simplecov"
+  gem "timecop"
   gem "webmock"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -570,6 +570,7 @@ GEM
     terser (1.2.3)
       execjs (>= 0.3.0, < 3)
     thor (1.3.1)
+    timecop (0.9.10)
     timeout (0.4.1)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
@@ -616,6 +617,7 @@ DEPENDENCIES
   simplecov
   sprockets-rails
   terser
+  timecop
   webmock
 
 RUBY VERSION

--- a/app/helpers/timed_update_helper.rb
+++ b/app/helpers/timed_update_helper.rb
@@ -1,0 +1,5 @@
+module TimedUpdateHelper
+  def before_update_time?(year:, month:, day:, hour:, minute:)
+    Time.zone.now.before? Time.zone.local(year, month, day, hour, minute)
+  end
+end

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,10 +1,10 @@
 <%
-  show_global_bar ||= true # Toggles the appearance of the global bar
-
-  title = "Bring photo ID to vote"
-  title_href = "/how-to-vote/photo-id-youll-need"
-  link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
-
+  if before_update_time?(year: 2024, month: 7, day: 4, hour: 22, minute: 0)
+    show_global_bar ||= true # Toggles the appearance of the global bar
+    title = "Bring photo ID to vote"
+    title_href = "/how-to-vote/photo-id-youll-need"
+    link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
+  end
 
   link_href = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/unit/helpers/timed_update_helper_test.rb
+++ b/test/unit/helpers/timed_update_helper_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class TimedUpdateHelperTest < ActiveSupport::TestCase
+  include TimedUpdateHelper
+
+  test "#before_update_time? returns true if we haven't reached the requested time yet" do
+    Timecop.freeze(2024, 6, 17, 23, 59)
+    assert before_update_time?(year: 2024, month: 6, day: 18, hour: 0, minute: 0)
+  end
+
+  test "#before_update_time? returns false if we've reached the requested time" do
+    Timecop.freeze(2024, 6, 18, 0, 0)
+    assert_not before_update_time?(year: 2024, month: 6, day: 18, hour: 0, minute: 0)
+  end
+
+  test "#before_update_time? returns false if we've passed the requested time" do
+    Timecop.freeze(2024, 6, 20, 10, 10)
+    assert_not before_update_time?(year: 2024, month: 6, day: 18, hour: 0, minute: 0)
+  end
+end


### PR DESCRIPTION
https://trello.com/c/upXxaeBR

## WHAT

Add in a helper method (before_update_time?) which can be used to make banner (or other layout) changes at a fixed time. Using this method rather than rolling a new one each time we have to make timed updates will prevent problems related to time zone settings (such as comparing a Time object - which does support time zones - with a Date object - which does not - causing an update to be an hour out during BST)
 
## WHY

Currently all deployments in banner text (non-emergency and perhaps emergency too) are manually triggered using GitHub Actions. Attempts to schedule banner updates using Ruby date functions (by merging the changes early), have caused issues with time-sensitive features due to server time differences from UK time (GMT/BST). A unique banner text deployment failed to update at the expected time because the server time did not match UK time. Automating the deployment to account for this time difference between server and UK time is essential to ensure timely updates without requiring human intervention at midnight.

## TESTING

We've deployed a version of this branch to integration with a nearer time, and observed that the banner vanished at the correct time. 

## RELATED PRS
[Update dev docs to point to new helper method](https://github.com/alphagov/govuk-developer-docs/pull/4716)

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

