### PR TITLE
Delete unneeded homepage template

### DIFF
--- a/app/controllers/root_controller.rb
+++ b/app/controllers/root_controller.rb
@@ -13,7 +13,6 @@ class RootController < ApplicationController
     gem_layout_full_width
     gem_layout_full_width_no_footer_navigation
     gem_layout_homepage
-    gem_layout_homepage_new
     gem_layout_no_feedback_form
     gem_layout_no_footer_navigation
     print

--- a/app/views/root/gem_layout_homepage_new.html.erb
+++ b/app/views/root/gem_layout_homepage_new.html.erb
@@ -1,5 +1,0 @@
-<%= render partial: "gem_base", locals: {
-	full_width: true,
-	homepage: true,
-	homepage_blue_navbar: true,
-} %>


### PR DESCRIPTION
## What

Delete unneeded `gem_layout_homepage_new` homepage template.

## Why

https://trello.com/c/TZRRwu5e/3304-consolidate-gemlayouthomepage-templates-in-static

A step required to consolidate [gem_layout_homepage_new](https://github.com/alphagov/static/blob/38302ecf649ed7d375c43ee269a13a17772a7d6c/app/views/root/gem_layout_homepage_new.html.erb) into [gem_layout_homepage](https://github.com/alphagov/static/blob/38302ecf649ed7d375c43ee269a13a17772a7d6c/app/views/root/gem_layout_homepage.html.erb), and delete the `_new` template.

## Anything else

This pull request is one of a series of changes needed to consolidate homepage layouts. The correct release sequence is as follows

- https://github.com/alphagov/static/pull/3586
- https://github.com/alphagov/frontend/pull/4645
- https://github.com/alphagov/static/pull/3589