### PR TITLE
Tidy up by removing redundant omit_footer_border

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -3,7 +3,6 @@
   full_width ||= false
   omit_feedback_form ||= nil
   omit_footer_navigation ||= nil
-  omit_footer_border ||= nil
   omit_global_banner ||= false
   omit_account_navigation ||= nil
   product_name ||= nil
@@ -31,7 +30,6 @@
   omit_feedback_form: omit_feedback_form,
   omit_footer_navigation: omit_footer_navigation,
   omit_account_navigation: omit_account_navigation,
-  omit_footer_border: omit_footer_border,
   one_login_navigation_items: one_login_navigation_items,
   product_name: product_name,
   show_account_layout: show_account_layout,

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -5,7 +5,6 @@
 <%= render partial: "gem_base", locals: {
   blue_bar: false,
   omit_feedback_form: true,
-  omit_footer_border: true,
   omit_footer_navigation: true,
   omit_global_banner: true,
   product_name: "GOV.UK email subscriptions",


### PR DESCRIPTION
Remove the redundant `omit_footer_border` variable definition.

The actual functionality was removed from govuk_publishing_components in v58.0.0 in [this commit](https://github.com/alphagov/govuk_publishing_components/commit/167b5a5dfdef603f0dceb06e80d9630874b4625b), with the intention of removing it from frontend apps at a later date. This is just to tidy up post v58.0.0 going out.

There is no visual difference resulting from the removal of this option since the footer component's border was updated to match the one used on GOV.UK in the same release.

Fixes https://trello.com/c/hh3oU8IX/3608-remove-omitfooterborder-option-from-gem-and-various-apps-that-pass-this-option

⚠️  This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️


