### PR TITLE
Bump components gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
     govuk_personalisation (1.1.0)
       plek (>= 1.9.0)
       rails (>= 6, < 9)
-    govuk_publishing_components (61.0.1)
+    govuk_publishing_components (61.0.3)
       govuk_app_config
       govuk_personalisation (>= 0.7.0)
       kramdown


### PR DESCRIPTION
## What
Bumps to the newest version of `govuk_publishing_components`

- bundle update --conservative govuk_publishing_components

## Why
Contains some needed visual fixes.
