### PR TITLE
Default to EMERGENCY_BANNER_REDIS_URL in Emergency Banner's Redis

### DIFF
--- a/lib/emergency_banner/display.rb
+++ b/lib/emergency_banner/display.rb
@@ -3,6 +3,7 @@ module EmergencyBanner
     class << self
       def client
         @client ||= Redis.new(
+          url: ENV.fetch("EMERGENCY_BANNER_REDIS_URL", ENV["REDIS_URL"]),
           reconnect_attempts: [
             15,
             30,


### PR DESCRIPTION
[Trello card](https://trello.com/c/zkDNXi7x/1400-create-new-redis-instance-for-whitehall-admin-integration)

In https://github.com/alphagov/govuk-helm-charts/pull/2598/commits/501163523cee534667548ab9b288060d2f595ae4 we added a new `EMERGENCY_BANNER_REDIS_URL` environment variable to Static on Integration pointing to Whitehall Admin's newly-provisioned Redis instance's database (`/1`).

Here we access that value in the Emergency Banner's Redis client which shares this Redis instance.

For environments that don't have this variable set yet (i.e. Staging and Production) we fallback on the default `REDIS_URL`.

This is temporary - once we've moved all environments over to the new URL we can remove this default.

`mock_env` is shamelessly copied from
[here](https://gist.github.com/jazzytomato/79bb6ff516d93486df4e14169f4426af) and allows us to specify some environment variables that won't persist between tests.

The memoization of the instance variable in the class method was a tricky one to overcome, as the setup persisted across tests. I've had to manually clear it on these new tests to get this working.

**NB: We'll need to deploy the [corresponding change](https://github.com/alphagov/whitehall/pull/9474) in Whitehall's codebase at the same time as this one to ensure the two are using the same shared instance**

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

