### PR TITLE
Remove `show_explore_header` from view templates

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -9,7 +9,6 @@
   product_name ||= nil
   navigation_items ||= []
   one_login_navigation_items ||= {}
-  show_explore_header = show_explore_header === false ? false : true
   show_cross_service_header ||= false
   show_account_layout ||= false
   account_nav_location ||= nil
@@ -37,7 +36,6 @@
   product_name: product_name,
   show_account_layout: show_account_layout,
   show_cross_service_header: show_cross_service_header,
-  show_explore_header: show_explore_header,
   title: content_for?(:title) ? yield(:title) : "GOV.UK - The best place to find government services and information",
   footer_meta: footer_meta,
 } %>

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -11,7 +11,6 @@
   product_name: "GOV.UK email subscriptions",
   show_account_layout: true,
   show_cross_service_header: true,
-  show_explore_header: false,
   omit_account_navigation: true,
   one_login_navigation_items: {
     one_login_home: {

--- a/app/views/root/gem_layout_full_width_no_footer_navigation.html.erb
+++ b/app/views/root/gem_layout_full_width_no_footer_navigation.html.erb
@@ -2,6 +2,5 @@
   locals: {
     full_width: true,
     omit_footer_navigation: true,
-    show_explore_header: false
   }
 %>

--- a/app/views/root/gem_layout_no_footer_navigation.html.erb
+++ b/app/views/root/gem_layout_no_footer_navigation.html.erb
@@ -1,6 +1,5 @@
 <%= render partial: "gem_base",
   locals: {
     omit_footer_navigation: true,
-    show_explore_header: false
   }
 %>


### PR DESCRIPTION
## What

Remove `show_explore_header` from view templates

[Trello](https://trello.com/c/qE79TFYj/3303-remove-legacy-header-variants-from-layoutforpublic)

## Why

Removed `show_explore_header` from the view templates as this option was removed from the `layout_for_public` component the `govuk_publishing_components` gem.

Depends on:
- [x] https://github.com/alphagov/govuk_publishing_components/pull/4643

### Further info

It is not possible to remove [layout-header.scss](https://github.com/alphagov/static/blob/main/app/assets/stylesheets/application.scss#L29) from static as the super navigation menu relies on the logo styles provided by the design system.

It may be possible to remove [layout-header.js](https://github.com/alphagov/static/blob/main/app/assets/javascripts/application.js#L20) from static, however this will likely require further testing to ensure it does not break anything, I will create a separate card for this.
