### PR TITLE
[DO NOT MERGE] [PNP-9741] Mark Static as retired in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> Static has been retired and is no longer in use.
+>
+> (See [RFC-176](https://github.com/alphagov/govuk-rfcs/blob/main/rfc-176-replacing-static.md) for an explanation.)
+
 # Static
 
 This application defines global templates for [GOV.UK](https://www.gov.uk) pages. It is used in conjunction with [Slimmer](https://github.com/alphagov/slimmer), which is Rack middleware that takes a HTML response from a Rails app and combines it with a template from Static.


### PR DESCRIPTION
Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What
This PR adds a note at the top of the README to mark that Static has been retired and is no longer in use.

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/PNP/boards/1356?selectedIssue=PNP-9741

