### PR TITLE
Remove unused layouts

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -22,16 +22,12 @@ class RootController < ApplicationController
     502
     503
     504
-    chromeless
     gem_layout
     gem_layout_account_manager
-    gem_layout_explore_header
     gem_layout_full_width
-    gem_layout_full_width_explore_header
     gem_layout_full_width_no_footer_navigation
     gem_layout_homepage
     gem_layout_homepage_new
-    gem_layout_no_emergency_banner
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
     scheduled_maintenance

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -1,7 +1,6 @@
 <%
   logo_link ||= Plek.new.website_root.present? ? Plek.new.website_root : "https://www.gov.uk/"
   full_width ||= false
-  omit_emergency_banner ||= false
   omit_feedback_form ||= nil
   omit_footer_navigation ||= nil
   omit_footer_border ||= nil
@@ -19,7 +18,7 @@
   homepage ||= false
   homepage_blue_navbar ||= false
 
-  @emergency_banner = !omit_emergency_banner && emergency_banner_notification
+  @emergency_banner = emergency_banner_notification
 
   if @emergency_banner
     emergency_banner = render "govuk_publishing_components/components/emergency_banner", {

--- a/app/views/root/chromeless.html.erb
+++ b/app/views/root/chromeless.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: "gem_base" %>

--- a/app/views/root/gem_layout_explore_header.html.erb
+++ b/app/views/root/gem_layout_explore_header.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: "gem_base" %>

--- a/app/views/root/gem_layout_full_width_explore_header.html.erb
+++ b/app/views/root/gem_layout_full_width_explore_header.html.erb
@@ -1,1 +1,0 @@
-<%= render partial: 'gem_base', locals: { full_width: true } %>

--- a/app/views/root/gem_layout_no_emergency_banner.html.erb
+++ b/app/views/root/gem_layout_no_emergency_banner.html.erb
@@ -1,5 +1,0 @@
-<%= render partial: "gem_base",
-  locals: {
-    omit_emergency_banner: true
-  }
-%>

--- a/test/integration/templates_test.rb
+++ b/test/integration/templates_test.rb
@@ -3,7 +3,7 @@ require_relative "../integration_test_helper"
 class TemplatesTest < ActionDispatch::IntegrationTest
   context "fetching templates" do
     should "be 200 for templates that exist" do
-      %w[404 406 500 chromeless gem_layout scheduled_maintenance].each do |template|
+      %w[404 406 500 gem_layout scheduled_maintenance].each do |template|
         get "/templates/#{template}.html.erb"
         assert_equal 200, last_response.status
       end


### PR DESCRIPTION
- remove four unused layouts: chromeless, gem_layout_explore_header, gem_layout_full_width_explore_header, gem_layout_no_emergency_banner.
- remove omit_emergency_banner code only used by no_emergency_banner layout.
- update test with removal of chromeless

Note: I've confirmed there are no mentions of these layouts in alphagov, and no requests for their templates in the logs in the last 14 days (last 5 days for gem_layout_no_emergency_banner, because that was when I [removed the hack in collections](https://github.com/alphagov/collections/pull/3743) that asked for it).

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

