### PR TITLE
Remove layout-header js and css imports

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,7 +17,6 @@
 //= require govuk_publishing_components/components/cross-service-header
 //= require govuk_publishing_components/components/feedback
 //= require govuk_publishing_components/components/global-banner
-//= require govuk_publishing_components/components/layout-header
 //= require govuk_publishing_components/components/layout-super-navigation-header
 //= require govuk_publishing_components/components/skip-link
 //= require govuk_publishing_components/components/search-with-autocomplete

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -26,7 +26,6 @@
 @import "govuk_publishing_components/components/global-banner";
 @import "govuk_publishing_components/components/layout-footer";
 @import "govuk_publishing_components/components/layout-for-public";
-@import "govuk_publishing_components/components/layout-header";
 @import "govuk_publishing_components/components/layout-super-navigation-header";
 
 @import "helpers/draft";


### PR DESCRIPTION
## What

Remove layout-header js and css imports

## Why

These imports are no longer required as the layout-header component is no longer used on GOV.UK.

Dependant on:
- [x] https://github.com/alphagov/govuk_publishing_components/pull/4709

