### PR TITLE
Include Redis healthchecking in /healthcheck/ready

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::Redis,
+  )
 
   scope format: false do
     scope to: proc { [410, {}, ["The component system has moved to https://github.com/alphagov/govuk_publishing_components"]] } do


### PR DESCRIPTION
Redis is a critical dependency for static, and it not being available causes failures. Therefore static cannot report readiness if it cannot reach Redis.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Part of https://github.com/alphagov/govuk-infrastructure/issues/2432

