### PR TITLE
Drop support for legacy browsers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     govuk_personalisation (0.16.0)
       plek (>= 1.9.0)
       rails (>= 6, < 8)
-    govuk_publishing_components (41.1.1)
+    govuk_publishing_components (42.0.0)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown
@@ -546,10 +546,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
-    sentry-rails (5.18.2)
+    sentry-rails (5.19.0)
       railties (>= 5.0)
-      sentry-ruby (~> 5.18.2)
-    sentry-ruby (5.18.2)
+      sentry-ruby (~> 5.19.0)
+    sentry-ruby (5.19.0)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-context (2.0.0)

--- a/app/assets/stylesheets/helpers/_old-ie.scss
+++ b/app/assets/stylesheets/helpers/_old-ie.scss
@@ -9,7 +9,7 @@
   margin-right: auto;
 }
 
-.js-enabled .govuk-sticky-element--hidden {
+.govuk-frontend-supported .govuk-sticky-element--hidden {
   @include govuk-visually-hidden;
 }
 

--- a/app/views/root/_javascript.html.erb
+++ b/app/views/root/_javascript.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag local_assigns[:js_file] || 'application', integrity: false %>
+<%= javascript_include_tag local_assigns[:js_file] || 'application', integrity: false, type: "module" %>
 <% if ENV["DRAFT_ENVIRONMENT"].present? %>
   <%= javascript_include_tag 'modules/base-target', integrity: false %>
 <% end %>


### PR DESCRIPTION
## What / Why
- Use type=module for this application's JS file...though I'm not sure what this file is used for, since the gem loads the `application.js` for static in the header layout.
- To coincide with https://github.com/alphagov/govuk_publishing_components/pull/4111
- Has [DO NOT MERGE] as we want the above PR live on `static` first before this is merged.
- To accurately test this you will need to checkout a local version the `govuk_publishing_components` branch linked above
- We will combine `es6-components.js` again as a separate task unless you disagree with this
- Trello card: https://trello.com/c/Hoa45SMD/141-turn-off-javascript-in-legacy-browsers