### PR TITLE
Improve data-ga4-global-bar attribute inclusion

### DIFF
--- a/app/assets/javascripts/global-bar-init.js
+++ b/app/assets/javascripts/global-bar-init.js
@@ -59,6 +59,10 @@ var globalBarInit = {
 
   makeBannerVisible: function () {
     document.documentElement.className = document.documentElement.className.concat(' show-global-bar')
+    var globalBarEl = document.querySelector('#global-bar')
+    if (globalBarEl) {
+      globalBarEl.setAttribute('data-ga4-global-bar', '')
+    }
   },
 
   init: function () {

--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -34,7 +34,7 @@
 
 <% if show_global_bar %>
   <!--[if gt IE 7]><!-->
-  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-ga4-global-bar data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
+  <div id="global-bar" class="<%= global_bar_classes.join(' ') %>" data-module="global-bar" <%= "data-global-bar-permanent=true" if always_visible %> data-nosnippet>
     <p class="global-bar-message govuk-width-container">
       <% if title %>
         <% if title_href %>

--- a/spec/javascripts/global-bar-init.spec.js
+++ b/spec/javascripts/global-bar-init.spec.js
@@ -1,10 +1,15 @@
-/* global globalBarInit, parseCookie, expectGlobalBarToShow, expectGlobalBarToBeHidden */
+/* global globalBarInit, parseCookie, expectGlobalBarToShow, expectGlobalBarToBeHidden, expectGa4AttributeToExist, expectGa4AttributeToNotExist */
 
 describe('Global bar initialize', function () {
+  beforeAll(function () {
+    $('html').append('<div id="global-bar"></div>')
+  })
+
   beforeEach(function () {
     deleteAllCookies()
     spyOn(globalBarInit, 'getBannerVersion').and.returnValue(5)
     $('html').removeClass('show-global-bar')
+    $('#global-bar').removeAttr('data-ga4-global-bar')
 
     window.GOVUK.setConsentCookie({ settings: true })
   })
@@ -17,6 +22,7 @@ describe('Global bar initialize', function () {
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(5)
     expectGlobalBarToBeHidden()
+    expectGa4AttributeToNotExist()
   })
 
   it('sets global_bar_seen cookie', function () {
@@ -25,6 +31,7 @@ describe('Global bar initialize', function () {
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(5)
     expectGlobalBarToShow()
+    expectGa4AttributeToExist()
   })
 
   it('sets cookie to default value if current cookie is old (prior to versioning mechanism)', function () {
@@ -35,6 +42,7 @@ describe('Global bar initialize', function () {
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(5)
 
     expectGlobalBarToShow()
+    expectGa4AttributeToExist()
   })
 
   it('resets cookie if version number is out of date, if count below 3', function () {
@@ -44,6 +52,7 @@ describe('Global bar initialize', function () {
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(5)
     expectGlobalBarToShow()
+    expectGa4AttributeToExist()
   })
 
   it('resets cookie if version number is out of date, if count above 3', function () {
@@ -53,6 +62,7 @@ describe('Global bar initialize', function () {
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).count).toBe(0)
     expect(parseCookie(GOVUK.getCookie('global_bar_seen')).version).toBe(5)
     expectGlobalBarToShow()
+    expectGa4AttributeToExist()
   })
 
   it('makes banner visible if view count is less than 3', function () {
@@ -60,6 +70,7 @@ describe('Global bar initialize', function () {
     GOVUK.globalBarInit.init()
 
     expectGlobalBarToShow()
+    expectGa4AttributeToExist()
   })
 })
 

--- a/spec/javascripts/helpers/GlobalBarHelper.js
+++ b/spec/javascripts/helpers/GlobalBarHelper.js
@@ -9,6 +9,14 @@ function expectGlobalBarToBeHidden () {
   expect($('html').hasClass('show-global-bar')).toBe(false)
 }
 
+function expectGa4AttributeToExist () {
+  expect($('#global-bar').attr('data-ga4-global-bar')).toBe('')
+}
+
+function expectGa4AttributeToNotExist () {
+  expect($('#global-bar').attr('data-ga4-global-bar')).toBe(undefined)
+}
+
 function expectAdditionalSectionToBeVisible () {
   expect($('.global-bar-additional').hasClass('global-bar-additional--show')).toBe(true)
 }


### PR DESCRIPTION
## What / Why
When the user is on the same page that the global bar links to, the global bar is hidden via CSS. For example, if the global bar links to `/how-to-vote`, the global bar will not display itself on the `/how-to-vote` page itself.  However the HTML still exists when the banner is hidden, so our `data-ga4-global-bar` attribute was still in the DOM, even though the global bar was not visible. This led to incorrect tracking on the page that the global bar was linking to, as the global bar was tracked as being shown to the user on that page when it was not.

The fix is to add the GA4 attribute using JavaScript, in the same bit of code that controls visibility of the global bar.

https://trello.com/c/ITfYEHT2/832-fix-global-bar-being-tracked-as-visible-on-the-page-it-links-to-even-though-it-is-not-visible

## How to test

- Run `static` with this branch
- Make the global bar visible by modifying the variables in `_global_bar.html.erb`. You can use these variables:

```
    show_global_bar ||= true # Toggles the appearance of the global bar
    title = "Bring photo ID to vote"
    title_href = "/templates/gem_layout.html.erb"
    link_text = "Check what photo ID you'll need to vote in person in the General Election on 4 July."
```

- If you go to http://static.dev.gov.uk/templates/gem_layout.html.erb you will see that the global bar is hidden because you're on the same path that the global bar is linking to. `data-ga4-global-bar` won't be in the DOM
- If you change `title_href = "/templates/gem_layout.html.erb"` to a different path, the global bar will reappear, and `data-ga4-global-bar` will exist in the DOM
