### PR TITLE
[BREAK GLASS IN CASE OF TROUBLE] Remove voter id global banner

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -1,10 +1,8 @@
 <%
-  if before_update_time?(year: 2024, month: 7, day: 4, hour: 22, minute: 0)
-    show_global_bar ||= true # Toggles the appearance of the global bar
-    title = "Bring photo ID to vote"
-    title_href = "/how-to-vote/photo-id-youll-need"
-    link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
-  end
+  show_global_bar = false
+  title = nil
+  title_href = nil
+  link_text = nil
 
   link_href = false
 


### PR DESCRIPTION

This PR will remove the global voter ID banner in case it isn't removed by the automatic code.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

