### PR TITLE
Remove verification tokens (these are to be handled by Frontend)

### DIFF
--- a/lib/tasks/publishing_api.rake
+++ b/lib/tasks/publishing_api.rake
@@ -5,30 +5,6 @@ ROUTES = [
     title: "Favicon",
     description: "The favicon is the image displayed in locations such as the browser tabs.",
   },
-  { # See https://gov-uk.atlassian.net/wiki/spaces/GOVUK/pages/3585441793/Google+Search+Console for ownership of these verification tokens
-    base_path: "/googlea6393a390aadfbaa.html",
-    content_id: "5a14203f-f79e-4cca-831e-668043f49f1a",
-    title: "Google site verification a6393a390aadfbaa",
-    description: "These files allow Google to verify ownership of a site.
-                      They should not be removed as that can cause the site to become unverified
-                      See https://support.google.com/webmasters/answer/35658",
-  },
-  {
-    base_path: "/googlec908b3bc32386239.html",
-    content_id: "7ca03916-4340-4b95-a4dd-3078c0446768",
-    title: "Google site verification c908b3bc32386239",
-    description: "These files allow Google to verify ownership of a site.
-                      They should not be removed as that can cause the site to become unverified
-                      See https://support.google.com/webmasters/answer/35658",
-  },
-  {
-    base_path: "/BingSiteAuth.xml",
-    content_id: "d793dba8-4ff7-4a3f-a6d3-54f52b7bd259",
-    title: "Bing site verification",
-    description: "This file allows Bing to verify ownership of a site.
-                      It should not be removed as that can cause the site to become unverified
-                      See https://www.bing.com/webmaster/help/how-to-verify-ownership-of-your-site-afcfefc6",
-  },
   {
     base_path: "/apple-touch-icon.png",
     content_id: "cdc36458-74d4-42a7-86c8-221e03877dfc",

--- a/public/BingSiteAuth.xml
+++ b/public/BingSiteAuth.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0"?>
-<users>
-	<user>66F6ADB7C4481C94247D1E08FA04C6A4</user>
-</users>

--- a/public/googlea6393a390aadfbaa.html
+++ b/public/googlea6393a390aadfbaa.html
@@ -1,1 +1,0 @@
-google-site-verification: googlea6393a390aadfbaa.html

--- a/public/googlec908b3bc32386239.html
+++ b/public/googlec908b3bc32386239.html
@@ -1,1 +1,0 @@
-google-site-verification: googlec908b3bc32386239.html


### PR DESCRIPTION
## What

Move the publishing/handling of routes for Google and Bing authorisation tokens out of Static. The handling of these tokens is moved from static to nginx as of: https://github.com/alphagov/govuk-helm-charts/pull/2357

## Why

Static shouldn't really be handling any outside routes. This is the first thing to move over - then we'll move the favicon/apple touch icons into frontend.

## Order of Deploy

When deploying, the change to govuk-helm-charts should go first. Then we restart router to pick up the new config. Then this change to static which removes its ability to serve the routes. Finally, we can delete the old route/content records in router-api and content-store.

https://trello.com/c/o55zYQeB/317-tidy-verification-paths-in-static
