### PR TITLE
Update/add component print styles

### DIFF
--- a/app/views/components/_global_bar.html.erb
+++ b/app/views/components/_global_bar.html.erb
@@ -18,7 +18,7 @@
   # Regardless of value, banner is always manually dismissable by users
   always_visible = true
 
-  global_bar_classes = %w(global-bar dont-print)
+  global_bar_classes = %w(global-bar govuk-!-display-none-print)
 
   title_classes = %w(global-bar-title)
   title_classes << "js-call-to-action" if title_href


### PR DESCRIPTION
## What
We have 148 components across [GOV.UK](http://gov.uk/) and 13 of them have print styles (see the component auditing for details). This PR updates the print styles for any public-facing components. The changes broadly fall into these categories:

- hiding/removing components that should never be printed
- improving components that already have print styles 
- creating print styles for components that don't already have them

[Trello card](https://trello.com/c/PnEVIZtq/192-review-and-fix-application-component-print-styles)

## Why
People still print a lot of pages from [GOV.UK](http://gov.uk/). And recent discussions have highlighted potential problems, or at least a perception that HTML pages when printed aren't as good as PDFs. We're trying to move away from/discourage the use of PDFs on [GOV.UK](http://gov.uk/), so improving the print experience could help.