### PR TITLE
Remove unused homepage_blue_navbar

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -16,7 +16,6 @@
   footer_meta ||= nil
   draft_environment ||= ENV["DRAFT_ENVIRONMENT"].present?
   homepage ||= false
-  homepage_blue_navbar ||= false
 
   global_bar = ''
   global_banner = render "components/global_bar" unless omit_global_banner
@@ -31,7 +30,7 @@
   emergency_banner: render("govuk_web_banners/emergency_banner", homepage:),
   full_width: full_width,
   global_banner: global_bar,
-  homepage: homepage_blue_navbar,
+  homepage: homepage,
   logo_link: logo_link,
   navigation_items: navigation_items,
   omit_feedback_form: omit_feedback_form,

--- a/app/views/root/gem_layout_homepage.html.erb
+++ b/app/views/root/gem_layout_homepage.html.erb
@@ -1,5 +1,4 @@
 <%= render partial: "gem_base", locals: {
 	full_width: true,
 	homepage: true,
-	homepage_blue_navbar: true,
 } %>


### PR DESCRIPTION
[To simplify the rollout of the homepage redesign work](https://github.com/alphagov/static/commit/3af25dff72646ba4f8fd6cc6b635f759afc48eff
), `homepage_blue_navbar` was set to `false` on the old homepage template. Whilst it was set to `true` on the new (currently live) homepage. 

This field is safe to remove - it no longer does anything
