### PR TITLE
Use new EmergencyBannerRedis healthcheck in /healthcheck/ready

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ GEM
       rake (>= 13)
     googleapis-common-protos-types (1.20.0)
       google-protobuf (>= 3.18, < 5.a)
-    govuk_app_config (9.18.1)
+    govuk_app_config (9.19.0)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.31)
       opentelemetry-instrumentation-all (>= 0.39.1, < 0.79.0)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,9 @@ Rails.application.routes.draw do
   mount GovukPublishingComponents::Engine, at: "/component-guide" if Rails.env.development?
 
   get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
-  get "/healthcheck/ready", to: GovukHealthcheck.rack_response
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::EmergencyBannerRedis,
+  )
 
   scope format: false do
     scope to: proc { [410, {}, ["The component system has moved to https://github.com/alphagov/govuk_publishing_components"]] } do


### PR DESCRIPTION
static reaches into the emergency banner redis in another service, if that redis is not available then static will serve errors.

Previously a redis url misconfiguration caused us to deploy a broken static replica set, so we've introduced a new healthcheck type for anything which uses the emergency banner redis, which for the /healthcheck/ready endpoint only will ensure that the emergency banner redis is available. If we had this before the incident the new deployment would have failed, none of the failing pods would have been served traffic, and all the old pods would have still been alive correctly serving traffic.

We also need to configure the kubernetes startupProbe to use /healthcheck/ready instead of /healthcheck/live, but that will be a follow on task to this PR.

I ran up an ephemeral EKS cluster, built and deployed this version of static to it. It behaved as expected, newly starting pods which couldn't connect to redis never passed their startup check, and the old pods remained alive and service traffic.

Once I enabled the redis is needs again the pods successfully started and deployment continued as expected.

This supersedes https://github.com/alphagov/static/pull/3722