### PR TITLE
Upgrade bundler and nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
       net-protocol
     netrc (0.11.0)
     nio4r (2.7.4)
-    nokogiri (1.17.2)
+    nokogiri (1.18.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     null_logger (0.0.1)
@@ -634,4 +634,4 @@ RUBY VERSION
    ruby 3.3.6p108
 
 BUNDLED WITH
-   2.3.22
+   2.6.2


### PR DESCRIPTION
Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

This PR is a substitute for https://github.com/alphagov/static/pull/3545 as that PR did not include bundler upgrade, which is [recommended by nokogiri](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#v1180--2024-12-25).

## Why

As a safer and more complete substitute for a dependabot PR which attempted to upgrade nokogiri.