### PR TITLE
Add for_static: true to all calls to layout_for_public component

### DIFF
--- a/app/views/root/_error_page.html.erb
+++ b/app/views/root/_error_page.html.erb
@@ -12,6 +12,7 @@
 %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
+  for_static: true,
   emergency_banner: emergency_banner,
   full_width: false,
   global_bar: user_satisfaction_survey + global_bar,

--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -37,6 +37,7 @@
 %>
 
 <%= render "govuk_publishing_components/components/layout_for_public", {
+  for_static: true,
   account_nav_location: account_nav_location,
   **(defined?(blue_bar) ? {blue_bar: blue_bar,} : {}),
   draft_watermark: draft_environment,


### PR DESCRIPTION
- Currently does nothing, but the component will be updated to only return the wrapper block (as per current behaviour) if this parameter is present.

https://trello.com/c/COQYfYgn/347-allow-layoutforpublic-to-work-like-a-normal-layout

