### PR TITLE
Add GitHub Actions to dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,8 @@ updates:
     directory: /
     schedule:
       interval: weekly
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily


### PR DESCRIPTION
## What

Add GitHub Actions to dependabot configuration, this approach is consistent with [frontend](https://github.com/alphagov/frontend/blob/main/.github/dependabot.yml#L20-L23) and [collections](https://github.com/alphagov/collections/blob/main/.github/dependabot.yml#L25-L28)

## Why

To ensure that GitHub actions are kept up-to-date

[Trello card](https://trello.com/c/tnUxY7k6/3366-add-github-actions-to-dependabot-checks-to-static-and-government-frontend)