### PR TITLE
Add search-with-autocomplete component as assets

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,6 +19,7 @@
 //= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/skip-link
+//= require govuk_publishing_components/components/search-with-autocomplete
 
 //= require modules/global-bar
 

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@
 @import "govuk_publishing_components/components/input";
 @import "govuk_publishing_components/components/label";
 @import "govuk_publishing_components/components/search";
+@import "govuk_publishing_components/components/search-with-autocomplete";
 @import "govuk_publishing_components/components/skip-link";
 @import "govuk_publishing_components/components/textarea";
 @import "govuk_publishing_components/components/title";


### PR DESCRIPTION
This adds in search-with-autocomplete to the global assets that static uses, this is added because the layout-super-navigation-header makes use of the search-with-autocomplete component.

The motivation for this change was to resolve a bug when we pushed search-with-autocomplete live and we discovered that the autocomplete only rendered and operated correctly on a few pages that already had the component embedded. The reason this was not operational was because the CSS and JavaScript were not available unless the autocomplete was already embedded.

There was a decision to make as to whether to add the dependency to the layout-super-navigation-header component or to add them separately here. I've gone with the separate approach as that was the precedent already used for the search nested component.

Following this change I'm going to go through and remove the previous embeddings of the JS and CSS so that we don't have it included twice.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

