### PR TITLE
Set Redis retry strategy for emergency banner

### DIFF
--- a/lib/emergency_banner/display.rb
+++ b/lib/emergency_banner/display.rb
@@ -2,7 +2,14 @@ module EmergencyBanner
   class Display
     class << self
       def client
-        @client ||= Redis.new(timeout: 0.1)
+        @client ||= Redis.new(
+          reconnect_attempts: [
+            15,
+            30,
+            45,
+            60,
+          ],
+        )
       end
     end
 


### PR DESCRIPTION
This brings the Redis connection retry strategy in line with the configuration specified in [`govuk_sidekiq`](https://github.com/alphagov/govuk_sidekiq/blob/32def77d86d929ca7eb48f35f08401fedeb8407d/lib/govuk_sidekiq/sidekiq_initializer.rb#L10-L12) and [Whitehall](https://github.com/alphagov/whitehall/pull/9430).

By making this change, the application will be able to cope with short periods of Redis instance downtime.

Note: this application uses [version 5.3 of the `redis` gem](https://github.com/alphagov/static/blob/116a981a8428823875eb0610f075710adbdf9307/Gemfile.lock#L490), so we need to use the syntax for 5.x instead of the 4.8 syntax that was used in Whitehall and `govuk_sidekiq`.

[Trello card](https://trello.com/c/YJULijF6)