### PR TITLE
Ensure that all global banner variables are set to nil/false

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -4,6 +4,11 @@
     title = "Bring photo ID to vote"
     title_href = "/how-to-vote/photo-id-youll-need"
     link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
+  else
+    show_global_bar = false
+    title = nil
+    title_href = nil
+    link_text = nil
   end
 
   link_href = false


### PR DESCRIPTION
Although the timed update tests worked fine, the static break-glass PR that replicated them did not. Add in the explicit calls to set the same variables in the post-10pm code.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

