### PR TITLE
Bump actions/checkout from 3 to 4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
 
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## What
Bump actions/checkout from 3 to 4

## Why
This resolves the CI error below:

> the runner of "actions/checkout@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue

This version is consistent with other applications, frontend for example - https://github.com/alphagov/frontend/blob/main/.github/workflows/ci.yml#L54