### PR TITLE
Remove `blue-bar` option from view templates

### DIFF
--- a/app/views/root/_gem_base.html.erb
+++ b/app/views/root/_gem_base.html.erb
@@ -19,7 +19,6 @@
 <%= render "govuk_publishing_components/components/layout_for_public", {
   for_static: true,
   account_nav_location: account_nav_location,
-  **(defined?(blue_bar) ? {blue_bar: blue_bar,} : {}),
   draft_watermark: draft_environment,
   emergency_banner: render("govuk_web_banners/emergency_banner", homepage:),
   global_banner: omit_global_banner ? nil : render("govuk_web_banners/global_banner"),

--- a/app/views/root/gem_layout_account_manager.html.erb
+++ b/app/views/root/gem_layout_account_manager.html.erb
@@ -3,7 +3,6 @@
 %>
 
 <%= render partial: "gem_base", locals: {
-  blue_bar: false,
   omit_feedback_form: true,
   omit_footer_navigation: true,
   omit_global_banner: true,


### PR DESCRIPTION
## What

Remove `blue-bar` option from view templates

## Why

Using the `blue_bar` option in the layout_for_public component has no impact, the blue_bar functionality was removed as part of the brand update

Jira: https://gov-uk.atlassian.net/browse/NAV-18190