### PR TITLE
[DO NOT MERGE] Remove blue bar

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -26,7 +26,6 @@
 <%= render "govuk_publishing_components/components/layout_for_public", {
   for_static: true,
   account_nav_location: account_nav_location,
-  **(defined?(blue_bar) ? {blue_bar: blue_bar,} : {}),
   draft_watermark: draft_environment,
   emergency_banner: render("govuk_web_banners/emergency_banner", homepage:),
   full_width: full_width,

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -3,7 +3,6 @@
 %>
 
 <%= render partial: "gem_base", locals: {
-  blue_bar: false,
   omit_feedback_form: true,
   omit_footer_border: true,
   omit_global_banner: true,


### PR DESCRIPTION
## What
Remove 'blue bar' layout option.

https://trello.com/c/3EkNY2Bs/3254-prepare-a-pr-to-turn-off-the-blue-border-at-the-bottom-of-the-header?filter=label:Frontend%20devs

## Why
The blue bar beneath the current black header on [GOV.UK](http://gov.uk/) pages is applied by https://github.com/alphagov/govuk_publishing_components. We want to remove the blue bar and we will need to update the gem accordingly. However the blue bar code is very old and complicated and we’re not sure how best to do it.

https://trello.com/c/9kohZAvu/3347-remove-support-for-the-blue-bar-below-the-header

## Visual Changes

### Before

### After

## Anything else
https://github.com/alphagov/govuk_publishing_components/pull/4616
https://github.com/alphagov/collections/pull/3976
https://github.com/alphagov/frontend/pull/4627